### PR TITLE
Update onboarding shell to create core context blocks

### DIFF
--- a/web/components/blocks/setup/BlockSetupShell.tsx
+++ b/web/components/blocks/setup/BlockSetupShell.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import { useRouter } from "next/navigation";
 import { useSessionContext } from "@supabase/auth-helpers-react";
-import { getBlocks, createBlock } from "@/lib/supabase/blocks";
+import { createBlock } from "@/lib/supabase/blocks";
 import { Card } from "@/components/ui/Card";
 import { ProgressStepper } from "@/components/ui/ProgressStepper";
 import { LoadingOverlay } from "@/components/ui/LoadingOverlay";
@@ -12,59 +12,32 @@ import StepBasics from "./StepBasics";
 import StepDetails from "./StepDetails";
 import StepReview from "./StepReview";
 import StepNav from "./StepNav";
-import { FormData, Step } from "./types";
+import { CoreBlockFormData, Step } from "./types";
 
-const totalSteps = 3;
+const CORE_TYPES = ["topic", "intent", "reference", "style_guide"];
+const totalSteps = 4;
 
 export default function BlockSetupShell() {
   const router = useRouter();
   const { session, isLoading: sessionLoading } = useSessionContext();
 
   const [step, setStep] = useState<Step>(1);
-  const [formData, setFormData] = useState<FormData>({
-    display_name: "",
-    brand_or_company: "",
-    sns_handle: "",
-    primary_sns_channel: "",
-    platforms: "",
-    follower_count: "",
-    locale: "",
-    tone_preferences: "",
-    logo_url: "",
+  const [formData, setFormData] = useState<CoreBlockFormData>({
+    label: "",
+    content: "",
+    meta_tags: "",
+    meta_context_scope: "",
+    meta_emotional_tone: "",
+    meta_locale: "",
   });
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string>();
 
-  // Load existing block data
-  useEffect(() => {
-    if (sessionLoading) return;
-    if (!session?.user) {
-      router.replace("/login");
-      return;
-    }
-    (async () => {
-      const { data, error } = await getBlocks(session.user.id);
-      if (error) {
-        console.error("Error loading blocks:", error);
-        return;
-      }
-      if (data) {
-        setFormData({
-          display_name: data.display_name || "",
-          brand_or_company: data.brand_or_company || "",
-          sns_handle: data.sns_links?.handle || "",
-          primary_sns_channel: data.sns_links?.primary || "",
-          platforms: Array.isArray(data.sns_links?.others)
-            ? data.sns_links.others.join(", ")
-            : "",
-          follower_count: data.follower_count?.toString() || "",
-          locale: data.locale || "",
-          tone_preferences: data.tone_preferences || "",
-          logo_url: data.logo_url || "",
-        });
-      }
-    })();
-  }, [session, sessionLoading, router]);
+  if (sessionLoading) return null;
+  if (!session?.user) {
+    router.replace("/login");
+    return null;
+  }
 
   const handleChange = (
     e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>
@@ -73,52 +46,77 @@ export default function BlockSetupShell() {
     setFormData((prev) => ({ ...prev, [name]: value }));
   };
 
-  const handleNext = () => setStep((s) => Math.min(totalSteps, s + 1) as Step);
-  const handleBack = () => setStep((s) => Math.max(1, s - 1) as Step);
+  function resetForm() {
+    setFormData({
+      label: "",
+      content: "",
+      meta_tags: "",
+      meta_context_scope: "",
+      meta_emotional_tone: "",
+      meta_locale: "",
+    });
+  }
 
-  const handleGenerate = async () => {
+  async function saveBlock(currentStep: Step) {
     if (!session?.user) {
       setError("You must be logged in to save this block.");
-      return;
+      return false;
     }
     const required = Object.values(formData);
     if (required.some((v) => !v || v.trim() === "")) {
       setError("Please fill in all fields before saving.");
-      return;
+      return false;
     }
     setLoading(true);
     setError(undefined);
     try {
       const payload = {
         user_id: session.user.id,
-        display_name: formData.display_name,
-        brand_or_company: formData.brand_or_company,
-        sns_links: {
-          primary: formData.primary_sns_channel,
-          handle: formData.sns_handle,
-          others: formData.platforms.split(",").map((s) => s.trim()),
-        },
-        tone_preferences: formData.tone_preferences,
-        locale: formData.locale,
-        logo_url: formData.logo_url,
+        label: formData.label,
+        content: formData.content,
+        type: CORE_TYPES[currentStep - 1],
+        is_core_block: true,
+        update_policy: "manual" as const,
+        meta_tags: formData.meta_tags.split(",").map((s) => s.trim()).filter(Boolean),
+        meta_context_scope: formData.meta_context_scope,
+        meta_emotional_tone: formData.meta_emotional_tone
+          .split(",")
+          .map((s) => s.trim())
+          .filter(Boolean),
+        meta_locale: formData.meta_locale,
       };
-      const { data: upserted, error: upsertError } = await createBlock(payload);
-      if (upsertError) throw upsertError;
-      router.push("/blocks");
+      const { error: createError } = await createBlock(payload);
+      if (createError) throw createError;
+      return true;
     } catch (err: any) {
       console.error("Save error:", err);
       setError(err.message || "Failed to save block.");
+      return false;
     } finally {
       setLoading(false);
     }
+  }
+
+  const handleNext = async () => {
+    const ok = await saveBlock(step);
+    if (!ok) return;
+    resetForm();
+    setStep((s) => ((s + 1) as Step));
   };
 
-  if (sessionLoading) return null;
+  const handleBack = () => setStep((s) => Math.max(1, s - 1) as Step);
+
+  const handleFinish = async () => {
+    const ok = await saveBlock(step);
+    if (ok) {
+      router.push("/blocks");
+    }
+  };
 
   return (
     <div className="max-w-md w-full mx-auto px-4 py-6">
       <div className="overflow-x-auto w-full mb-4">
-        <ProgressStepper current={step} steps={["Basics", "Details", "Review"]} />
+        <ProgressStepper current={step} steps={CORE_TYPES} />
       </div>
       <Card className="relative space-y-6">
         {loading && <LoadingOverlay message="Saving your block..." />}
@@ -129,9 +127,9 @@ export default function BlockSetupShell() {
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: -20 }}
           >
-            {step === 1 && <StepBasics formData={formData} onChange={handleChange} />}
-            {step === 2 && <StepDetails formData={formData} onChange={handleChange} />}
-            {step === 3 && <StepReview formData={formData} />}
+            <StepBasics formData={formData} onChange={handleChange} />
+            <StepDetails formData={formData} onChange={handleChange} />
+            <StepReview formData={formData} />
           </motion.div>
         </AnimatePresence>
         <StepNav
@@ -139,7 +137,7 @@ export default function BlockSetupShell() {
           totalSteps={totalSteps}
           onBack={handleBack}
           onNext={handleNext}
-          onGenerate={handleGenerate}
+          onGenerate={handleFinish}
           loading={loading}
           error={error}
         />

--- a/web/components/blocks/setup/StepBasics.tsx
+++ b/web/components/blocks/setup/StepBasics.tsx
@@ -1,11 +1,10 @@
 "use client";
 
 import React from "react";
-import { FormData } from "./types";
-import { ProfileUploadButton } from "@/components/ui/ProfileUploadButton";
+import { CoreBlockFormData } from "./types";
 
 interface StepBasicsProps {
-  formData: FormData;
+  formData: CoreBlockFormData;
   onChange: (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => void;
 }
 
@@ -13,28 +12,23 @@ export default function StepBasics({ formData, onChange }: StepBasicsProps) {
   return (
     <div className="space-y-4">
       <div>
-        <label className="block text-sm font-medium text-muted-foreground">Display Name</label>
+        <label className="block text-sm font-medium text-muted-foreground">Label</label>
         <input
           type="text"
-          name="display_name"
-          value={formData.display_name}
+          name="label"
+          value={formData.label}
           onChange={onChange}
           className="mt-1 block w-full border rounded p-2"
         />
       </div>
       <div>
-        <label className="block text-sm font-medium text-muted-foreground">Brand or Company</label>
-        <input
-          type="text"
-          name="brand_or_company"
-          value={formData.brand_or_company}
+        <label className="block text-sm font-medium text-muted-foreground">Content</label>
+        <textarea
+          name="content"
+          value={formData.content}
           onChange={onChange}
+          rows={6}
           className="mt-1 block w-full border rounded p-2"
-        />
-      </div>
-      <div>
-        <ProfileUploadButton
-          onUpload={(url) => onChange({ target: { name: "logo_url", value: url } } as any)}
         />
       </div>
     </div>

--- a/web/components/blocks/setup/StepDetails.tsx
+++ b/web/components/blocks/setup/StepDetails.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import React from "react";
-import { FormData } from "./types";
+import { CoreBlockFormData } from "./types";
 
 interface StepDetailsProps {
-  formData: FormData;
+  formData: CoreBlockFormData;
   onChange: (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => void;
 }
 
@@ -12,41 +12,31 @@ export default function StepDetails({ formData, onChange }: StepDetailsProps) {
   return (
     <div className="space-y-4">
       <div>
-        <label className="block text-sm font-medium text-muted-foreground">SNS Handle</label>
+        <label className="block text-sm font-medium text-muted-foreground">Tags (comma-separated)</label>
         <input
           type="text"
-          name="sns_handle"
-          value={formData.sns_handle}
+          name="meta_tags"
+          value={formData.meta_tags}
           onChange={onChange}
           className="mt-1 block w-full border rounded p-2"
         />
       </div>
       <div>
-        <label className="block text-sm font-medium text-muted-foreground">Primary SNS Channel</label>
+        <label className="block text-sm font-medium text-muted-foreground">Context Scope</label>
         <input
           type="text"
-          name="primary_sns_channel"
-          value={formData.primary_sns_channel}
+          name="meta_context_scope"
+          value={formData.meta_context_scope}
           onChange={onChange}
           className="mt-1 block w-full border rounded p-2"
         />
       </div>
       <div>
-        <label className="block text-sm font-medium text-muted-foreground">Platforms (comma-separated)</label>
+        <label className="block text-sm font-medium text-muted-foreground">Emotional Tone (comma-separated)</label>
         <input
           type="text"
-          name="platforms"
-          value={formData.platforms}
-          onChange={onChange}
-          className="mt-1 block w-full border rounded p-2"
-        />
-      </div>
-      <div>
-        <label className="block text-sm font-medium text-muted-foreground">Follower Count</label>
-        <input
-          type="text"
-          name="follower_count"
-          value={formData.follower_count}
+          name="meta_emotional_tone"
+          value={formData.meta_emotional_tone}
           onChange={onChange}
           className="mt-1 block w-full border rounded p-2"
         />
@@ -55,18 +45,8 @@ export default function StepDetails({ formData, onChange }: StepDetailsProps) {
         <label className="block text-sm font-medium text-muted-foreground">Locale</label>
         <input
           type="text"
-          name="locale"
-          value={formData.locale}
-          onChange={onChange}
-          className="mt-1 block w-full border rounded p-2"
-        />
-      </div>
-      <div>
-        <label className="block text-sm font-medium text-muted-foreground">Tone Preferences (comma-separated)</label>
-        <input
-          type="text"
-          name="tone_preferences"
-          value={formData.tone_preferences}
+          name="meta_locale"
+          value={formData.meta_locale}
           onChange={onChange}
           className="mt-1 block w-full border rounded p-2"
         />

--- a/web/components/blocks/setup/StepNav.tsx
+++ b/web/components/blocks/setup/StepNav.tsx
@@ -29,12 +29,12 @@ export default function StepNav({
           Back
         </Button>
         {currentStep < totalSteps ? (
-          <Button onClick={onNext} size="md">
-            Next
+          <Button onClick={onNext} size="md" disabled={loading}>
+            {loading ? "Saving..." : "Save & Next"}
           </Button>
         ) : (
           <Button onClick={onGenerate} size="md" disabled={loading}>
-            {loading ? "Generating..." : "Generate Report"}
+            {loading ? "Saving..." : "Finish"}
           </Button>
         )}
       </div>

--- a/web/components/blocks/setup/StepReview.tsx
+++ b/web/components/blocks/setup/StepReview.tsx
@@ -1,55 +1,34 @@
 "use client";
 
 import React from "react";
-import { FormData } from "./types";
+import { CoreBlockFormData } from "./types";
 import { ReviewRow } from "@/components/ui/ReviewRow";
 
 interface StepReviewProps {
-  formData: FormData;
+  formData: CoreBlockFormData;
 }
 
 export default function StepReview({ formData }: StepReviewProps) {
-  const {
-    display_name,
-    brand_or_company,
-    sns_handle,
-    primary_sns_channel,
-    platforms,
-    follower_count,
-    locale,
-    tone_preferences,
-    logo_url,
-  } = formData;
-  const otherPlatforms = platforms
-    ? platforms.split(",").map((p) => p.trim()).filter(Boolean)
-    : [];
+  const { label, content, meta_tags, meta_context_scope, meta_emotional_tone, meta_locale } = formData;
+  const tags = meta_tags ? meta_tags.split(',').map((t) => t.trim()).filter(Boolean) : [];
+  const tones = meta_emotional_tone ? meta_emotional_tone.split(',').map((t) => t.trim()).filter(Boolean) : [];
   return (
     <div className="space-y-4 text-sm">
-      <ReviewRow label="Display Name" value={display_name} />
-      <ReviewRow label="Brand or Company" value={brand_or_company} />
-      <ReviewRow label="SNS Handle" value={sns_handle} />
-      <ReviewRow label="Primary SNS Channel" value={primary_sns_channel} />
+      <ReviewRow label="Label" value={label} />
+      <ReviewRow label="Content" value={content} />
       <ReviewRow
-        label="Other Platforms"
-        value={otherPlatforms.length > 0 ? (
+        label="Tags"
+        value={tags.length > 0 ? (
           <div className="flex flex-wrap gap-2 mt-1">
-            {otherPlatforms.map((p, idx) => (
+            {tags.map((p, idx) => (
               <span key={idx} className="px-2 py-0.5 text-xs bg-muted rounded-full">{p}</span>
             ))}
           </div>
         ) : undefined}
       />
-      <ReviewRow label="Follower Count" value={follower_count} />
-      <ReviewRow label="Locale" value={locale} />
-      <ReviewRow label="Tone Preferences" value={tone_preferences} />
-      {logo_url && (
-        <ReviewRow
-          label="Logo"
-          value={
-            <img src={logo_url} alt="Logo" className="w-24 h-24 object-contain rounded border" />
-          }
-        />
-      )}
+      <ReviewRow label="Context Scope" value={meta_context_scope} />
+      <ReviewRow label="Emotional Tone" value={tones.join(', ')} />
+      <ReviewRow label="Locale" value={meta_locale} />
     </div>
   );
 }

--- a/web/components/blocks/setup/types.ts
+++ b/web/components/blocks/setup/types.ts
@@ -1,13 +1,10 @@
-export interface FormData {
-  display_name: string;
-  brand_or_company: string;
-  sns_handle: string;
-  primary_sns_channel: string;
-  platforms: string;
-  follower_count: string;
-  locale: string;
-  tone_preferences: string;
-  logo_url: string;
+export interface CoreBlockFormData {
+  label: string;
+  content: string;
+  meta_tags: string;
+  meta_context_scope: string;
+  meta_emotional_tone: string;
+  meta_locale: string;
 }
 
-export type Step = 1 | 2 | 3;
+export type Step = 1 | 2 | 3 | 4;


### PR DESCRIPTION
## Summary
- refactor BlockSetupShell to use core context block fields
- update step components for new block metadata
- tweak step navigation labels

## Test plan
- `make format` *(fails: build backend error)*
- `make lint` *(fails: build backend error)*
- `make tests` *(fails: build backend error)*

------
https://chatgpt.com/codex/tasks/task_e_6841001b953c832996eeec9816106b40