### PR TITLE
Fix event bus import references

### DIFF
--- a/api/src/app/agent_tasks/layer2_tasks/agents/tasks_composer_agent.py
+++ b/api/src/app/agent_tasks/layer2_tasks/agents/tasks_composer_agent.py
@@ -7,7 +7,7 @@ creates a Task Brief draft, links blocks, emits event.
 
 import os, json, asyncpg, uuid, datetime, asyncio, sys
 from datetime import timezone
-from app.event_bus import publish_event
+from app.supabase_helpers import publish_event
 from ..schemas import ComposeRequest, TaskBriefDraft
 from ..utils.prompt_builder import build_prompt
 

--- a/api/src/app/agent_tasks/layer2_tasks/agents/tasks_editor_agent.py
+++ b/api/src/app/agent_tasks/layer2_tasks/agents/tasks_editor_agent.py
@@ -1,7 +1,7 @@
 #api/src/app/agent_tasks/layer2_tasks/agents/tasks_editor_agent.py
 
 from ..schemas import TaskBriefDraft, TaskBriefEdited
-from app.event_bus import publish_event
+from app.supabase_helpers import publish_event
 
 EVENT_TOPIC_IN  = "brief.draft_created"
 EVENT_TOPIC_OUT = "brief.edited"

--- a/api/src/app/agent_tasks/layer2_tasks/agents/tasks_validator_agent.py
+++ b/api/src/app/agent_tasks/layer2_tasks/agents/tasks_validator_agent.py
@@ -1,7 +1,8 @@
 #api/src/app/agent_tasks/layer2_tasks/agents/tasks_validator_agent.py
 
 from ..schemas import TaskBriefEdited, TaskBriefValidation
-from app.event_bus import publish_event, DB_URL
+from app.event_bus import DB_URL
+from app.supabase_helpers import publish_event
 import asyncpg
 import datetime
 
@@ -38,5 +39,5 @@ async def validate(brief: TaskBriefEdited) -> TaskBriefValidation:
         errors=errors,
         checked_at=datetime.datetime.utcnow(),
     )
-    publish_event(EVENT_TOPIC_OUT, validation.dict())
+    await publish_event(EVENT_TOPIC_OUT, validation.dict())
     return validation


### PR DESCRIPTION
## Summary
- import `publish_event` from `supabase_helpers`
- await publish_event in validator agent

## Testing
- `make format` *(fails: failed to download openai-agents)*
- `make lint` *(fails: failed to download openai-agents)*
- `make mypy` *(fails: failed to download openai-agents)*
- `make tests` *(fails: failed to clone openai-agents)*

------
https://chatgpt.com/codex/tasks/task_e_684004f85a688329a8fb82af51cd0640