### PR TITLE
Layer1 basket create v1

### DIFF
--- a/api/src/app/agent_tasks/orchestration/orch_block_manager_agent.py
+++ b/api/src/app/agent_tasks/orchestration/orch_block_manager_agent.py
@@ -59,7 +59,7 @@ async def _handle_event(conn: asyncpg.Connection, evt) -> None:
                 conn,
                 action="merge",
                 block_id=dup["block_ids"][0],
-                proposed_data={"block_ids": dup["block_ids"]},
+                proposed_data={"block_ids": dup["block_ids"], "update_policy": "auto"},
                 source_event=topic,
                 reason="duplicate_labels",
             )

--- a/api/src/app/agent_tasks/orchestration/thread_parser_listener.py
+++ b/api/src/app/agent_tasks/orchestration/thread_parser_listener.py
@@ -15,24 +15,56 @@ async def handle_new_basket(basket_id: str, payload: Any) -> None:
     await run_analyzer()
 
     async with asyncpg.connect(DB_URL) as conn:
-        block_id = str(uuid.uuid4())
-        await conn.execute(
-            (
-                "insert into context_blocks(id,user_id,type,label,content,update_policy) "
-                "values($1,'demo-user','note',$2,$3,'auto')"
-            ),
-            block_id,
-            (payload.get("intent_summary") or "note")[:50],
-            payload.get("input_text", ""),
-        )
-        await conn.execute(
-            (
-                "insert into block_brief_link(id,block_id,task_brief_id,transformation) "
-                "values(gen_random_uuid(),$1,$2,'source')"
-            ),
-            block_id,
-            basket_id,
-        )
+        for t, key in [
+            ("topic", "topic"),
+            ("intent", "intent"),
+            ("reference", "file_ids"),
+            ("insight", "insight"),
+        ]:
+            if t == "reference":
+                for f in payload.get("file_ids", []):
+                    bid = str(uuid.uuid4())
+                    await conn.execute(
+                        (
+                            "insert into context_blocks(id,user_id,type,label,content,is_primary,meta_scope,source) "
+                            "values($1,'demo-user',$2,$3,$4,true,'basket','user_upload')"
+                        ),
+                        bid,
+                        t,
+                        f.split("/")[-1][:50],
+                        f,
+                    )
+                    await conn.execute(
+                        (
+                            "insert into block_brief_link(id,block_id,task_brief_id,transformation) "
+                            "values(gen_random_uuid(),$1,$2,'source')"
+                        ),
+                        bid,
+                        basket_id,
+                    )
+            else:
+                value = payload.get(key)
+                if not value:
+                    continue
+                bid = str(uuid.uuid4())
+                await conn.execute(
+                    (
+                        "insert into context_blocks(id,user_id,type,label,content,is_primary,meta_scope) "
+                        "values($1,'demo-user',$2,$3,$4,true,'basket')"
+                    ),
+                    bid,
+                    t,
+                    value[:50],
+                    value,
+                )
+                await conn.execute(
+                    (
+                        "insert into block_brief_link(id,block_id,task_brief_id,transformation) "
+                        "values(gen_random_uuid(),$1,$2,'source')"
+                    ),
+                    bid,
+                    basket_id,
+                )
         await conn.execute("update baskets set status='confirmed' where id=$1", basket_id)
 
     await generate(basket_id, "demo-user")
@@ -43,24 +75,56 @@ async def handle_update_basket(basket_id: str, payload: Any) -> None:
     await run_analyzer()
 
     async with asyncpg.connect(DB_URL) as conn:
-        block_id = str(uuid.uuid4())
-        await conn.execute(
-            (
-                "insert into context_blocks(id,user_id,type,label,content,update_policy) "
-                "values($1,'demo-user','note',$2,$3,'auto')"
-            ),
-            block_id,
-            (payload.get("intent_summary") or "note")[:50],
-            payload.get("input_text", ""),
-        )
-        await conn.execute(
-            (
-                "insert into block_brief_link(id,block_id,task_brief_id,transformation) "
-                "values(gen_random_uuid(),$1,$2,'source')"
-            ),
-            block_id,
-            basket_id,
-        )
+        for t, key in [
+            ("topic", "topic"),
+            ("intent", "intent_summary"),
+            ("reference", "file_ids"),
+            ("insight", "input_text"),
+        ]:
+            if t == "reference":
+                for f in payload.get("file_ids", []):
+                    bid = str(uuid.uuid4())
+                    await conn.execute(
+                        (
+                            "insert into context_blocks(id,user_id,type,label,content,is_primary,meta_scope,source) "
+                            "values($1,'demo-user',$2,$3,$4,true,'basket','user_upload')"
+                        ),
+                        bid,
+                        t,
+                        f.split("/")[-1][:50],
+                        f,
+                    )
+                    await conn.execute(
+                        (
+                            "insert into block_brief_link(id,block_id,task_brief_id,transformation) "
+                            "values(gen_random_uuid(),$1,$2,'source')"
+                        ),
+                        bid,
+                        basket_id,
+                    )
+            else:
+                value = payload.get(key)
+                if not value:
+                    continue
+                bid = str(uuid.uuid4())
+                await conn.execute(
+                    (
+                        "insert into context_blocks(id,user_id,type,label,content,is_primary,meta_scope) "
+                        "values($1,'demo-user',$2,$3,$4,true,'basket')"
+                    ),
+                    bid,
+                    t,
+                    value[:50],
+                    value,
+                )
+                await conn.execute(
+                    (
+                        "insert into block_brief_link(id,block_id,task_brief_id,transformation) "
+                        "values(gen_random_uuid(),$1,$2,'source')"
+                    ),
+                    bid,
+                    basket_id,
+                )
         await conn.execute("update baskets set status='confirmed' where id=$1", basket_id)
 
     await generate(basket_id, "demo-user")

--- a/api/src/app/routes/baskets.py
+++ b/api/src/app/routes/baskets.py
@@ -10,7 +10,9 @@ from ..supabase_helpers import publish_event
 router = APIRouter(prefix="/baskets", tags=["baskets"])
 
 class BasketCreate(BaseModel):
+    topic: str
     intent: str
+    insight: Optional[str] = None
     details: Optional[str] = None
     file_ids: Optional[List[str]] = None
 
@@ -26,7 +28,9 @@ async def create_basket(payload: BasketCreate):
     resp = supabase.table("baskets").insert(
         {
             "id": basket_id,
+            "topic": payload.topic,
             "intent_summary": payload.intent,
+            "insight": payload.insight,
             "details": payload.details,
             "file_ids": payload.file_ids or [],
             "status": "draft",
@@ -42,7 +46,9 @@ async def create_basket(payload: BasketCreate):
         "basket.compose_request",
         {
             "basket_id": basket_id,
+            "topic": payload.topic,
             "intent": payload.intent,
+            "insight": payload.insight,
             "details": payload.details,
             "file_ids": payload.file_ids or [],
         },

--- a/tests/baskets/create.test.ts
+++ b/tests/baskets/create.test.ts
@@ -1,0 +1,17 @@
+import { buildContextBlocks } from '../../web/lib/baskets/submit';
+
+describe('basket block builder', () => {
+  it('requires topic, intent and reference', () => {
+    expect(() => buildContextBlocks({topic:'',intent:'',references:[]})).toThrow();
+  });
+
+  it('creates four blocks when all fields provided', () => {
+    const blocks = buildContextBlocks({
+      topic: 't',
+      intent: 'i',
+      insight: 'n',
+      references: ['file1']
+    });
+    expect(blocks.length).toBe(3 + 1); // topic, intent, reference, insight
+  });
+});

--- a/web/app/basket/create/page.tsx
+++ b/web/app/basket/create/page.tsx
@@ -1,10 +1,10 @@
 "use client";
-import BasketInputPanel from "@/components/BasketInputPanel";
+import BasketCreateForm from "@/components/baskets/BasketCreateForm";
 
 export default function BasketNewPage() {
   return (
     <div className="max-w-xl mx-auto p-6">
-      <BasketInputPanel mode="create" />
+      <BasketCreateForm onSubmit={(blocks) => console.log(blocks)} />
     </div>
   );
 }

--- a/web/components/baskets/BasketCreateForm.tsx
+++ b/web/components/baskets/BasketCreateForm.tsx
@@ -1,0 +1,81 @@
+"use client";
+import { useState } from "react";
+import { UploadArea } from "@/components/ui/UploadArea";
+import { buildContextBlocks } from "@/lib/baskets/submit";
+
+interface Props {
+  onSubmit?: (blocks: any[]) => void;
+}
+
+export default function BasketCreateForm({ onSubmit }: Props) {
+  const [topic, setTopic] = useState("");
+  const [intent, setIntent] = useState("");
+  const [insight, setInsight] = useState("");
+  const [refs, setRefs] = useState<string[]>([]);
+  const addRef = (url: string) => setRefs((r) => (r.length < 3 ? [...r, url] : r));
+  const removeRef = (url: string) => setRefs((r) => r.filter((u) => u !== url));
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const blocks = buildContextBlocks({ topic, intent, insight, references: refs });
+    onSubmit?.(blocks);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div className="space-y-1">
+        <label className="block text-sm font-medium">What are we working on?</label>
+        <input
+          className="w-full border p-2 rounded"
+          value={topic}
+          onChange={(e) => setTopic(e.target.value)}
+          required
+        />
+      </div>
+      <div className="space-y-1">
+        <label className="block text-sm font-medium">What’s the objective?</label>
+        <input
+          className="w-full border p-2 rounded"
+          value={intent}
+          onChange={(e) => setIntent(e.target.value)}
+          required
+        />
+      </div>
+      <div className="space-y-1">
+        <label className="block text-sm font-medium">Extra insight (optional)</label>
+        <textarea
+          className="w-full border p-2 rounded"
+          value={insight}
+          onChange={(e) => setInsight(e.target.value)}
+          rows={3}
+        />
+      </div>
+      <div className="space-y-1">
+        <label className="block text-sm font-medium">Reference files</label>
+        <UploadArea
+          prefix="basket"
+          bucket="block-files"
+          maxFiles={3}
+          onUpload={addRef}
+          preview
+          removable
+          enableDrop
+          showPreviewGrid
+        />
+        {refs.length > 0 && (
+          <ul className="text-sm space-y-1">
+            {refs.map((u) => (
+              <li key={u} className="flex justify-between">
+                <span className="truncate mr-2">{u}</span>
+                <button type="button" onClick={() => removeRef(u)} className="text-red-600">remove</button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+      <button type="submit" className="bg-blue-600 text-white px-4 py-2 rounded">
+        Create Basket
+      </button>
+    </form>
+  );
+}

--- a/web/lib/baskets/submit.ts
+++ b/web/lib/baskets/submit.ts
@@ -1,0 +1,66 @@
+// web/lib/baskets/submit.ts
+
+export interface BasketValues {
+  topic: string;
+  intent: string;
+  insight?: string;
+  references: string[];
+}
+
+export interface ContextBlock {
+  id?: string;
+  type: "topic" | "intent" | "reference" | "insight";
+  label: string;
+  content: string;
+  is_primary: boolean;
+  meta_scope: "basket";
+  source?: string;
+  associated_block_id?: string;
+}
+
+export function buildContextBlocks(values: BasketValues): ContextBlock[] {
+  if (!values.topic.trim()) throw new Error("Topic required");
+  if (!values.intent.trim()) throw new Error("Intent required");
+  if (values.references.length === 0) throw new Error("At least one reference required");
+
+  const blocks: ContextBlock[] = [];
+
+  blocks.push({
+    type: "topic",
+    label: values.topic.slice(0, 50),
+    content: values.topic,
+    is_primary: true,
+    meta_scope: "basket",
+  });
+
+  blocks.push({
+    type: "intent",
+    label: values.intent.slice(0, 50),
+    content: values.intent,
+    is_primary: true,
+    meta_scope: "basket",
+  });
+
+  values.references.forEach((url) => {
+    blocks.push({
+      type: "reference",
+      label: url.split("/").pop() || "file",
+      content: url,
+      is_primary: true,
+      meta_scope: "basket",
+      source: "user_upload",
+    });
+  });
+
+  if (values.insight && values.insight.trim()) {
+    blocks.push({
+      type: "insight",
+      label: values.insight.slice(0, 50),
+      content: values.insight,
+      is_primary: true,
+      meta_scope: "basket",
+    });
+  }
+
+  return blocks;
+}


### PR DESCRIPTION
## Summary
- implement basic basket creation form with topic, intent, optional insight and references
- generate context block payloads via helper
- extend API to accept topic/insight and emit them in events
- parse basket events into context blocks
- queue updates for duplicate blocks
- add unit tests for context block builder

## Testing
- `npx jest tests/baskets/create.test.ts` *(fails: could not find config file)*
- `PYTHONPATH=api/src pytest -q` *(fails: OSError: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6844fd09656c8329a19dd8d0c51b85a3