### PR TITLE
Implement basket work update mode

### DIFF
--- a/api/src/app/agent_tasks/orchestration/thread_parser_listener.py
+++ b/api/src/app/agent_tasks/orchestration/thread_parser_listener.py
@@ -17,13 +17,47 @@ async def handle_new_basket(basket_id: str, payload: Any) -> None:
     async with asyncpg.connect(DB_URL) as conn:
         block_id = str(uuid.uuid4())
         await conn.execute(
-            "insert into context_blocks(id,user_id,type,label,content,update_policy) values($1,'demo-user','note',$2,$3,'auto')",
+            (
+                "insert into context_blocks(id,user_id,type,label,content,update_policy) "
+                "values($1,'demo-user','note',$2,$3,'auto')"
+            ),
             block_id,
             (payload.get("intent_summary") or "note")[:50],
             payload.get("input_text", ""),
         )
         await conn.execute(
-            "insert into block_brief_link(id,block_id,task_brief_id,transformation) values(gen_random_uuid(),$1,$2,'source')",
+            (
+                "insert into block_brief_link(id,block_id,task_brief_id,transformation) "
+                "values(gen_random_uuid(),$1,$2,'source')"
+            ),
+            block_id,
+            basket_id,
+        )
+        await conn.execute("update baskets set status='confirmed' where id=$1", basket_id)
+
+    await generate(basket_id, "demo-user")
+
+
+async def handle_update_basket(basket_id: str, payload: Any) -> None:
+    """Process additional input for an existing basket."""
+    await run_analyzer()
+
+    async with asyncpg.connect(DB_URL) as conn:
+        block_id = str(uuid.uuid4())
+        await conn.execute(
+            (
+                "insert into context_blocks(id,user_id,type,label,content,update_policy) "
+                "values($1,'demo-user','note',$2,$3,'auto')"
+            ),
+            block_id,
+            (payload.get("intent_summary") or "note")[:50],
+            payload.get("input_text", ""),
+        )
+        await conn.execute(
+            (
+                "insert into block_brief_link(id,block_id,task_brief_id,transformation) "
+                "values(gen_random_uuid(),$1,$2,'source')"
+            ),
             block_id,
             basket_id,
         )

--- a/web/app/baskets/[id]/page.tsx
+++ b/web/app/baskets/[id]/page.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useState } from "react";
 import { createClient } from "@/lib/supabaseClient";
 import { Button } from "@/components/ui/Button";
+import Link from "next/link";
 
 export default function BasketDetailPage({ params }: any) {
   const supabase = createClient();
@@ -44,6 +45,9 @@ export default function BasketDetailPage({ params }: any) {
           ))}
         </ul>
       </section>
+      <Button asChild>
+        <Link href={`/baskets/${params.id}/work`}>Add to Basket</Link>
+      </Button>
     </div>
   );
 }

--- a/web/app/baskets/[id]/work/page.tsx
+++ b/web/app/baskets/[id]/work/page.tsx
@@ -1,0 +1,31 @@
+"use client";
+import { useEffect, useState } from "react";
+import BasketInputPanel from "@/components/BasketInputPanel";
+
+export default function BasketWorkPage({ params }: any) {
+  const [basket, setBasket] = useState<any>(null);
+
+  useEffect(() => {
+    const fetchBasket = async () => {
+      const res = await fetch(`/api/baskets/${params.id}`);
+      if (res.ok) {
+        const json = await res.json();
+        setBasket(json);
+      }
+    };
+    fetchBasket();
+  }, [params.id]);
+
+  if (!basket) return <p className="p-4">Loading…</p>;
+
+  return (
+    <div className="p-6 space-y-4">
+      <h1 className="text-xl font-bold">Work on Basket</h1>
+      <BasketInputPanel
+        mode="edit"
+        basketId={params.id}
+        initial={{ intent_summary: basket.intent_summary }}
+      />
+    </div>
+  );
+}

--- a/web/components/BasketInputPanel/index.tsx
+++ b/web/components/BasketInputPanel/index.tsx
@@ -4,13 +4,16 @@ import UploadButton from "./UploadButton";
 import { useBasketInput } from "./useBasketInput";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/Button";
+import type { BasketInputPayload } from "./types";
 
 interface BasketInputPanelProps {
   mode?: "create" | "edit";
+  basketId?: string;
+  initial?: Partial<BasketInputPayload>;
 }
 
-export default function BasketInputPanel({ mode = "create" }: BasketInputPanelProps) {
-  const { inputText, setInputText, intent, setIntent } = useBasketInput();
+export default function BasketInputPanel({ mode = "create", basketId, initial }: BasketInputPanelProps) {
+  const { inputText, setInputText, intent, setIntent } = useBasketInput(initial);
   const router = useRouter();
 
   async function handleCreate() {
@@ -23,6 +26,16 @@ export default function BasketInputPanel({ mode = "create" }: BasketInputPanelPr
       const { basket_id } = await res.json();
       router.push(`/baskets/${basket_id}`);
     }
+  }
+
+  async function handleUpdate() {
+    if (!basketId) return;
+    await fetch(`/api/baskets/${basketId}/work`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ input_text: inputText, intent_summary: intent, assets: [] }),
+    });
+    router.refresh();
   }
 
   return (
@@ -42,7 +55,11 @@ export default function BasketInputPanel({ mode = "create" }: BasketInputPanelPr
       <UploadButton onUpload={() => {}} />
       <PreviewDrawer />
       <div className="pt-2">
-        <Button onClick={handleCreate}>Create Basket</Button>
+        {mode === "create" ? (
+          <Button onClick={handleCreate}>Create Basket</Button>
+        ) : (
+          <Button onClick={handleUpdate}>Update Basket</Button>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add API route to update existing baskets with new user dumps
- support editing via `BasketInputPanel`
- link to work mode from basket detail
- implement Next.js page for `/baskets/[id]/work`

## Testing
- `ruff check api/src/app/agent_tasks/orchestration/thread_parser_listener.py api/src/app/agent_entrypoints.py --fix`
- `make tests` *(fails: build backend error)*

------
https://chatgpt.com/codex/tasks/task_e_6843b1f3d114832996fa03b43ea31926