### PR TITLE
Add DumpArea flow for basket creation

### DIFF
--- a/web/app/auth/callback/page.tsx
+++ b/web/app/auth/callback/page.tsx
@@ -23,7 +23,7 @@ export default function AuthCallbackPage() {
         .eq('user_id', data.session.user.id)
         .limit(1);
       if (!baskets || baskets.length === 0) {
-        router.replace('/basket/create');
+        router.replace('/baskets/create');
       } else {
         router.replace('/dashboard');
       }

--- a/web/app/basket/layout.tsx
+++ b/web/app/basket/layout.tsx
@@ -1,7 +1,0 @@
-"use client";
-import { ReactNode } from "react";
-import Shell from "@/components/layouts/Shell";
-
-export default function BasketLayout({ children }: { children: ReactNode }) {
-  return <Shell>{children}</Shell>;
-}

--- a/web/app/baskets/create/page.tsx
+++ b/web/app/baskets/create/page.tsx
@@ -9,7 +9,7 @@ import { toast } from "react-hot-toast";
 
 export default function BasketCreatePage() {
   const [text, setText] = useState("");
-  const [files, setFiles] = useState<File[]>([]);
+  const [files, setFiles] = useState<(File | string)[]>([]);
   const [loading, setLoading] = useState(false);
   const router = useRouter();
 
@@ -40,7 +40,7 @@ export default function BasketCreatePage() {
       <DumpArea
         text={text}
         onTextChange={setText}
-        onFilesChange={setFiles}
+        onFilesChange={(vals) => setFiles(vals)}
       />
 
       <div className="pt-2">

--- a/web/app/baskets/create/page.tsx
+++ b/web/app/baskets/create/page.tsx
@@ -4,30 +4,24 @@ import { useState } from "react";
 import DumpArea from "@/components/ui/DumpArea";
 import { Button } from "@/components/ui/Button";
 import { useRouter } from "next/navigation";
-import { createBasketFromDump } from "@/lib/baskets/createFromDump";
+import { createBasketWithInput } from "@/lib/baskets/createBasketWithInput";
 import { toast } from "react-hot-toast";
 
-export default function BasketNewPage() {
+export default function BasketCreatePage() {
   const [text, setText] = useState("");
-  const [files, setFiles] = useState<string[]>([]);
-  const [links, setLinks] = useState<string[]>([]);
+  const [files, setFiles] = useState<File[]>([]);
   const [loading, setLoading] = useState(false);
   const router = useRouter();
 
   const handleSubmit = async () => {
-    if (!text.trim() && files.length === 0 && links.length === 0) {
+    if (!text.trim() && files.length === 0) {
       toast.error("Please provide some content for the dump");
       return;
     }
-
     setLoading(true);
     try {
-      const { id } = await createBasketFromDump({
-        textDump: text,
-        files,
-        links,
-      });
-      router.push(`/baskets/${id}`);
+      const basket = await createBasketWithInput({ text, files });
+      router.push(`/baskets/${basket.id}/work`);
     } catch (err: any) {
       console.error(err);
       toast.error("Failed to create basket");
@@ -39,29 +33,18 @@ export default function BasketNewPage() {
   return (
     <main className="p-6 max-w-4xl mx-auto space-y-6">
       <div className="space-y-1">
-        <h1 className="text-2xl font-semibold tracking-tight">
-          🧠 Dump your thoughts here
-        </h1>
-        <p className="text-muted-foreground">
-          Paste chats, upload images/docs, or drop links.
-        </p>
+        <h1 className="text-2xl font-semibold tracking-tight">🧠 Dump your thoughts here</h1>
+        <p className="text-muted-foreground">Paste chats and upload reference files.</p>
       </div>
 
       <DumpArea
         text={text}
         onTextChange={setText}
-        files={files}
         onFilesChange={setFiles}
-        links={links}
-        onLinksChange={setLinks}
       />
 
       <div className="pt-2">
-        <Button
-          className="w-full"
-          onClick={handleSubmit}
-          disabled={loading}
-        >
+        <Button className="w-full" onClick={handleSubmit} disabled={loading}>
           {loading ? "Creating…" : "Create Basket"}
         </Button>
       </div>

--- a/web/app/baskets/page.tsx
+++ b/web/app/baskets/page.tsx
@@ -24,7 +24,7 @@ export default function BasketsPage() {
           title="\uD83D\uDC4B Welcome! Let\u2019s start your first basket \u2014 it only takes a minute."
           action={(
             <Button asChild>
-              <Link href="/basket/create">Create Basket</Link>
+              <Link href="/baskets/create">Create Basket</Link>
             </Button>
           )}
         />

--- a/web/app/components/layout/Sidebar.tsx
+++ b/web/app/components/layout/Sidebar.tsx
@@ -13,7 +13,7 @@ import { createClient } from "@/lib/supabaseClient";
 const baseItems = [
   { href: "/dashboard", label: "🧶 Dashboard" },
   { href: "/baskets", label: "🧺 Baskets" },
-  { href: "/basket/create", label: "➕ New Basket" },
+  { href: "/baskets/create", label: "➕ New Basket" },
   { href: "/blocks", label: "◾ Blocks" }, // 🧩 Moved here
 ];
 

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -32,7 +32,7 @@ export default function LandingPage() {
                 living memory powered by "context blocks" and "task baskets".
               </p>
               <Link
-                href="/basket/create"
+                href="/baskets/create"
                 className="inline-block px-8 py-4 border border-foreground text-foreground rounded-md hover:bg-black hover:text-white transition"
               >
                 drop your first thought

--- a/web/components/layouts/DashboardNav.tsx
+++ b/web/components/layouts/DashboardNav.tsx
@@ -14,7 +14,7 @@ interface NavItem {
 const navItems: NavItem[] = [
   { title: "Dashboard", href: "/dashboard", icon: Home },
   { title: "Baskets", href: "/baskets", icon: User },
-  { title: "New Basket", href: "/basket/create", icon: User },
+  { title: "New Basket", href: "/baskets/create", icon: User },
   { title: "Blocks", href: "/blocks", icon: User },
   { title: "Queue", href: "/queue", icon: User },
 ];

--- a/web/lib/baskets/createBasketWithInput.ts
+++ b/web/lib/baskets/createBasketWithInput.ts
@@ -1,0 +1,74 @@
+import { createClient } from "@/lib/supabaseClient";
+import { uploadFile } from "@/lib/uploadFile";
+import { apiPost } from "@/lib/api";
+
+export interface BasketInputPayload {
+  text: string;
+  files?: File[];
+}
+
+export async function createBasketWithInput({ text, files = [] }: BasketInputPayload) {
+  const supabase = createClient();
+
+  const { data: userData } = await supabase.auth.getUser();
+  if (!userData?.user) throw new Error("Not authenticated");
+  const userId = userData.user.id;
+
+  const uploadedUrls: string[] = [];
+  const fileIds: string[] = [];
+
+  for (const file of files) {
+    const filename = `${Date.now()}-${file.name}`;
+    const path = `dump_${userId}/${filename}`;
+    const url = await uploadFile(file, path, "basket-dumps");
+    uploadedUrls.push(url);
+
+    const { data, error } = await supabase
+      .from("block_files")
+      .insert({
+        user_id: userId,
+        file_url: url,
+        file_name: file.name,
+        size_bytes: file.size,
+        storage_domain: "basket-dumps",
+      })
+      .select("id")
+      .single();
+    if (error) throw new Error(error.message);
+    if (data) fileIds.push(data.id);
+  }
+
+  const { data: basket, error: basketErr } = await supabase
+    .from("baskets")
+    .insert({
+      user_id: userId,
+      raw_dump: text,
+      media: uploadedUrls,
+      is_draft: true,
+    })
+    .select()
+    .single();
+
+  if (basketErr || !basket) throw new Error(basketErr?.message || "basket insert failed");
+
+  const { data: input, error: inputErr } = await supabase
+    .from("basket_inputs")
+    .insert({
+      basket_id: basket.id,
+      content: text,
+      file_ids: fileIds,
+      source: "user",
+    })
+    .select()
+    .single();
+
+  if (inputErr || !input) throw new Error(inputErr?.message || "input insert failed");
+
+  await apiPost("/api/agent-run", {
+    agent: "orch_block_manager_agent",
+    event: "basket_inputs.created",
+    input: { input_id: input.id },
+  });
+
+  return basket;
+}


### PR DESCRIPTION
## Summary
- add helper to create a basket with its first input and trigger block manager
- add `/baskets/create` page using DumpArea component
- update navigation links to new route
- remove old `/basket/create` page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68467bc446ec8329a2544a73d2debc4d