### PR TITLE
Add compose pipeline endpoint and UI

### DIFF
--- a/api/src/app/agent_entrypoints.py
+++ b/api/src/app/agent_entrypoints.py
@@ -1,39 +1,48 @@
-from fastapi import Request, HTTPException, Depends, APIRouter
 import json
 from datetime import datetime
 
 from agents import Runner
-from .agent_tasks.layer1_infra.agents.infra_manager_agent import manager
-from .agent_tasks.holding.strategy_agent import strategy
+from fastapi import APIRouter, HTTPException, Request
+
+from .agent_tasks.holding.competitor_agent import competitor_agent as competitor
 from .agent_tasks.holding.content_agent import content
 from .agent_tasks.holding.feedback_agent import feedback
-from .agent_tasks.holding.repurpose_agent import repurpose
 from .agent_tasks.holding.profile_analyzer_agent import profile_analyzer_agent as profile_analyzer
-from .agent_tasks.holding.competitor_agent import competitor_agent as competitor
-
-from .agent_tasks.layer2_tasks.utils.task_router import route_and_validate_task
-from .agent_tasks.layer2_tasks.utils.output_utils import build_payload
-from .agent_tasks.layer2_tasks.utils.task_utils import create_task_and_session
+from .agent_tasks.holding.repurpose_agent import repurpose
+from .agent_tasks.holding.strategy_agent import strategy
+from .agent_tasks.layer1_infra.agents.infra_manager_agent import manager
 from .agent_tasks.layer1_infra.utils.supabase_helpers import supabase
+from .agent_tasks.layer2_tasks.agents.tasks_composer_agent import run as compose_run
+from .agent_tasks.layer2_tasks.agents.tasks_editor_agent import edit as editor_run
+from .agent_tasks.layer2_tasks.agents.tasks_validator_agent import validate as validate_run
 from .agent_tasks.layer2_tasks.registry import get_missing_fields
 
-#0603 for layer2 agents (above fastapi, Depends import as well)
+# 0603 for layer2 agents (above fastapi, Depends import as well)
 from .agent_tasks.layer2_tasks.schemas import ComposeRequest
-from .agent_tasks.layer2_tasks.agents.tasks_composer_agent import run as compose
-
+from .agent_tasks.layer2_tasks.utils.output_utils import build_payload
+from .agent_tasks.layer2_tasks.utils.task_router import route_and_validate_task
+from .agent_tasks.layer2_tasks.utils.task_utils import create_task_and_session
 
 router = APIRouter()
 
+
 @router.post("/brief/compose")
 async def compose_brief(req: ComposeRequest):
-    draft = await compose(
-        req.user_id,
-        intent=req.user_intent,
-        sub_instructions=req.sub_instructions,
-        file_urls=req.file_urls,
-    )
-    return {"brief_id": draft.brief_id}
-#0603 for layer2 agents (above fastapi, Depends import as well)
+    # 1 Compose
+    draft = await compose_run(req)
+
+    # 2 Editor (pass-through v0)
+    edited = await editor_run(draft)
+
+    # 3 Validator
+    report = await validate_run(edited)
+    if not report.ok:
+        raise HTTPException(status_code=400, detail=report.errors)
+
+    return {"brief_id": draft.brief_id, "validated": True}
+
+
+# 0603 for layer2 agents (above fastapi, Depends import as well)
 
 AGENT_REGISTRY = {
     "strategy": strategy,
@@ -44,18 +53,22 @@ AGENT_REGISTRY = {
     "competitor": competitor,
 }
 
+
 def log_agent_message(task_id, user_id, agent_type, message):
     try:
-        supabase.table("agent_messages").insert({
-            "task_id": task_id,
-            "user_id": user_id,
-            "agent_type": agent_type,
-            "message_type": message.get("type", "text"),
-            "message_content": message,
-            "created_at": datetime.utcnow().isoformat(),
-        }).execute()
+        supabase.table("agent_messages").insert(
+            {
+                "task_id": task_id,
+                "user_id": user_id,
+                "agent_type": agent_type,
+                "message_type": message.get("type", "text"),
+                "message_content": message,
+                "created_at": datetime.utcnow().isoformat(),
+            }
+        ).execute()
     except Exception as e:
         print(f"[warn] Failed to log message to agent_messages: {e}")
+
 
 async def run_agent(req: Request):
     data = await req.json()
@@ -73,15 +86,21 @@ async def run_agent(req: Request):
     collected_inputs = data.get("collected_inputs", {}) or {}
 
     if not task_id:
-        task_id = create_task_and_session(user_id, "manager", metadata={
-            "task_type_id": task_type_id,
-            "inputs": collected_inputs,
-            "status": "clarifying",
-        })
+        task_id = create_task_and_session(
+            user_id,
+            "manager",
+            metadata={
+                "task_type_id": task_type_id,
+                "inputs": collected_inputs,
+                "status": "clarifying",
+            },
+        )
 
     missing_fields = get_missing_fields(task_type_id, collected_inputs)
     try:
-        supabase.table("agent_sessions").update({"inputs": collected_inputs}).eq("id", task_id).execute()
+        supabase.table("agent_sessions").update({"inputs": collected_inputs}).eq(
+            "id", task_id
+        ).execute()
     except Exception:
         print(f"Warning: failed to persist inputs for task_id={task_id}")
 
@@ -89,7 +108,13 @@ async def run_agent(req: Request):
         task_id=task_id,
         user_id=user_id,
         agent_type="manager",
-        message={"type": "system", "content": {"provided_fields": list(collected_inputs.keys()), "missing_fields": missing_fields}},
+        message={
+            "type": "system",
+            "content": {
+                "provided_fields": list(collected_inputs.keys()),
+                "missing_fields": missing_fields,
+            },
+        },
         reason="input_status",
         trace=[],
     )
@@ -99,7 +124,12 @@ async def run_agent(req: Request):
         result = await Runner.run(
             manager,
             input=prompt,
-            context={"task_id": task_id, "user_id": user_id, "task_type_id": task_type_id, "collected_inputs": collected_inputs},
+            context={
+                "task_id": task_id,
+                "user_id": user_id,
+                "task_type_id": task_type_id,
+                "collected_inputs": collected_inputs,
+            },
             max_turns=12,
         )
     except Exception:
@@ -107,7 +137,10 @@ async def run_agent(req: Request):
             task_id=task_id,
             user_id=user_id,
             agent_type="manager",
-            message={"type": "text", "content": "Sorry, I couldn’t process your request—could you rephrase?"},
+            message={
+                "type": "text",
+                "content": "Sorry, I couldn’t process your request—could you rephrase?",
+            },
             reason="parse_error",
             trace=[],
         )
@@ -122,7 +155,10 @@ async def run_agent(req: Request):
             task_id=task_id,
             user_id=user_id,
             agent_type="manager",
-            message={"type": "text", "content": "Sorry, I couldn’t process your request—could you rephrase?"},
+            message={
+                "type": "text",
+                "content": "Sorry, I couldn’t process your request—could you rephrase?",
+            },
             reason="parse_error",
             trace=[],
         )
@@ -135,7 +171,9 @@ async def run_agent(req: Request):
         field = parsed.get("field")
         question = parsed.get("message")
         try:
-            supabase.table("agent_sessions").update({"inputs": collected_inputs, "pending_field": field}).eq("id", task_id).execute()
+            supabase.table("agent_sessions").update(
+                {"inputs": collected_inputs, "pending_field": field}
+            ).eq("id", task_id).execute()
         except Exception:
             print(f"[warn] Could not persist pending_field for task_id={task_id}")
         payload = build_payload(
@@ -153,11 +191,15 @@ async def run_agent(req: Request):
         agent_type = parsed.get("agent_type")
         inputs = parsed.get("input", {})
         try:
-            supabase.table("agent_sessions").update({"status": "dispatched", "inputs": inputs}).eq("id", task_id).execute()
+            supabase.table("agent_sessions").update({"status": "dispatched", "inputs": inputs}).eq(
+                "id", task_id
+            ).execute()
         except Exception:
             print(f"Warning: failed to update session status to dispatched for task_id={task_id}")
 
-        spec_result = await route_and_validate_task(task_type_id, {"task_id": task_id, "user_id": user_id}, inputs)
+        spec_result = await route_and_validate_task(
+            task_type_id, {"task_id": task_id, "user_id": user_id}, inputs
+        )
         output_type = spec_result.get("output_type")
         validated_data = spec_result.get("validated_output")
         final_payload = build_payload(
@@ -170,7 +212,9 @@ async def run_agent(req: Request):
         )
         log_agent_message(task_id, user_id, agent_type, final_payload["message"])
         try:
-            supabase.table("agent_sessions").update({"status": "completed"}).eq("id", task_id).execute()
+            supabase.table("agent_sessions").update({"status": "completed"}).eq(
+                "id", task_id
+            ).execute()
         except Exception:
             print(f"Warning: failed to update session status to completed for task_id={task_id}")
         return {"ok": True, "task_id": task_id}
@@ -185,6 +229,7 @@ async def run_agent(req: Request):
     )
     log_agent_message(task_id, user_id, "manager", fallback_payload["message"])
     return {"ok": True, "task_id": task_id}
+
 
 async def run_agent_direct(req: Request):
     data = await req.json()
@@ -216,7 +261,7 @@ async def run_agent_direct(req: Request):
         msg = {"type": "text", "content": raw}
 
     trace = result.to_debug_dict() if hasattr(result, "to_debug_dict") else []
-    payload = build_payload(
+    payload = build_payload(  # noqa: F841
         task_id=task_id,
         user_id=user_id,
         agent_type=agent.name,

--- a/api/src/app/agent_entrypoints.py
+++ b/api/src/app/agent_entrypoints.py
@@ -16,8 +16,6 @@ from .agent_tasks.layer2_tasks.agents.tasks_composer_agent import run as compose
 from .agent_tasks.layer2_tasks.agents.tasks_editor_agent import edit as editor_run
 from .agent_tasks.layer2_tasks.agents.tasks_validator_agent import validate as validate_run
 from .agent_tasks.layer2_tasks.registry import get_missing_fields
-
-# 0603 for layer2 agents (above fastapi, Depends import as well)
 from .agent_tasks.layer2_tasks.schemas import ComposeRequest
 from .agent_tasks.layer2_tasks.utils.output_utils import build_payload
 from .agent_tasks.layer2_tasks.utils.task_router import route_and_validate_task
@@ -41,8 +39,6 @@ async def compose_brief(req: ComposeRequest):
 
     return {"brief_id": draft.brief_id, "validated": True}
 
-
-# 0603 for layer2 agents (above fastapi, Depends import as well)
 
 AGENT_REGISTRY = {
     "strategy": strategy,

--- a/api/src/app/agent_tasks/layer2_tasks/agents/tasks_validator_agent.py
+++ b/api/src/app/agent_tasks/layer2_tasks/agents/tasks_validator_agent.py
@@ -1,13 +1,16 @@
 """Validate task briefs before execution."""
 
-from ..schemas import TaskBriefEdited, TaskBriefValidation
-from app.event_bus import DB_URL
-from app.supabase_helpers import publish_event
-import asyncpg
 import datetime
 
-EVENT_TOPIC_IN  = "brief.edited"
+import asyncpg
+
+from app.event_bus import DB_URL, publish_event
+
+from ..schemas import TaskBriefEdited, TaskBriefValidation
+
+EVENT_TOPIC_IN = "brief.edited"
 EVENT_TOPIC_OUT = "brief.validated"
+
 
 async def validate(brief: TaskBriefEdited) -> TaskBriefValidation:
     errors = []

--- a/codex/setup_task_env.sh
+++ b/codex/setup_task_env.sh
@@ -1,0 +1,7 @@
+cd api
+python3 -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip setuptools wheel
+pip install -r src/requirements.codex.txt
+export PYTHONPATH=src
+cd ..

--- a/supabase/edge-functions/create_view_pending_block_queue.sql
+++ b/supabase/edge-functions/create_view_pending_block_queue.sql
@@ -1,0 +1,15 @@
+create or replace function pending_block_queue_with_block_label()
+returns table (
+  id uuid,
+  action text,
+  block_id uuid,
+  proposed_data jsonb,
+  created_at timestamptz,
+  label text
+) language sql stable as $$
+  select q.id, q.action, q.block_id, q.proposed_data, q.created_at, cb.label
+  from block_change_queue q
+  join context_blocks cb on cb.id = q.block_id
+  where q.status = 'pending'
+  order by q.created_at;
+$$;

--- a/web/app/blocks/queue/page.tsx
+++ b/web/app/blocks/queue/page.tsx
@@ -1,0 +1,90 @@
+/* Pending Block-Change Queue
+   Lists rows from block_change_queue where status='pending'
+   User can Approve → status='approved'  |  Reject → 'rejected'
+*/
+"use client";
+
+import { useEffect, useState } from "react";
+import { createClient } from "@/lib/supabaseClient";
+import { Button } from "@/components/ui/Button";
+import Shell from "@/components/layouts/Shell";
+
+interface QueueRow {
+  id: string;
+  action: string;
+  block_id: string;
+  proposed_data: any;
+  created_at: string;
+  context_blocks?: { label: string };
+}
+
+export default function BlockQueuePage() {
+  const supabase = createClient();
+  const [rows, setRows] = useState<QueueRow[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  // fetch queue rows + block labels in one call
+  const fetchRows = async () => {
+    setLoading(true);
+    const { data } = await supabase.rpc("pending_block_queue_with_block_label");
+    // Fallback if RPC not created → simple join
+    if (data) setRows(data as any);
+    else {
+      const { data: raw } = await supabase
+        .from("block_change_queue")
+        .select(
+          "id,action,block_id,proposed_data,created_at,context_blocks(label)"
+        )
+        .eq("status", "pending")
+        .order("created_at");
+      setRows(raw as any);
+    }
+    setLoading(false);
+  };
+
+  useEffect(() => {
+    fetchRows();
+  }, []);
+
+  const handle = async (id: string, newStatus: "approved" | "rejected") => {
+    await supabase
+      .from("block_change_queue")
+      .update({ status: newStatus })
+      .eq("id", id);
+    setRows((prev) => prev.filter((r) => r.id !== id));
+  };
+
+  return (
+    <Shell>
+      <div className="max-w-4xl mx-auto p-6 space-y-6">
+        <h1 className="text-2xl font-bold">Pending Block Updates</h1>
+        {loading && <p>Loading…</p>}
+        {!loading && rows.length === 0 && <p>No pending changes 🎉</p>}
+        <ul className="space-y-4">
+          {rows.map((row) => (
+            <li
+              key={row.id}
+              className="border rounded p-4 flex justify-between items-start gap-4"
+            >
+              <div className="grow">
+                <h3 className="font-medium">
+                  {row.context_blocks?.label || row.block_id.slice(0, 8)}
+                </h3>
+                <p className="text-xs text-gray-500">
+                  {row.action.toUpperCase()} · {new Date(row.created_at).toLocaleString()}
+                </p>
+                <pre className="mt-2 text-xs bg-gray-50 p-2 rounded overflow-x-auto">
+                  {JSON.stringify(row.proposed_data, null, 2)}
+                </pre>
+              </div>
+              <div className="space-y-2">
+                <Button variant="success" onClick={() => handle(row.id, "approved")}>Approve</Button>
+                <Button variant="destructive" onClick={() => handle(row.id, "rejected")}>Reject</Button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </Shell>
+  );
+}

--- a/web/app/blocks/queue/page.tsx
+++ b/web/app/blocks/queue/page.tsx
@@ -78,8 +78,8 @@ export default function BlockQueuePage() {
                 </pre>
               </div>
               <div className="space-y-2">
-                <Button variant="success" onClick={() => handle(row.id, "approved")}>Approve</Button>
-                <Button variant="destructive" onClick={() => handle(row.id, "rejected")}>Reject</Button>
+                <Button onClick={() => handle(row.id, "approved")}>Approve</Button>
+                <Button variant="outline" onClick={() => handle(row.id, "rejected")}>Reject</Button>
               </div>
             </li>
           ))}

--- a/web/app/briefs/[id]/page.tsx
+++ b/web/app/briefs/[id]/page.tsx
@@ -1,11 +1,11 @@
-// web/app/briefs/[briefID]/page.tsx
+// web/app/briefs/[id]/page.tsx
 
-export default function BriefDetailPage({ params }: any) {
+export default function BriefDetailPage({ params }: { params: { id: string } }) {
   return (
     <div className="p-6">
       <h1 className="text-xl font-bold">📝 Brief Detail</h1>
       <p className="text-muted-foreground text-sm">
-        Brief ID: {params?.briefID}
+        Brief ID: {params?.id}
       </p>
     </div>
   );

--- a/web/app/briefs/[id]/page.tsx
+++ b/web/app/briefs/[id]/page.tsx
@@ -1,6 +1,6 @@
 // web/app/briefs/[id]/page.tsx
 
-export default function BriefDetailPage({ params }: { params: { id: string } }) {
+export default function BriefDetailPage({ params }: any) {
   return (
     <div className="p-6">
       <h1 className="text-xl font-bold">📝 Brief Detail</h1>

--- a/web/app/briefs/[id]/view/page.tsx
+++ b/web/app/briefs/[id]/view/page.tsx
@@ -4,7 +4,7 @@ import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { createClient } from "@/lib/supabaseClient";
 
-export default function BriefView({ params }: { params: { id: string } }) {
+export default function BriefView({ params }: any) {
   const supabase = createClient();
   const [brief, setBrief] = useState<any>(null);
   const router = useRouter();

--- a/web/app/briefs/[id]/view/page.tsx
+++ b/web/app/briefs/[id]/view/page.tsx
@@ -1,0 +1,34 @@
+/* simple read-only view of draft brief */
+"use client";
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import { createClient } from "@/lib/supabaseClient";
+
+export default function BriefView({ params }: { params: { id: string } }) {
+  const supabase = createClient();
+  const [brief, setBrief] = useState<any>(null);
+  const router = useRouter();
+
+  useEffect(() => {
+    const fetchBrief = async () => {
+      const { data } = await supabase
+        .from("task_briefs")
+        .select("*")
+        .eq("id", params.id)
+        .single();
+      setBrief(data);
+    };
+    fetchBrief();
+  }, [params.id]);
+
+  if (!brief) return <p className="p-4">Loading…</p>;
+
+  return (
+    <div className="max-w-3xl mx-auto p-6 space-y-6">
+      <h1 className="text-2xl font-bold">Draft Brief</h1>
+      <p><b>Intent:</b> {brief.intent}</p>
+      {brief.sub_instructions && <p><b>Sub-instructions:</b> {brief.sub_instructions}</p>}
+      <pre className="bg-gray-50 p-4 rounded">{JSON.stringify(brief.core_context_snapshot, null, 2)}</pre>
+    </div>
+  );
+}

--- a/web/app/briefs/create/page.tsx
+++ b/web/app/briefs/create/page.tsx
@@ -44,30 +44,30 @@ export default function CreateBriefPage() {
   }, [user]);
 
   const handleSubmit = async () => {
-    if (!intent.trim() || !contextBlockId || !briefTypeId) {
-      alert("Please fill all required fields.");
+    if (!intent.trim()) {
+      alert("Intent required");
       return;
     }
 
-    const { data, error } = await supabase
-      .from("task_briefs")
-      .insert({
-        user_id: user?.id,
-        intent,
-        sub_instructions: subInstructions || "",
+    const res = await fetch("/api/brief/compose", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        user_id: user!.id,
+        user_intent: intent,
+        sub_instructions,
         file_urls: media,
-        context_block_id: contextBlockId,
-        task_brief_type_id: briefTypeId,
-      })
-      .select()
-      .single();
+        compilation_mode: "structured",
+      }),
+    });
 
-    if (error) {
-      console.error("Brief creation failed:", error);
-      alert("Error creating brief");
-    } else {
-      router.push(`/briefs/${data.id}/view`);
+    if (!res.ok) {
+      const { detail } = await res.json();
+      alert(`Compose failed: ${detail}`);
+      return;
     }
+    const { brief_id } = await res.json();
+    router.push(`/briefs/${brief_id}/view`);
   };
 
   if (!user) return null;

--- a/web/app/briefs/create/page.tsx
+++ b/web/app/briefs/create/page.tsx
@@ -55,7 +55,7 @@ export default function CreateBriefPage() {
       body: JSON.stringify({
         user_id: user!.id,
         user_intent: intent,
-        sub_instructions,
+        sub_instructions: subInstructions,
         file_urls: media,
         compilation_mode: "structured",
       }),

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -1,10 +1,9 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import Link from "next/link";
-import { useEffect, useState } from "react";
 import "./globals.css";
 import SupabaseProvider from "@/components/SupabaseProvider";
-import { createClient } from "@/lib/supabaseClient";
+import QueueLink from "@/components/QueueLink";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -50,26 +49,3 @@ export default function RootLayout({
   );
 }
 
-function QueueLink() {
-  const supabase = createClient();
-  const [count, setCount] = useState(0);
-
-  useEffect(() => {
-    supabase
-      .from("block_change_queue")
-      .select("id", { count: "exact" })
-      .eq("status", "pending")
-      .then(({ count }) => setCount(count || 0));
-  }, []);
-
-  return (
-    <Link href="/blocks/queue" className="relative">
-      Queue
-      {count > 0 && (
-        <span className="absolute -right-3 -top-2 rounded-full bg-red-600 text-white text-xs px-1">
-          {count}
-        </span>
-      )}
-    </Link>
-  );
-}

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -1,8 +1,10 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import Link from "next/link";
+import { useEffect, useState } from "react";
 import "./globals.css";
 import SupabaseProvider from "@/components/SupabaseProvider";
-// Removed DashboardLayout import, using direct children in root layout
+import { createClient } from "@/lib/supabaseClient";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -33,9 +35,41 @@ export default function RootLayout({
     <html lang="en">
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
         <SupabaseProvider>
+          <header className="p-4 border-b">
+            <nav className="flex items-center gap-6 text-sm">
+              <Link href="/briefs">Briefs</Link>
+              <Link href="/blocks">Blocks</Link>
+              {/* Inbox badge */}
+              <QueueLink />
+            </nav>
+          </header>
           {children}
         </SupabaseProvider>
       </body>
     </html>
+  );
+}
+
+function QueueLink() {
+  const supabase = createClient();
+  const [count, setCount] = useState(0);
+
+  useEffect(() => {
+    supabase
+      .from("block_change_queue")
+      .select("id", { count: "exact" })
+      .eq("status", "pending")
+      .then(({ count }) => setCount(count || 0));
+  }, []);
+
+  return (
+    <Link href="/blocks/queue" className="relative">
+      Queue
+      {count > 0 && (
+        <span className="absolute -right-3 -top-2 rounded-full bg-red-600 text-white text-xs px-1">
+          {count}
+        </span>
+      )}
+    </Link>
   );
 }

--- a/web/app/tasks/[taskId]/page.tsx
+++ b/web/app/tasks/[taskId]/page.tsx
@@ -13,7 +13,7 @@ import { Card } from "@/components/ui/Card";
 import { createClient } from "@/lib/supabaseClient";
 
 
-export default function Page({ params }: { params: any }) {
+export default function Page({ params }: any) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const taskTypeId = params.taskId;

--- a/web/components/QueueLink.tsx
+++ b/web/components/QueueLink.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { createClient } from "@/lib/supabaseClient";
+
+export default function QueueLink() {
+  const supabase = createClient();
+  const [count, setCount] = useState(0);
+
+  useEffect(() => {
+    supabase
+      .from("block_change_queue")
+      .select("id", { count: "exact" })
+      .eq("status", "pending")
+      .then(({ count }) => setCount(count || 0));
+  }, []);
+
+  return (
+    <Link href="/blocks/queue" className="relative">
+      Queue
+      {count > 0 && (
+        <span className="absolute -right-3 -top-2 rounded-full bg-red-600 text-white text-xs px-1">
+          {count}
+        </span>
+      )}
+    </Link>
+  );
+}


### PR DESCRIPTION
## Summary
- chain composer, editor, validator in compose route
- call API compose from create brief UI
- stub brief viewer page
- expose `publish_event` via `event_bus`
- update validator to import from event_bus

## Testing
- `ruff format api/src/app/agent_entrypoints.py api/src/app/event_bus.py api/src/app/agent_tasks/layer2_tasks/agents/tasks_validator_agent.py`
- `ruff check api/src/app/agent_entrypoints.py api/src/app/event_bus.py api/src/app/agent_tasks/layer2_tasks/agents/tasks_validator_agent.py`
- `make tests` *(fails: build backend error)*

------
https://chatgpt.com/codex/tasks/task_e_68412a2facfc832991286895e9f81dbb