### PR TITLE
Refactor basket create form design and validation

### DIFF
--- a/web/app/basket/create/page.tsx
+++ b/web/app/basket/create/page.tsx
@@ -3,7 +3,8 @@ import BasketCreateForm from "@/components/baskets/BasketCreateForm";
 
 export default function BasketNewPage() {
   return (
-    <div className="max-w-2xl mx-auto p-6">
+    <div className="px-6 py-10 max-w-2xl mx-auto">
+      <h1 className="text-2xl font-semibold mb-6">What are we working on?</h1>
       <BasketCreateForm />
     </div>
   );

--- a/web/components/BasketInputPanel/index.tsx
+++ b/web/components/BasketInputPanel/index.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/Button";
 import { Card } from "@/components/ui/Card";
 import { Input } from "@/components/ui/Input";
 import React, { useState } from "react";
+import { toast } from "react-hot-toast";
 import type { BasketInputPayload } from "./types";
 
 interface BasketInputPanelProps {
@@ -19,16 +20,14 @@ export default function BasketInputPanel({ mode = "create", basketId, initial }:
   const { inputText, setInputText, intent, setIntent } = useBasketInput(initial);
   const router = useRouter();
   const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
 
   async function handleCreate(e: React.FormEvent) {
     e.preventDefault();
     if (!intent.trim()) {
-      setError("Intent is required");
+      toast.error("Intent is required");
       return;
     }
     setLoading(true);
-    setError(null);
     const res = await fetch("/api/baskets", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -39,14 +38,14 @@ export default function BasketInputPanel({ mode = "create", basketId, initial }:
       const { id } = await res.json();
       router.push(`/baskets/${id}/work`);
     } else {
-      setError("Failed to create basket");
+      toast.error("Basket creation failed. Please check your inputs.");
     }
   }
 
   async function handleUpdate() {
     if (!basketId) return;
     if (!intent.trim()) {
-      setError("Intent is required");
+      toast.error("Intent is required");
       return;
     }
     await fetch(`/api/baskets/${basketId}/work`, {
@@ -89,7 +88,6 @@ export default function BasketInputPanel({ mode = "create", basketId, initial }:
           <UploadButton onUpload={() => {}} />
         </div>
         <PreviewDrawer />
-        {error && <p className="text-sm text-red-600">{error}</p>}
         <div className="pt-2">
           {mode === "create" ? (
             <Button type="submit" disabled={loading}>

--- a/web/components/baskets/BasketCreateForm.tsx
+++ b/web/components/baskets/BasketCreateForm.tsx
@@ -45,15 +45,9 @@ export default function BasketCreateForm({ onSuccess }: Props) {
   };
 
   return (
-    <Card className="mt-8 mx-auto max-w-2xl">
+    <Card className="w-full">
       <CardContent className="p-6">
         <form onSubmit={handleSubmit} className="space-y-6">
-          <div className="space-y-2">
-            <h2 className="text-xl font-semibold">What are we working on?</h2>
-            <p className="text-sm text-muted-foreground">
-              Start with a short, descriptive task or request.
-            </p>
-          </div>
           <div className="space-y-2">
             <label className="text-sm font-medium">Intent</label>
             <Input


### PR DESCRIPTION
## Summary
- clean up BasketCreateForm layout
- wrap `/basket/create` page in centered container with heading
- use toast errors in BasketInputPanel

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68462e2e4c148329bcd8ee335c66f9d7