### PR TITLE
Add Google account chooser

### DIFF
--- a/web/app/login/page.tsx
+++ b/web/app/login/page.tsx
@@ -26,7 +26,10 @@ export default function LoginPage() {
         const redirectTo = `${process.env.NEXT_PUBLIC_SITE_URL}/auth/callback`;
         const { error } = await supabase.auth.signInWithOAuth({
             provider: "google",
-            options: { redirectTo },
+            options: {
+                redirectTo,
+                queryParams: { prompt: "select_account" },
+            },
         });
         if (error) {
             console.error("Error logging in with Google:", error.message);


### PR DESCRIPTION
## Summary
- show account chooser when logging in with Google

## Testing
- `npm test`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68463005e3f48329859f43dda5557d2e