### PR TITLE
setup_playwright_e2e_with_auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,3 +152,5 @@ openai_agents/
 # Python
 /api/.venv/
 /api/poetry.lock
+# Playwright auth sessions
+storageState.json

--- a/codex/README.playwright.md
+++ b/codex/README.playwright.md
@@ -1,0 +1,42 @@
+# 🧪 Playwright Setup for Codex-Paired Testing
+
+This file documents the recommended testing loop when using Codex to generate or modify features. 
+
+---
+## ✅ 1. Install Playwright
+
+```bash
+npm install -D @playwright/test
+npx playwright install
+```
+
+---
+## 🔐 2. Authenticate Once via Dev Auth
+
+```bash
+npx playwright codegen --save-storage=storageState.json http://localhost:3000
+```
+
+1. Log in using your test user (e.g., Google or magic link).
+2. Close the window after redirecting to dashboard.
+
+> This saved session will be reused for all tests.
+
+---
+## 🧪 3. Run Basket Creation Test
+
+```bash
+npx playwright test tests/basket-create.spec.ts
+```
+
+This test creates a real basket in your database and confirms the flow visually and structurally.
+
+---
+## 🧼 Notes
+- `.gitignore` already skips committing the `storageState.json`
+- You can create additional tests in `/tests/` as your app evolves
+- `playwright.config.ts` automatically boots the local server if not running
+
+---
+## 🌱 Next: Seeding Example Data
+You can add `tests/seed.ts` for batch data seeding or fake users. Or let Codex generate auto-tests that cover your flows.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  use: {
+    baseURL: 'http://localhost:3000',
+    storageState: 'storageState.json',
+    headless: true,
+  },
+  webServer: {
+    command: 'npm run dev',
+    port: 3000,
+    timeout: 120 * 1000,
+    reuseExistingServer: true,
+  },
+});

--- a/tests/basket-create.spec.ts
+++ b/tests/basket-create.spec.ts
@@ -1,0 +1,14 @@
+import { test, expect } from '@playwright/test';
+
+test('Create a new basket from dump', async ({ page }) => {
+  await page.goto('/baskets/new');
+
+  await page.fill('textarea[placeholder="What’s the idea or intent?"]', 'Run a playful Gen Z TikTok challenge');
+  await page.fill('textarea[placeholder="Add extra insights…"]', 'Lean into visual humor and cultural slang');
+
+  await page.click('button:has-text("Create")');
+  await page.waitForURL('**/baskets/**');
+
+  const heading = await page.locator('h1');
+  await expect(heading).toContainText('Run a playful Gen Z TikTok challenge');
+});


### PR DESCRIPTION
## Summary
- ignore `storageState.json` so Playwright session state doesn't get committed
- add Playwright configuration with web server reuse
- create an example basket creation e2e test
- document Playwright workflow for Codex developers

## Testing
- `npm test`
- `pytest -vv`


------
https://chatgpt.com/codex/tasks/task_e_6846782593748329a100f7845fa83d9e