### PR TITLE
Refactor basket creation to emit context blocks

### DIFF
--- a/tests/baskets/create.test.ts
+++ b/tests/baskets/create.test.ts
@@ -2,9 +2,9 @@ import { buildContextBlocks } from '../../web/lib/baskets/submit';
 
 describe('basket block builder', () => {
   it('requires topic and intent', () => {
-    expect(() => buildContextBlocks({topic:'',intent:'',references:[]})).toThrow();
-    expect(() => buildContextBlocks({topic:'t',intent:'',references:[]})).toThrow();
-    expect(() => buildContextBlocks({topic:'t',intent:'i',references:[]})).not.toThrow();
+    expect(() => buildContextBlocks({topic:'',intent:'',reference_file_ids:[]})).toThrow();
+    expect(() => buildContextBlocks({topic:'t',intent:'',reference_file_ids:[]})).toThrow();
+    expect(() => buildContextBlocks({topic:'t',intent:'i',reference_file_ids:[]})).not.toThrow();
   });
 
   it('creates four blocks when all fields provided', () => {
@@ -12,7 +12,7 @@ describe('basket block builder', () => {
       topic: 't',
       intent: 'i',
       insight: 'n',
-      references: ['file1']
+      reference_file_ids: ['file1']
     });
     expect(blocks.length).toBe(3 + 1); // topic, intent, reference, insight
   });

--- a/web/components/baskets/BasketCreateForm.tsx
+++ b/web/components/baskets/BasketCreateForm.tsx
@@ -14,8 +14,8 @@ interface Props {
 }
 
 export default function BasketCreateForm({ onSuccess }: Props) {
+  const [topic, setTopic] = useState("");
   const [intent, setIntent] = useState("");
-  const [objective, setObjective] = useState("");
   const [insight, setInsight] = useState("");
   const [refs, setRefs] = useState<string[]>([]);
   const addRef = (url: string) => setRefs((r) => (r.length < 3 ? [...r, url] : r));
@@ -26,13 +26,19 @@ export default function BasketCreateForm({ onSuccess }: Props) {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (!topic.trim() || !intent.trim() || refs.length === 0) {
+      toast.error(
+        "Please complete all required fields: topic, intent, and at least one reference file."
+      );
+      return;
+    }
     setLoading(true);
     try {
       const { id } = await createBasket({
-        topic: intent,
-        intent: objective,
+        topic,
+        intent,
         insight,
-        references: refs,
+        reference_file_ids: refs,
       });
       onSuccess?.(id);
       router.push(`/baskets/${id}/work`);
@@ -45,24 +51,26 @@ export default function BasketCreateForm({ onSuccess }: Props) {
   };
 
   return (
-    <Card className="w-full">
-      <CardContent className="p-6">
-        <form onSubmit={handleSubmit} className="space-y-6">
+    <div className="px-6 py-10 max-w-2xl mx-auto">
+      <h1 className="text-2xl font-semibold mb-6">What are we working on?</h1>
+      <Card className="w-full">
+        <CardContent className="p-6">
+          <form onSubmit={handleSubmit} className="space-y-6">
           <div className="space-y-2">
-            <label className="text-sm font-medium">Intent</label>
+            <label className="text-sm font-medium">Topic \u2022</label>
             <Input
               placeholder="e.g. Launch a new product on Instagram"
-              value={intent}
-              onChange={(e) => setIntent(e.target.value)}
+              value={topic}
+              onChange={(e) => setTopic(e.target.value)}
               required
             />
           </div>
           <div className="space-y-2">
-            <label className="text-sm font-medium">What’s the objective?</label>
+            <label className="text-sm font-medium">Intent \u2022</label>
             <Input
               placeholder="e.g. Drive signups to waitlist"
-              value={objective}
-              onChange={(e) => setObjective(e.target.value)}
+              value={intent}
+              onChange={(e) => setIntent(e.target.value)}
               required
             />
           </div>
@@ -110,5 +118,6 @@ export default function BasketCreateForm({ onSuccess }: Props) {
         </form>
       </CardContent>
     </Card>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- emit context blocks for basket inputs
- create basket form layout and validation updates
- adjust client basket submit helper
- update basket block builder tests

## Testing
- `npm run test`
- `pytest -q -vv`

------
https://chatgpt.com/codex/tasks/task_e_68463d2021a4832999d12adb5b810a3e