### PR TITLE
fix_event_input_parsing_type_error

### DIFF
--- a/api/src/app/events/on_input_created.py
+++ b/api/src/app/events/on_input_created.py
@@ -11,7 +11,7 @@ async def handle_event(event: dict[str, Any]) -> dict[str, Any]:
 
     if "record" in event:
         record = event["record"]
-    elif "input" in event and "input_id" in event["input"]:
+    elif isinstance(event, dict) and "input" in event and "input_id" in event["input"]:
         input_id = event["input"]["input_id"]
         resp = supabase.table("basket_inputs").select("*").eq("id", input_id).single().execute()
         if not resp.data:

--- a/api/src/app/routes/agent_run.py
+++ b/api/src/app/routes/agent_run.py
@@ -1,5 +1,8 @@
+import logging
 from fastapi import APIRouter, Body
 from ..events.on_input_created import handle_event
+
+logger = logging.getLogger("uvicorn.error")
 
 router = APIRouter(tags=["agents"])
 
@@ -7,5 +10,6 @@ router = APIRouter(tags=["agents"])
 async def agent_run(payload: dict = Body(...)):
     """Forward incoming events directly to the handler."""
     # Accept both {event: {...}} and direct {...} formats
-    event = payload.get("event") or payload
+    event = payload["event"] if isinstance(payload.get("event"), dict) else payload
+    logger.info("/agent-run payload type: %s", type(event).__name__)
     return await handle_event(event)


### PR DESCRIPTION
## Summary
- handle dev-mode payloads where event is not a dict
- log payload type in /agent-run route

## Testing
- `npx playwright test` *(fails: `Process from config.webServer was not able to start`)*

------
https://chatgpt.com/codex/tasks/task_e_6847cf56309883298f53360b2dae693f