### PR TITLE
Fix brand font inheritance

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -117,7 +117,7 @@
         @apply border-border outline-ring/50;
     }
     body {
-        @apply bg-background text-foreground;
+        @apply bg-background text-foreground font-sans;
     }
 }
 

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -39,7 +39,7 @@ export default function RootLayout({
       lang="en"
       className={`${geistSans.variable} ${geistMono.variable} ${pacifico.variable}`}
     >
-      <body className="antialiased font-sans">
+      <body className="antialiased">
         <SupabaseProvider>{children}</SupabaseProvider>
       </body>
     </html>

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -41,7 +41,7 @@ export default function LandingPage() {
       </section>
 
       {/* Main content - no animated background */}
-      <main className="bg-background text-foreground font-sans flex flex-col">
+      <main className="bg-background text-foreground flex flex-col">
         <div className="max-w-[1200px] mx-auto px-4 w-full">
           {/* Description + Feature Icons */}
           <section id="benefits" className="px-6 py-12 border-b grid grid-cols-1 md:grid-cols-2 gap-10">


### PR DESCRIPTION
## Summary
- apply `font-sans` via Tailwind base layer
- remove `font-sans` utility from layout and landing page

## Testing
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_6843d36fc7b483299ae11680000ce439