### PR TITLE
Fix font branding

### DIFF
--- a/web/app/about/page.tsx
+++ b/web/app/about/page.tsx
@@ -13,7 +13,7 @@ export default function HomePage() {
             "manage your memory<br />
             working with AI" <br />
             <br />
-            <span className="font-pacifico">yarnnn</span>
+            <span className="font-brand">yarnnn</span>
           </h1>
         </section>
         <AgentsTeaserSection />

--- a/web/app/privacy/page.tsx
+++ b/web/app/privacy/page.tsx
@@ -14,7 +14,7 @@ export default function Page() {
         <p><strong>Effective Date: March 25th, 2025</strong></p>
 
         <p>
-          This Privacy Policy outlines how <span className="font-pacifico">yarnnn</span> ("we", "our", or "us") accesses, uses,
+          This Privacy Policy outlines how <span className="font-brand">yarnnn</span> ("we", "our", or "us") accesses, uses,
           and protects your information when you authorize the application to connect
           with your Google account.
         </p>
@@ -44,7 +44,7 @@ export default function Page() {
             https://myaccount.google.com/permissions
           </a>
           <br />
-          Revoking disables Gmail-related features in <span className="font-pacifico">yarnnn</span>.
+          Revoking disables Gmail-related features in <span className="font-brand">yarnnn</span>.
         </p>
 
         <h2>4. Data Security</h2>

--- a/web/app/terms/page.tsx
+++ b/web/app/terms/page.tsx
@@ -14,7 +14,7 @@ export default function Page() {
         <p><strong>Effective Date: March 28th, 2025</strong></p>
 
         <p>
-          Welcome to <span className="font-pacifico">yarnnn</span>. By using our app or site, you agree to these Terms of Service.
+          Welcome to <span className="font-brand">yarnnn</span>. By using our app or site, you agree to these Terms of Service.
           If you disagree, do not use the services.
         </p>
 
@@ -60,7 +60,7 @@ export default function Page() {
 
         <h2>6. Disclaimers</h2>
         <p>
-          <span className="font-pacifico">yarnnn</span> is provided "as is" with no warranties. We do our best to ensure reliability
+          <span className="font-brand">yarnnn</span> is provided "as is" with no warranties. We do our best to ensure reliability
           but offer no uptime guarantees.
         </p>
 

--- a/web/components/landing/LandingFooter.tsx
+++ b/web/components/landing/LandingFooter.tsx
@@ -8,7 +8,7 @@ export default function LandingFooter() {
         {/* Logo/Icon and Brand */}
         <div className="flex items-center gap-3">
           <ArrowElbowRight size={28} className="text-black" />
-          <span className="text-lg font-pacifico tracking-tight">yarnnn</span>
+          <span className="text-lg font-brand tracking-tight">yarnnn</span>
         </div>
 
         {/* Office & Contact */}

--- a/web/components/landing/LandingHeader.tsx
+++ b/web/components/landing/LandingHeader.tsx
@@ -5,7 +5,7 @@ export default function LandingHeader() {
   return (
     <header className="w-full py-4 px-5 flex justify-between items-center bg-white">
       <div className="text-xl">
-        <Link href="/" className="text-black hover:text-black/80 transition-colors font-pacifico">
+        <Link href="/" className="text-black hover:text-black/80 transition-colors font-brand">
           yarnnn
         </Link>
       </div>

--- a/web/components/layouts/SidebarNav.tsx
+++ b/web/components/layouts/SidebarNav.tsx
@@ -68,7 +68,7 @@ export default function SidebarNav({
               href="/"
               className="flex items-center gap-2 ml-2 text-black hover:text-black/80 transition-colors"
             >
-              <span className="font-pacifico text-lg">yarnnn</span>
+              <span className="font-brand text-lg">yarnnn</span>
             </Link>
           )}
         </div>


### PR DESCRIPTION
## Summary
- use `font-brand` utility for consistent Pacifico branding

## Test Plan
- `make format` *(fails: Dependency #2 of field `project.dependencies` cannot be a direct reference)*
- `make lint` *(fails: Dependency #2 of field `project.dependencies` cannot be a direct reference)*
- `make tests` *(fails: Dependency #2 of field `project.dependencies` cannot be a direct reference)*

------
https://chatgpt.com/codex/tasks/task_e_6843c2fffa3c8329bb0555b8ebf7e207