### PR TITLE
replace_basket_create_with_dump_flow

### DIFF
--- a/web/app/basket/create/page.tsx
+++ b/web/app/basket/create/page.tsx
@@ -1,11 +1,54 @@
 "use client";
-import BasketCreateForm from "@/components/baskets/BasketCreateForm";
+import { useState } from "react";
+import DumpArea from "@/components/ui/DumpArea";
+import { Button } from "@/components/ui/Button";
+import { useRouter } from "next/navigation";
+import { createBasketFromDump } from "@/lib/baskets/createFromDump";
+import { toast } from "react-hot-toast";
 
 export default function BasketNewPage() {
+  const [text, setText] = useState("");
+  const [files, setFiles] = useState<string[]>([]);
+  const [links, setLinks] = useState<string[]>([]);
+  const [loading, setLoading] = useState(false);
+  const router = useRouter();
+
+  const handleSubmit = async () => {
+    if (!text.trim() && files.length === 0 && links.length === 0) {
+      toast.error("Please provide some content for the dump");
+      return;
+    }
+    setLoading(true);
+    try {
+      const { id } = await createBasketFromDump({
+        textDump: text,
+        files,
+        links,
+      });
+      router.push(`/baskets/${id}`);
+    } catch (err: any) {
+      console.error(err);
+      toast.error("Failed to create basket");
+    } finally {
+      setLoading(false);
+    }
+  };
+
   return (
-    <div className="px-6 py-10 max-w-2xl mx-auto">
-      <h1 className="text-2xl font-semibold mb-6">What are we working on?</h1>
-      <BasketCreateForm />
+    <div className="px-6 py-10 space-y-4">
+      <DumpArea
+        text={text}
+        onTextChange={setText}
+        files={files}
+        onFilesChange={setFiles}
+        links={links}
+        onLinksChange={setLinks}
+      />
+      <div className="max-w-3xl mx-auto">
+        <Button className="w-full" onClick={handleSubmit} disabled={loading}>
+          {loading ? "Creating…" : "Create Basket"}
+        </Button>
+      </div>
     </div>
   );
 }

--- a/web/components/ui/DumpArea.tsx
+++ b/web/components/ui/DumpArea.tsx
@@ -8,10 +8,26 @@ import { Card, CardContent } from "@/components/ui/Card";
 import { Textarea } from "@/components/ui/Textarea";
 import { Badge } from "@/components/ui/Badge";
 
-export default function DumpArea() {
-  const [text, setText] = useState("");
-  const [files, setFiles] = useState<string[]>([]);
-  const [links, setLinks] = useState<string[]>([]);
+export interface DumpAreaProps {
+  text?: string;
+  onTextChange?: (v: string) => void;
+  files?: string[];
+  onFilesChange?: (v: string[]) => void;
+  links?: string[];
+  onLinksChange?: (v: string[]) => void;
+}
+
+export default function DumpArea({
+  text: textProp,
+  onTextChange,
+  files: filesProp,
+  onFilesChange,
+  links: linksProp,
+  onLinksChange,
+}: DumpAreaProps = {}) {
+  const [text, setText] = useState(textProp || "");
+  const [files, setFiles] = useState<string[]>(filesProp || []);
+  const [links, setLinks] = useState<string[]>(linksProp || []);
 
   return (
     <Card className="p-4 w-full max-w-3xl mx-auto mt-6">
@@ -28,7 +44,10 @@ export default function DumpArea() {
           <Textarea
             id="dump-text"
             value={text}
-            onChange={(e) => setText(e.target.value)}
+            onChange={(e) => {
+              setText(e.target.value);
+              onTextChange?.(e.target.value);
+            }}
             placeholder="e.g. ChatGPT said to run a 7-day campaign..."
             rows={6}
           />
@@ -39,7 +58,11 @@ export default function DumpArea() {
           <UploadArea
             prefix="dump"
             maxFiles={5}
-            onUpload={(url) => setFiles((prev) => [...prev, url])}
+            onUpload={(url) => {
+              const next = [...files, url];
+              setFiles(next);
+              onFilesChange?.(next);
+            }}
             preview
             enableDrop
             showPreviewGrid
@@ -67,7 +90,9 @@ export default function DumpArea() {
                 e.preventDefault();
                 const url = (e.target as HTMLInputElement).value.trim();
                 if (url) {
-                  setLinks([...links, url]);
+                  const next = [...links, url];
+                  setLinks(next);
+                  onLinksChange?.(next);
                   (e.target as HTMLInputElement).value = "";
                 }
               }

--- a/web/components/ui/UploadArea.tsx
+++ b/web/components/ui/UploadArea.tsx
@@ -37,7 +37,7 @@ interface FileMeta {
 
 export function UploadArea({
   prefix,
-  bucket = "task-media",
+  bucket = "basket-dumps",
   maxFiles,
   onUpload,
   maxSizeMB = 5,

--- a/web/lib/agents/triggerBlockParser.ts
+++ b/web/lib/agents/triggerBlockParser.ts
@@ -1,0 +1,11 @@
+import { apiPost } from "@/lib/api";
+
+export async function triggerBlockParser(
+  basket_id: string,
+  payload: { raw_dump: string; media?: any[] }
+) {
+  await apiPost("/api/agent-run", {
+    agent: "orch_block_manager_agent",
+    input: { basket_id, ...payload },
+  });
+}

--- a/web/lib/baskets/createFromDump.ts
+++ b/web/lib/baskets/createFromDump.ts
@@ -1,0 +1,79 @@
+import { createClient } from "@/lib/supabaseClient";
+import { uploadFile } from "@/lib/uploadFile";
+import { triggerBlockParser } from "@/lib/agents/triggerBlockParser";
+
+export interface DumpPayload {
+  textDump: string;
+  files: (File | string)[];
+  links: string[];
+}
+
+export async function createBasketFromDump({
+  textDump,
+  files,
+  links,
+}: DumpPayload): Promise<{ id: string }> {
+  const supabase = createClient();
+  const { data: userData } = await supabase.auth.getUser();
+  if (!userData?.user) throw new Error("Not authenticated");
+  const userId = userData.user.id;
+
+  const uploaded: { file_url: string; file_name: string; size_bytes: number }[] = [];
+  const fileIds: string[] = [];
+
+  for (const item of files) {
+    let url: string;
+    let name: string;
+    let size = 0;
+    if (item instanceof File) {
+      const filename = `${Date.now()}-${item.name}`;
+      url = await uploadFile(item, `dump_${userId}/${filename}`, "basket-dumps");
+      name = item.name;
+      size = item.size;
+    } else {
+      url = item;
+      name = url.split("/").pop() || "file";
+    }
+    const { data, error } = await supabase
+      .from("block_files")
+      .insert({
+        user_id: userId,
+        file_url: url,
+        file_name: name,
+        size_bytes: size,
+        storage_domain: "basket-dumps",
+      })
+      .select("id")
+      .single();
+    if (error) throw new Error(error.message);
+    if (data) fileIds.push(data.id);
+    uploaded.push({ file_url: url, file_name: name, size_bytes: size });
+  }
+
+  const { data: basket, error: basketErr } = await supabase
+    .from("baskets")
+    .insert({
+      user_id: userId,
+      raw_dump: textDump,
+      intent: null,
+      media: uploaded,
+      is_draft: true,
+    })
+    .select("id")
+    .single();
+
+  if (basketErr) throw new Error(basketErr.message);
+  const basketId = basket!.id as string;
+
+  await supabase.from("basket_inputs").insert({
+    basket_id: basketId,
+    content: textDump,
+    file_ids: fileIds,
+    links,
+    source: "user",
+  });
+
+  await triggerBlockParser(basketId, { raw_dump: textDump, media: uploaded });
+
+  return { id: basketId };
+}


### PR DESCRIPTION
## Summary
- replace `/basket/create` form with DumpArea UX
- update DumpArea to support controlled props
- default UploadArea bucket to `basket-dumps`
- add helper to create basket from dump and upload files
- trigger `orch_block_manager_agent` on basket creation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68466767f5108329b4a4ceb49d7f93be