### PR TITLE
Update domain references to yarnnn.com

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,3 @@
+NEXT_PUBLIC_SITE_URL=https://yarnnn.com
+NEXTAUTH_URL=https://yarnnn.com
+SUPABASE_REDIRECT_URL=https://yarnnn.com

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ npm run dev
 
 Make sure your `/web/.env.local` is set:
 ```
-NEXT_PUBLIC_API_URL=https://rightnow-agent-app-fullstack.onrender.com
+NEXT_PUBLIC_API_URL=https://yarnnn.com
 ```
 
 ### 🧪 To Run Backend (only if modifying Python code)
@@ -66,7 +66,7 @@ This app uses a hosted architecture for backend and database, simplifying local 
 | Component     | Run Locally? | Hosted?                              |
 |---------------|--------------|---------------------------------------|
 | Frontend (Next.js) | ✅ Yes       | Vercel                              |
-| Backend (FastAPI)  | ❌ Default  | [Render](https://rightnow-agent-app-fullstack.onrender.com) |
+| Backend (FastAPI)  | ❌ Default  | [Render](https://yarnnn.com) |
 | Database (Supabase) | ❌         | Supabase                            |
 
 ---

--- a/codex/tasks/legacy_tasks_202505/auth_env_redirectlogic.md
+++ b/codex/tasks/legacy_tasks_202505/auth_env_redirectlogic.md
@@ -25,7 +25,7 @@ After session is restored, use router.push('/profile') (or desired route) to nav
 For local dev:
 Confirm that .env.local has NEXT_PUBLIC_SITE_URL=http://localhost:3000
 For production:
-Confirm that Vercel envs have NEXT_PUBLIC_SITE_URL=https://rgtnow.com
+Confirm that Vercel envs have NEXT_PUBLIC_SITE_URL=https://yarnnn.com
 Example Implementation:
 (Update as needed to match your app structure and hooks)
 // app/auth/callback/page.tsx

--- a/codex/tasks/legacy_tasks_202505/debug_agentrouting.md
+++ b/codex/tasks/legacy_tasks_202505/debug_agentrouting.md
@@ -1,6 +1,6 @@
 ## codex/tasks/debug_agentrouting.md
 
-❌ 404 Error: POST https://rightnow-agent-app-fullstack.onrender.com/agent
+❌ 404 Error: POST https://yarnnn.com/agent
 
 🔎 Cause:
 Render shows the service is running, but the /agent route is returning 404.
@@ -45,10 +45,10 @@ Make sure:
 agent_router is correctly defined and used
 There's a @agent_router.post("") → not @agent_router.post("/agent") (you only want the base /agent once)
 ✅ Step 4: Try hitting this POST again:
-POST https://rightnow-agent-app-fullstack.onrender.com/agent
+POST https://yarnnn.com/agent
 If still 404, test with a different route like:
 
-GET https://rightnow-agent-app-fullstack.onrender.com/docs
+GET https://yarnnn.com/docs
 That should show your OpenAPI docs and confirm what routes are available.
 
 🔧 If Still Broken

--- a/codex/tasks/legacy_tasks_202505/design_landingabout_update.md
+++ b/codex/tasks/legacy_tasks_202505/design_landingabout_update.md
@@ -68,7 +68,7 @@ the same for the footer design code below, apply ONLY for the index and about pa
                 <div class="self-stretch flex flex-col justify-start items-start gap-7">
                     <div class="self-stretch justify-start text-black text-xl font-normal font-['Instrument_Sans'] leading-tight">CONTACT</div>
                     <div class="self-stretch flex flex-col justify-start items-start gap-2.5">
-                        <div class="self-stretch justify-start text-black text-xl font-normal font-['Instrument_Sans'] leading-tight">contactus@rgtnow.com</div>
+                        <div class="self-stretch justify-start text-black text-xl font-normal font-['Instrument_Sans'] leading-tight">contactus@yarnnn.com</div>
                     </div>
                 </div>
             </div>

--- a/codex/tasks/legacy_tasks_202505/fe_refactor_homepage_hero_and_layout.md
+++ b/codex/tasks/legacy_tasks_202505/fe_refactor_homepage_hero_and_layout.md
@@ -84,7 +84,7 @@ Company logo
 Center:
 
 CONTACT  
-contactus@rgtnow.com
+contactus@yarnnn.com
 Right:
 links for privacy policy and services page
 🔧 Requirements

--- a/codex/tasks/legacy_tasks_202505/igrate_landing_page_and_how_it_works.md
+++ b/codex/tasks/legacy_tasks_202505/igrate_landing_page_and_how_it_works.md
@@ -48,8 +48,8 @@ Create a new landing page at: /web/app/index/page.tsx
 #### 3. Footer
 - “powered using OpenAI” text
 - Two text links:
-  - https://www.rgtnow.com/privacy
-  - https://www.rgtnow.com/services
+  - https://yarnnn.com/privacy
+  - https://yarnnn.com/services
 
 ### Styling Notes
 - Use Tailwind utility classes.

--- a/codex/tasks/legacy_tasks_202505/landingpage_refactor_w_figma.md
+++ b/codex/tasks/legacy_tasks_202505/landingpage_refactor_w_figma.md
@@ -76,7 +76,7 @@ export default function LandingPage() {
           <p className="font-medium">OFFICE</p>
           <p>Seoul, South Korea</p>
           <p className="font-medium pt-4">CONTACT</p>
-          <p>contactus@rgtnow.com</p>
+          <p>contactus@yarnnn.com</p>
         </div>
         <div className="space-y-2">
           <p className="font-medium">SOCIAL</p>

--- a/codex/tasks/legacy_tasks_202505/update_privacy_and_terms_pages.md
+++ b/codex/tasks/legacy_tasks_202505/update_privacy_and_terms_pages.md
@@ -30,7 +30,7 @@ Create two new pages:
 
 ### Content:
 Replace any occurrence of "HelpMeAI" with "rightNOW"
-Replace contact email with: contactus@rgtnow.com
+Replace contact email with: contactus@yarnnn.com
 Keep links to Google OAuth permission page intact
 
 ### Optional UI:
@@ -65,7 +65,7 @@ Revoking disables Gmail-related features in rightNOW.
 We use OAuth2 and do not store credentials or Gmail data. All communication with Google APIs is encrypted.
 
 **5. Contact Us**
-📧 contactus@rgtnow.com
+📧 contactus@yarnnn.com
 
 ---
 
@@ -105,7 +105,7 @@ We may suspend or terminate access for violating these terms.
 rightNOW is provided "as is" with no warranties. We do our best to ensure reliability but offer no uptime guarantees.
 
 **7. Contact**
-📧 contactus@rgtnow.com
+📧 contactus@yarnnn.com
 ```
 
 ---

--- a/web/README.md
+++ b/web/README.md
@@ -72,6 +72,6 @@ NEXT_PUBLIC_SUPABASE_URL=https://xyzcompany.supabase.co
 SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
 ```
 On your production host (e.g., Vercel), set the same variables in the project settings:
-  • `BACKEND_URL` → your Render backend URL (e.g. `https://rightnow-agent-app-fullstack.onrender.com`)
+  • `BACKEND_URL` → your Render backend URL (e.g. `https://yarnnn.com`)
   • `NEXT_PUBLIC_SUPABASE_URL` → your Supabase project URL
   • `SUPABASE_SERVICE_ROLE_KEY` → your Supabase service role secret

--- a/web/app/privacy/page.tsx
+++ b/web/app/privacy/page.tsx
@@ -63,8 +63,8 @@ export default function Page() {
                 <h2>5. Contact Us</h2>
                 <p>
                     📧{" "}
-                    <a href="mailto:contactus@rgtnow.com">
-                        contactus@rgtnow.com
+                    <a href="mailto:contactus@yarnnn.com">
+                        contactus@yarnnn.com
                     </a>
                 </p>
             </div>

--- a/web/app/terms/page.tsx
+++ b/web/app/terms/page.tsx
@@ -77,8 +77,8 @@ export default function Page() {
                 <h2>7. Contact</h2>
                 <p>
                     📧{" "}
-                    <a href="mailto:contactus@rgtnow.com">
-                        contactus@rgtnow.com
+                    <a href="mailto:contactus@yarnnn.com">
+                        contactus@yarnnn.com
                     </a>
                 </p>
             </div>

--- a/web/components/landing/LandingFooter.tsx
+++ b/web/components/landing/LandingFooter.tsx
@@ -33,7 +33,7 @@ export default function LandingFooter() {
                     <div>
                         <div className="font-medium mb-1">Contact</div>
                         <div className="text-neutral-700">
-                            contactus@rgtnow.com
+                            contactus@yarnnn.com
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- update all references to the old domain to use `https://yarnnn.com`
- adjust contact emails and docs
- provide `.env.sample` with environment defaults

## Testing
- `npm test`
- `pytest tests/unit/test_config_agent.py -q` *(fails: ModuleNotFoundError: asyncpg)*

------
https://chatgpt.com/codex/tasks/task_e_684623e9956083298f368f76dc3c07c0