### PR TITLE
Create basket with first dump

### DIFF
--- a/web/lib/baskets/createBasketWithInput.ts
+++ b/web/lib/baskets/createBasketWithInput.ts
@@ -13,6 +13,7 @@ export async function createBasketWithInput({ text, files = [] }: BasketInputPay
   const { data: userData } = await supabase.auth.getUser();
   if (!userData?.user) throw new Error("Not authenticated");
   const userId = userData.user.id;
+  const intent = text.split("\n")[0]?.slice(0, 100) || null;
 
   const uploadedUrls: string[] = [];
   const fileIds: string[] = [];
@@ -54,6 +55,7 @@ export async function createBasketWithInput({ text, files = [] }: BasketInputPay
     .insert({
       user_id: userId,
       raw_dump: text,
+      intent,
       media: uploadedUrls,
       is_draft: true,
     })


### PR DESCRIPTION
## Summary
- derive initial basket intent from first line of text
- handle dump uploads and basket creation with `DumpArea`

## Testing
- `npm test` *(fails: Cannot find module 'jest-cli')*
- `npm run lint` in `web/` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684690b97a40832988f193b928a9a39a