### PR TITLE
Align frontend branding with Yarnnn

### DIFF
--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -16,8 +16,8 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "rightNOW",
-  description: "you need marketing agents, not a marketing team!",
+  title: "Yarnnn",
+  description: "weave your ideas with AI",
   icons: {
     // Favicon placed in public/favicon.svg
     icon: '/favicon.svg',
@@ -36,17 +36,9 @@ export default function RootLayout({
         <SupabaseProvider>
           <header className="p-4 border-b">
             <nav className="flex items-center gap-6 text-sm">
-              {process.env.NEXT_PUBLIC_NEXT_DUMP_FLOW ? (
-                <>
-                  <Link href="/baskets/new">Baskets</Link>
-                  <Link href="/blocks">Blocks</Link>
-                </>
-              ) : (
-                <>
-                  <Link href="/briefs">Briefs</Link>
-                  <Link href="/blocks">Blocks</Link>
-                </>
-              )}
+              <Link href="/dashboard">Dashboard</Link>
+              <Link href="/baskets/new">Baskets</Link>
+              <Link href="/blocks">Blocks</Link>
               <QueueLink />
             </nav>
           </header>

--- a/web/app/privacy/page.tsx
+++ b/web/app/privacy/page.tsx
@@ -14,7 +14,7 @@ export default function Page() {
         <p><strong>Effective Date: March 25th, 2025</strong></p>
 
         <p>
-          This Privacy Policy outlines how rightNOW ("we", "our", or "us") accesses, uses,
+          This Privacy Policy outlines how Yarnnn ("we", "our", or "us") accesses, uses,
           and protects your information when you authorize the application to connect
           with your Google account.
         </p>
@@ -44,7 +44,7 @@ export default function Page() {
             https://myaccount.google.com/permissions
           </a>
           <br />
-          Revoking disables Gmail-related features in rightNOW.
+          Revoking disables Gmail-related features in Yarnnn.
         </p>
 
         <h2>4. Data Security</h2>

--- a/web/app/terms/page.tsx
+++ b/web/app/terms/page.tsx
@@ -14,7 +14,7 @@ export default function Page() {
         <p><strong>Effective Date: March 28th, 2025</strong></p>
 
         <p>
-          Welcome to rightNOW. By using our app or site, you agree to these Terms of Service.
+          Welcome to Yarnnn. By using our app or site, you agree to these Terms of Service.
           If you disagree, do not use the services.
         </p>
 
@@ -60,7 +60,7 @@ export default function Page() {
 
         <h2>6. Disclaimers</h2>
         <p>
-          rightNOW is provided "as is" with no warranties. We do our best to ensure reliability
+          Yarnnn is provided "as is" with no warranties. We do our best to ensure reliability
           but offer no uptime guarantees.
         </p>
 

--- a/web/components/layouts/SidebarNav.tsx
+++ b/web/components/layouts/SidebarNav.tsx
@@ -6,7 +6,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 
-import { Home, User, Clipboard, FileText, LibraryIcon } from "lucide-react";
+import { Home, Clipboard, FileText, LibraryIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/Button";
 import UserNav from "@/components/UserNav";
@@ -17,29 +17,12 @@ interface NavItem {
   icon: React.ComponentType<{ className?: string }>;
 }
 
-const baseItems: NavItem[] = [
+const navItems: NavItem[] = [
   { title: "Dashboard", href: "/dashboard", icon: Home },
-  { title: "Blocks", href: "/blocks", icon: LibraryIcon },
-];
-
-const briefItems: NavItem[] = [
-  { title: "Briefs", href: "/briefs/create", icon: FileText },
-  { title: "Tasks", href: "/tasks", icon: Clipboard },
-  { title: "Creations", href: "/creations", icon: User },
-];
-
-const basketItems: NavItem[] = [
   { title: "Baskets", href: "/baskets/new", icon: FileText },
+  { title: "Blocks", href: "/blocks", icon: LibraryIcon },
   { title: "Integrations", href: "/integrations", icon: Clipboard },
-  { title: "Briefs", href: "/briefs/create", icon: FileText },
-  { title: "Tasks", href: "/tasks", icon: Clipboard },
-  { title: "Creations", href: "/creations", icon: User },
 ];
-
-const getNavItems = (): NavItem[] =>
-  process.env.NEXT_PUBLIC_NEXT_DUMP_FLOW === "true"
-    ? [...baseItems, ...basketItems]
-    : [...baseItems, ...briefItems];
 
 interface SidebarNavProps {
   collapsed?: boolean;
@@ -51,7 +34,7 @@ export default function SidebarNav({
   onCollapseToggle,
 }: SidebarNavProps) {
   const pathname = usePathname();
-  const navItems = getNavItems();
+  // Navigation items are defined statically above
 
   return (
     <nav


### PR DESCRIPTION
## Summary
- rebrand layout metadata to Yarnnn
- update top navigation links
- simplify sidebar navigation
- replace remaining rightNOW mentions in Terms and Privacy

## Testing
- `pytest -q` *(fails: ModuleNotFoundError and network unreachable)*


------
https://chatgpt.com/codex/tasks/task_e_68439d58eb2c8329b46025be303a879a