### PR TITLE
Add DumpArea component with test page

### DIFF
--- a/web/app/(test)/test/dump/page.tsx
+++ b/web/app/(test)/test/dump/page.tsx
@@ -1,0 +1,12 @@
+import DumpArea from "@/components/ui/DumpArea";
+
+export default function DumpTestPage() {
+  return (
+    <main className="min-h-screen bg-background py-10 px-4">
+      <div className="max-w-5xl mx-auto">
+        <h1 className="text-2xl font-bold mb-4">🧪 DumpArea Component Test</h1>
+        <DumpArea />
+      </div>
+    </main>
+  );
+}

--- a/web/components/ui/Badge.tsx
+++ b/web/components/ui/Badge.tsx
@@ -1,0 +1,30 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@/lib/utils";
+
+const badgeVariants = cva(
+  "inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-semibold transition-colors",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground",
+        secondary: "bg-secondary text-secondary-foreground",
+        outline: "text-foreground border-border",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return <div className={cn(badgeVariants({ variant }), className)} {...props} />;
+}
+Badge.displayName = "Badge";
+
+export { Badge, badgeVariants };

--- a/web/components/ui/DumpArea.tsx
+++ b/web/components/ui/DumpArea.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { useState } from "react";
+import { UploadArea } from "@/components/ui/UploadArea";
+import { Input } from "@/components/ui/Input";
+import { Label } from "@/components/ui/Label";
+import { Card, CardContent } from "@/components/ui/Card";
+import { Textarea } from "@/components/ui/Textarea";
+import { Badge } from "@/components/ui/Badge";
+
+export default function DumpArea() {
+  const [text, setText] = useState("");
+  const [files, setFiles] = useState<string[]>([]);
+  const [links, setLinks] = useState<string[]>([]);
+
+  return (
+    <Card className="p-4 w-full max-w-3xl mx-auto mt-6">
+      <CardContent className="space-y-6">
+        <div>
+          <h2 className="text-xl font-semibold">🧠 Dump your thoughts here</h2>
+          <p className="text-sm text-muted-foreground">
+            Paste chats, upload images/docs, or drop links.
+          </p>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="dump-text">Raw Text Dump</Label>
+          <Textarea
+            id="dump-text"
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            placeholder="e.g. ChatGPT said to run a 7-day campaign..."
+            rows={6}
+          />
+        </div>
+
+        <div className="space-y-2">
+          <Label>Reference Files</Label>
+          <UploadArea
+            prefix="dump"
+            maxFiles={5}
+            onUpload={(url) => setFiles((prev) => [...prev, url])}
+            preview
+            enableDrop
+            showPreviewGrid
+          />
+          {files.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No files uploaded yet.</p>
+          ) : (
+            <div className="flex flex-wrap gap-2">
+              {files.map((url, idx) => (
+                <Badge key={idx} variant="secondary">
+                  📎 {url.split("/").pop()}
+                </Badge>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <div className="space-y-2">
+          <Label>Relevant Links</Label>
+          <Input
+            type="text"
+            placeholder="Paste a link and press Enter"
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                const url = (e.target as HTMLInputElement).value.trim();
+                if (url) {
+                  setLinks([...links, url]);
+                  (e.target as HTMLInputElement).value = "";
+                }
+              }
+            }}
+          />
+          {links.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No links added yet.</p>
+          ) : (
+            <ul className="space-y-1 text-sm text-muted-foreground">
+              {links.map((link, idx) => (
+                <li key={idx} className="truncate">
+                  🔗 <Badge variant="outline">{link}</Badge>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/web/components/ui/Label.tsx
+++ b/web/components/ui/Label.tsx
@@ -1,0 +1,19 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+const Label = React.forwardRef<
+  React.ElementRef<"label">,
+  React.ComponentPropsWithoutRef<"label">
+>(({ className, ...props }, ref) => (
+  <label
+    ref={ref}
+    className={cn(
+      "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
+      className,
+    )}
+    {...props}
+  />
+));
+Label.displayName = "Label";
+
+export { Label };


### PR DESCRIPTION
## Summary
- introduce `Badge` and `Label` UI helpers
- create a new `DumpArea` component for testing uploads and links
- add a test page under `(test)/test/dump`

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68464dfbda908329a4c7c3aaa1bdb335