### PR TITLE
Refactor upload bucket logic

### DIFF
--- a/api/src/app/agent_tasks/orchestration/thread_parser_listener.py
+++ b/api/src/app/agent_tasks/orchestration/thread_parser_listener.py
@@ -36,6 +36,15 @@ async def handle_new_basket(basket_id: str, payload: Any) -> None:
                     )
                     await conn.execute(
                         (
+                            "insert into block_files(id,user_id,file_url,label,associated_block_id,is_primary,storage_domain) "
+                            "values(gen_random_uuid(),'demo-user',$1,$2,$3,true,'block-files')"
+                        ),
+                        f,
+                        f.split("/")[-1][:50],
+                        bid,
+                    )
+                    await conn.execute(
+                        (
                             "insert into block_brief_link(id,block_id,task_brief_id,transformation) "
                             "values(gen_random_uuid(),$1,$2,'source')"
                         ),
@@ -93,6 +102,15 @@ async def handle_update_basket(basket_id: str, payload: Any) -> None:
                         t,
                         f.split("/")[-1][:50],
                         f,
+                    )
+                    await conn.execute(
+                        (
+                            "insert into block_files(id,user_id,file_url,label,associated_block_id,is_primary,storage_domain) "
+                            "values(gen_random_uuid(),'demo-user',$1,$2,$3,true,'block-files')"
+                        ),
+                        f,
+                        f.split("/")[-1][:50],
+                        bid,
                     )
                     await conn.execute(
                         (

--- a/docs/STORAGE.md
+++ b/docs/STORAGE.md
@@ -1,0 +1,11 @@
+## 📦 Supabase Buckets (Context OS)
+
+| Bucket        | Purpose | storage_domain |
+|---------------|---------|----------------|
+| `block-files` | Structured files that form context blocks at basket creation | block-files |
+| `basket-dumps` | Unstructured user dumps for agent parsing post-creation | basket-dumps |
+| `user-library` | Persistent reusable uploads (e.g., logos, brand kits) | user-library |
+
+All files are tracked in `block_files`, and uploads during `/basket/create` must be tagged with `storage_domain = block-files`.
+
+Buckets are public to enable frontend previewing of images or text assets.

--- a/supabase/migrations/20250612_block_files_storage_domain.sql
+++ b/supabase/migrations/20250612_block_files_storage_domain.sql
@@ -1,0 +1,3 @@
+-- Ensure storage_domain enum and defaults
+create type if not exists storage_domain as enum ('block-files','user-library','basket-dumps');
+alter table block_files alter column storage_domain set default 'block-files';

--- a/web/lib/uploadFile.ts
+++ b/web/lib/uploadFile.ts
@@ -13,9 +13,10 @@ import { createClient } from "@/lib/supabaseClient";
 export async function uploadFile(
   file: File,
   path: string,
-  bucket: string = "task-briefs"
+  bucket: string = "block-files"
 ): Promise<string> {
   const supabase = createClient();
+  const storageDomain = "block-files";
 
   // Validate file type and size
   const maxSizeMB = 5;
@@ -35,7 +36,9 @@ export async function uploadFile(
     console.error(`[uploadFile] upload error in bucket "${bucket}":`, error);
     const statusCode = (error as any)?.status;
     if (statusCode === 404) {
-      throw new Error(`Storage bucket "${bucket}" not found.`);
+      throw new Error(
+        "Upload failed — check that 'block-files' bucket exists and is public"
+      );
     }
     throw new Error(`File upload failed: ${(error as any)?.message || "Unknown error"}`);
   }


### PR DESCRIPTION
## Summary
- update uploadFile to use block-files bucket
- insert block_files rows during basket parsing
- document bucket organization
- add migration for block_files storage_domain default

## Testing
- `npm test` *(fails: jest not found)*
- `pytest -q` *(fails: ModuleNotFoundError: psycopg2)*


------
https://chatgpt.com/codex/tasks/task_e_684514fb7ce08329941e2db88ac42c50