### PR TITLE
Refactor basket create form design & validation

### DIFF
--- a/tests/baskets/create.test.ts
+++ b/tests/baskets/create.test.ts
@@ -1,8 +1,10 @@
 import { buildContextBlocks } from '../../web/lib/baskets/submit';
 
 describe('basket block builder', () => {
-  it('requires topic, intent and reference', () => {
+  it('requires topic and intent', () => {
     expect(() => buildContextBlocks({topic:'',intent:'',references:[]})).toThrow();
+    expect(() => buildContextBlocks({topic:'t',intent:'',references:[]})).toThrow();
+    expect(() => buildContextBlocks({topic:'t',intent:'i',references:[]})).not.toThrow();
   });
 
   it('creates four blocks when all fields provided', () => {

--- a/web/app/basket/create/page.tsx
+++ b/web/app/basket/create/page.tsx
@@ -3,7 +3,7 @@ import BasketCreateForm from "@/components/baskets/BasketCreateForm";
 
 export default function BasketNewPage() {
   return (
-    <div className="max-w-xl mx-auto p-6">
+    <div className="max-w-2xl mx-auto p-6">
       <BasketCreateForm />
     </div>
   );

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono, Pacifico } from "next/font/google";
 import "./globals.css";
 import SupabaseProvider from "@/components/SupabaseProvider";
+import { Toaster } from "react-hot-toast";
 
 // Font setup
 const geistSans = Geist({
@@ -41,6 +42,7 @@ export default function RootLayout({
         >
             <body className="antialiased min-h-screen">
                 <SupabaseProvider>{children}</SupabaseProvider>
+                <Toaster position="top-right" />
             </body>
         </html>
     );

--- a/web/components/baskets/BasketCreateForm.tsx
+++ b/web/components/baskets/BasketCreateForm.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/Button";
 import { UploadArea } from "@/components/ui/UploadArea";
 import { createBasket } from "@/lib/baskets/submit";
 import { useRouter } from "next/navigation";
+import { toast } from "react-hot-toast";
 
 interface Props {
   onSuccess?: (id: string) => void;
@@ -21,13 +22,11 @@ export default function BasketCreateForm({ onSuccess }: Props) {
   const removeRef = (url: string) => setRefs((r) => r.filter((u) => u !== url));
 
   const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
   const router = useRouter();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setLoading(true);
-    setError(null);
     try {
       const { id } = await createBasket({
         topic: intent,
@@ -39,7 +38,7 @@ export default function BasketCreateForm({ onSuccess }: Props) {
       router.push(`/baskets/${id}/work`);
     } catch (err) {
       console.error(err);
-      setError("Failed to create basket");
+      toast.error("Basket creation failed. Please check required fields.");
     } finally {
       setLoading(false);
     }
@@ -50,7 +49,7 @@ export default function BasketCreateForm({ onSuccess }: Props) {
       <CardContent className="p-6">
         <form onSubmit={handleSubmit} className="space-y-6">
           <div className="space-y-2">
-            <h2 className="text-2xl font-semibold">What are we working on?</h2>
+            <h2 className="text-xl font-semibold">What are we working on?</h2>
             <p className="text-sm text-muted-foreground">
               Start with a short, descriptive task or request.
             </p>
@@ -111,9 +110,6 @@ export default function BasketCreateForm({ onSuccess }: Props) {
               rows={3}
             />
           </div>
-          {error && (
-            <p className="text-sm text-red-600">{error}</p>
-          )}
           <Button type="submit" className="w-full" disabled={loading}>
             {loading ? "Creating…" : "Create Basket"}
           </Button>

--- a/web/lib/baskets/submit.ts
+++ b/web/lib/baskets/submit.ts
@@ -4,7 +4,7 @@ export interface BasketValues {
   topic: string;
   intent: string;
   insight?: string;
-  references: string[];
+  references?: string[];
 }
 
 export interface ContextBlock {
@@ -21,7 +21,6 @@ export interface ContextBlock {
 export function buildContextBlocks(values: BasketValues): ContextBlock[] {
   if (!values.topic.trim()) throw new Error("Topic required");
   if (!values.intent.trim()) throw new Error("Intent required");
-  if (values.references.length === 0) throw new Error("At least one reference required");
 
   const blocks: ContextBlock[] = [];
 
@@ -41,7 +40,7 @@ export function buildContextBlocks(values: BasketValues): ContextBlock[] {
     meta_scope: "basket",
   });
 
-  values.references.forEach((url) => {
+  (values.references || []).forEach((url) => {
     blocks.push({
       type: "reference",
       label: url.split("/").pop() || "file",

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -23,6 +23,7 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-hook-form": "^7.56.3",
+        "react-hot-toast": "^2.4.1",
         "react-markdown": "^8.0.7",
         "swr": "^2.2.0",
         "tailwind-merge": "^3.3.0",
@@ -1691,6 +1692,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/goober": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.16.tgz",
+      "integrity": "sha512-erjk19y1U33+XAMe1VTvIONHYoSqE4iS7BYUZfHaqeohLmnC0FdxEh7rQU+6MZ4OajItzjZFSRtVANrQwNq6/g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "csstype": "^3.0.10"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -2797,6 +2807,22 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/react-hot-toast": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.4.1.tgz",
+      "integrity": "sha512-j8z+cQbWIM5LY37pR6uZR6D4LfseplqnuAO4co4u8917hBUvXlEqyP1ZzqVLcqoyUesZZv/ImreoCeHVDpE5pQ==",
+      "license": "MIT",
+      "dependencies": {
+        "goober": "^2.1.10"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
       }
     },
     "node_modules/react-is": {

--- a/web/package.json
+++ b/web/package.json
@@ -24,6 +24,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.56.3",
+    "react-hot-toast": "^2.4.1",
     "react-markdown": "^8.0.7",
     "swr": "^2.2.0",
     "tailwind-merge": "^3.3.0",


### PR DESCRIPTION
## Summary
- adjust BasketCreateForm layout and show toast errors on failure
- make reference files optional when creating a basket
- mount Toaster provider at the app root
- tweak basket create page container
- update basket block builder tests

## Testing
- `npm test --silent`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psycopg2')*

------
https://chatgpt.com/codex/tasks/task_e_68462629243883298690c11efa282c36