### PR TITLE
Schema sync and safe inserts

### DIFF
--- a/api/src/schemas/context_block.py
+++ b/api/src/schemas/context_block.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from uuid import UUID
+
+from pydantic import Field
+
+from .base import BaseSchema
+
+
+class ContextBlock(BaseSchema):
+    """Core schema for a single context block."""
+
+    id: UUID | None = None
+    user_id: str
+    label: str
+    content: str | None = None
+    file_ids: list[str] | None = None
+    type: str = "text"
+    source: str = "parser"
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    is_primary: bool = True
+
+    # Fields not yet persisted in the DB
+    update_policy: str | None = None
+    is_core_block: bool | None = None
+    associated_block_id: str | None = None
+    meta_scope: str | None = None
+    meta_context_scope: str | None = None
+    meta_tags: list[str] | None = None
+    meta_emotional_tone: list[str] | None = None
+    meta_locale: str | None = None
+
+    def model_dump(self, *, mode: str = "python", exclude_none: bool = False) -> dict:
+        """Compatibility wrapper for Pydantic v1."""
+        return self.dict(exclude_none=exclude_none)

--- a/tests/contracts/test_contracts.py
+++ b/tests/contracts/test_contracts.py
@@ -8,6 +8,7 @@ from schemas.basket_composer import BasketComposerIn
 from schemas.block_diff import BlockDiffIn
 from schemas.block_manager import BlockManagerIn
 from schemas.config import ConfigIn
+from schemas.context_block import ContextBlock
 from schemas.dump_parser import DumpParserIn
 from schemas.research import ResearchIn
 from schemas.usage import UsageIn
@@ -57,3 +58,15 @@ def test_round_trip_compose_request():
             "file_urls": [],
         }
     )
+
+
+def test_optional_fields_skip():
+    raw = {
+        "id": "00000000-0000-0000-0000-000000000000",
+        "user_id": "00000000-0000-0000-0000-000000000001",
+        "label": "t",
+        "content": "c",
+    }
+    data = ContextBlock.model_validate(raw)
+    out = data.model_dump(mode="json", exclude_none=True)
+    assert "meta_scope" not in out


### PR DESCRIPTION
## Summary
- add ContextBlock schema with optional extra fields
- serialize ContextBlock safely when inserting
- ensure basket route uses validated safe inserts
- cover optional fields in contract tests

## Testing
- `ruff format ...`
- `ruff check --fix api/src/schemas/context_block.py api/src/app/agent_tasks/orch/apply_diff_blocks.py api/src/app/routes/baskets.py tests/contracts/test_contracts.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848f0dc5b188329a25d6c801912a7e7