### PR TITLE
Add legal links and update footer logo

### DIFF
--- a/web/components/Brand.tsx
+++ b/web/components/Brand.tsx
@@ -1,3 +1,19 @@
-export default function Brand({ className = "" }: { className?: string }) {
-    return <span className={`font-brand ${className}`}>yarnnn</span>;
+import Image from 'next/image';
+
+interface BrandProps {
+  className?: string;
+  width?: number;
+  height?: number;
+}
+
+export default function Brand({ className = '', width = 100, height = 28 }: BrandProps) {
+  return (
+    <Image
+      src="/assets/logos/yarn-logo-light.png"
+      alt="yarnnn logo"
+      width={width}
+      height={height}
+      className={className}
+    />
+  );
 }

--- a/web/components/landing/LandingFooter.tsx
+++ b/web/components/landing/LandingFooter.tsx
@@ -1,4 +1,5 @@
 "use client";
+import Link from "next/link";
 import { ArrowElbowRight } from "phosphor-react";
 import Brand from "@/components/Brand";
 
@@ -7,9 +8,19 @@ export default function LandingFooter() {
         <footer className="bg-white text-black border-t border-neutral-200 py-8 px-4">
             <div className="max-w-[1200px] mx-auto flex flex-col md:flex-row items-center justify-between gap-6">
                 {/* Logo/Icon and Brand */}
-                <div className="flex items-center gap-3">
-                    <ArrowElbowRight size={28} className="text-black" />
-                    <Brand className="text-lg tracking-tight" />
+                <div className="flex flex-col items-start gap-2">
+                    <div className="flex items-center gap-3">
+                        <ArrowElbowRight size={28} className="text-black" />
+                        <Brand className="" width={120} height={32} />
+                    </div>
+                    <div className="flex gap-4 text-sm">
+                        <Link href="/privacy" className="hover:underline">
+                            Privacy
+                        </Link>
+                        <Link href="/terms" className="hover:underline">
+                            Terms
+                        </Link>
+                    </div>
                 </div>
 
                 {/* Office & Contact */}


### PR DESCRIPTION
## Summary
- replace `Brand` text with logo image
- include Privacy and Terms links in landing footer

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*
- `make lint` *(fails: build backend error)*

------
https://chatgpt.com/codex/tasks/task_e_6844eed3f06c8329bd1464c22859cba7