### PR TITLE
Refactor basket form UI

### DIFF
--- a/web/components/baskets/BasketCreateForm.tsx
+++ b/web/components/baskets/BasketCreateForm.tsx
@@ -1,5 +1,9 @@
 "use client";
 import { useState } from "react";
+import { Card, CardContent } from "@/components/ui/Card";
+import { Input } from "@/components/ui/Input";
+import { Textarea } from "@/components/ui/Textarea";
+import { Button } from "@/components/ui/Button";
 import { UploadArea } from "@/components/ui/UploadArea";
 import { buildContextBlocks } from "@/lib/baskets/submit";
 
@@ -8,8 +12,8 @@ interface Props {
 }
 
 export default function BasketCreateForm({ onSubmit }: Props) {
-  const [topic, setTopic] = useState("");
   const [intent, setIntent] = useState("");
+  const [objective, setObjective] = useState("");
   const [insight, setInsight] = useState("");
   const [refs, setRefs] = useState<string[]>([]);
   const addRef = (url: string) => setRefs((r) => (r.length < 3 ? [...r, url] : r));
@@ -17,65 +21,86 @@ export default function BasketCreateForm({ onSubmit }: Props) {
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    const blocks = buildContextBlocks({ topic, intent, insight, references: refs });
+    const blocks = buildContextBlocks({
+      topic: intent,
+      intent: objective,
+      insight,
+      references: refs,
+    });
     onSubmit?.(blocks);
   };
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-4">
-      <div className="space-y-1">
-        <label className="block text-sm font-medium">What are we working on?</label>
-        <input
-          className="w-full border p-2 rounded"
-          value={topic}
-          onChange={(e) => setTopic(e.target.value)}
-          required
-        />
-      </div>
-      <div className="space-y-1">
-        <label className="block text-sm font-medium">What’s the objective?</label>
-        <input
-          className="w-full border p-2 rounded"
-          value={intent}
-          onChange={(e) => setIntent(e.target.value)}
-          required
-        />
-      </div>
-      <div className="space-y-1">
-        <label className="block text-sm font-medium">Extra insight (optional)</label>
-        <textarea
-          className="w-full border p-2 rounded"
-          value={insight}
-          onChange={(e) => setInsight(e.target.value)}
-          rows={3}
-        />
-      </div>
-      <div className="space-y-1">
-        <label className="block text-sm font-medium">Reference files</label>
-        <UploadArea
-          prefix="basket"
-          bucket="block-files"
-          maxFiles={3}
-          onUpload={addRef}
-          preview
-          removable
-          enableDrop
-          showPreviewGrid
-        />
-        {refs.length > 0 && (
-          <ul className="text-sm space-y-1">
-            {refs.map((u) => (
-              <li key={u} className="flex justify-between">
-                <span className="truncate mr-2">{u}</span>
-                <button type="button" onClick={() => removeRef(u)} className="text-red-600">remove</button>
-              </li>
-            ))}
-          </ul>
-        )}
-      </div>
-      <button type="submit" className="bg-blue-600 text-white px-4 py-2 rounded">
-        Create Basket
-      </button>
-    </form>
+    <Card className="mt-8 mx-auto max-w-2xl">
+      <CardContent className="p-6">
+        <form onSubmit={handleSubmit} className="space-y-6">
+          <div className="space-y-2">
+            <h2 className="text-2xl font-semibold">What are we working on?</h2>
+            <p className="text-sm text-muted-foreground">
+              Start with a short, descriptive task or request.
+            </p>
+          </div>
+          <div className="space-y-2">
+            <label className="text-sm font-medium">Intent</label>
+            <Input
+              placeholder="e.g. Launch a new product on Instagram"
+              value={intent}
+              onChange={(e) => setIntent(e.target.value)}
+              required
+            />
+          </div>
+          <div className="space-y-2">
+            <label className="text-sm font-medium">What’s the objective?</label>
+            <Input
+              placeholder="e.g. Drive signups to waitlist"
+              value={objective}
+              onChange={(e) => setObjective(e.target.value)}
+              required
+            />
+          </div>
+          <div className="space-y-2">
+            <label className="text-sm font-medium">Reference files</label>
+            <UploadArea
+              prefix="basket"
+              bucket="block-files"
+              maxFiles={3}
+              onUpload={addRef}
+              preview
+              removable
+              enableDrop
+              showPreviewGrid
+            />
+            {refs.length > 0 && (
+              <ul className="text-sm space-y-1">
+                {refs.map((u) => (
+                  <li key={u} className="flex justify-between">
+                    <span className="truncate mr-2">{u}</span>
+                    <button
+                      type="button"
+                      onClick={() => removeRef(u)}
+                      className="text-red-600"
+                    >
+                      remove
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+          <div className="space-y-2">
+            <label className="text-sm font-medium">Extra insight (optional)</label>
+            <Textarea
+              placeholder="Any background context or ideas we should know?"
+              value={insight}
+              onChange={(e) => setInsight(e.target.value)}
+              rows={3}
+            />
+          </div>
+          <Button type="submit" className="w-full">
+            Create Basket
+          </Button>
+        </form>
+      </CardContent>
+    </Card>
   );
 }

--- a/web/components/ui/Textarea.tsx
+++ b/web/components/ui/Textarea.tsx
@@ -1,0 +1,24 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export interface TextareaProps
+  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+
+export const Textarea = React.forwardRef<
+  HTMLTextAreaElement,
+  TextareaProps
+>(({ className, ...props }, ref) => {
+  return (
+    <textarea
+      className={cn(
+        "w-full p-3 rounded-lg border border-input bg-input text-base text-foreground shadow-sm placeholder:text-muted-foreground",
+        "focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50",
+        className
+      )}
+      ref={ref}
+      {...props}
+    />
+  );
+});
+
+Textarea.displayName = "Textarea";


### PR DESCRIPTION
## Summary
- update BasketCreateForm layout to use Card and shadcn form controls
- add reusable Textarea component

## Testing
- `npm run lint` *(fails: next not found)*
- `make tests` *(fails: build backend error)*

------
https://chatgpt.com/codex/tasks/task_e_68450ba3e974832983cfc141d4f4c261