### PR TITLE
feat(trace): Wave-2 agent_events table + logged decorator + /debug route

### DIFF
--- a/api/src/app/agent_server.py
+++ b/api/src/app/agent_server.py
@@ -14,36 +14,32 @@
 #     uvicorn src.app.agent_server:app --host 0.0.0.0 --port $PORT
 
 from __future__ import annotations
+
 import os
 import sys
-import json
-import urllib.request
-import traceback
 
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from datetime import datetime
 try:
     from dotenv import load_dotenv
     load_dotenv()
 except ImportError:
     pass
 # FastAPI and CORS imports
-from fastapi import FastAPI, HTTPException, Depends
 import logging
+
+from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-
 # Authentication helper and output normalization
-from .agent_tasks.layer1_infra.utils.auth_helpers import current_user_id
-from .agent_tasks.layer1_infra.utils.normalize_output import normalize_output
-# Task routing for execution
-from .agent_tasks.layer2_tasks.utils.task_router import route_and_validate_task
-from .routes.task_types import router as task_types_router
-from .routes.task_brief import router as task_brief_router
-from .routes.baskets import router as basket_router
 from .routes.agent_run import router as agent_run_router
+from .routes.baskets import router as basket_router
+from .routes.debug import router as debug_router
+from .routes.task_brief import router as task_brief_router
+
+# Task routing for execution
+from .routes.task_types import router as task_types_router
 
 # ── Environment variable for Bubble webhook URL
 CHAT_URL = os.getenv("BUBBLE_CHAT_URL")
@@ -68,7 +64,8 @@ app.add_middleware(
 )
 
 # Mount agent entrypoint handlers
-from .agent_entrypoints import router as agent_router, run_agent, run_agent_direct
+from .agent_entrypoints import router as agent_router, run_agent, run_agent_direct  # noqa: E402
+
 app.post("/agent")(run_agent)
 app.post("/agent/direct")(run_agent_direct)
 app.include_router(agent_router)
@@ -81,6 +78,7 @@ app.include_router(task_brief_router)
 app.include_router(basket_router)
 # Agent-run proxy route
 app.include_router(agent_run_router)
+app.include_router(debug_router)
 
 
 

--- a/api/src/app/agent_tasks/layer1_infra/agents/infra_analyzer_agent.py
+++ b/api/src/app/agent_tasks/layer1_infra/agents/infra_analyzer_agent.py
@@ -4,6 +4,7 @@ from datetime import datetime, timezone
 import asyncpg
 from schemas.audit import AuditIn, AuditOut
 from schemas.validators import validates
+from utils.logged_agent import logged
 
 from app.event_bus import DB_URL  # reuse same URL
 from app.supabase_helpers import publish_event
@@ -25,6 +26,7 @@ select norm_label, ids from dupes;
 
 EVENT_TOPIC = "block.audit_report"
 
+@logged("infra_analyzer_agent")
 @validates(AuditIn)
 async def run(_: AuditIn) -> AuditOut:
     """Main entry for orchestration_runner."""

--- a/api/src/app/agent_tasks/layer1_infra/agents/infra_observer_agent.py
+++ b/api/src/app/agent_tasks/layer1_infra/agents/infra_observer_agent.py
@@ -6,6 +6,7 @@ from datetime import datetime, timezone
 import asyncpg
 from schemas.usage import UsageIn, UsageOut
 from schemas.validators import validates
+from utils.logged_agent import logged
 
 from app.event_bus import DB_URL
 from app.supabase_helpers import publish_event
@@ -31,6 +32,7 @@ where h.block_id is null;
 EVENT_TOPIC = "block.usage_report"
 
 
+@logged("infra_observer_agent")
 @validates(UsageIn)
 async def run(_: UsageIn) -> UsageOut:
     """Called by orchestration_runner."""

--- a/api/src/app/agent_tasks/layer1_infra/agents/infra_research_agent.py
+++ b/api/src/app/agent_tasks/layer1_infra/agents/infra_research_agent.py
@@ -5,6 +5,7 @@ from datetime import datetime, timezone
 import asyncpg
 from schemas.research import ResearchIn, ResearchOut
 from schemas.validators import validates
+from utils.logged_agent import logged
 
 from app.event_bus import DB_URL
 from app.supabase_helpers import publish_event
@@ -28,6 +29,7 @@ where id = any($1::uuid[])
 
 EVENT_TOPIC = "block.refresh_report"
 
+@logged("infra_research_agent")
 @validates(ResearchIn)
 async def run(_: ResearchIn) -> ResearchOut:
     """Called by orchestration_runner."""

--- a/api/src/app/agent_tasks/layer2_tasks/agents/tasks_composer_agent.py
+++ b/api/src/app/agent_tasks/layer2_tasks/agents/tasks_composer_agent.py
@@ -15,6 +15,7 @@ from datetime import timezone
 
 import asyncpg
 from schemas.validators import validates
+from utils.logged_agent import logged
 
 from app.supabase_helpers import publish_event
 
@@ -45,6 +46,7 @@ order by brief_count desc
 limit 3
 """
 
+@logged("tasks_composer_agent")
 @validates(ComposeRequest)
 async def run(payload: ComposeRequest) -> TaskBriefDraft:
     user_id = payload.user_id

--- a/api/src/app/agent_tasks/layer2_tasks/agents/tasks_editor_agent.py
+++ b/api/src/app/agent_tasks/layer2_tasks/agents/tasks_editor_agent.py
@@ -1,6 +1,7 @@
 #api/src/app/agent_tasks/layer2_tasks/agents/tasks_editor_agent.py
 
 from schemas.validators import validates
+from utils.logged_agent import logged
 
 from app.supabase_helpers import publish_event
 
@@ -9,6 +10,7 @@ from ..schemas import TaskBriefDraft, TaskBriefEdited
 EVENT_TOPIC_IN  = "brief.draft_created"
 EVENT_TOPIC_OUT = "brief.edited"
 
+@logged("tasks_editor_agent")
 @validates(TaskBriefDraft)
 async def edit(draft: TaskBriefDraft) -> TaskBriefEdited:
     edited = TaskBriefEdited(**draft.model_dump(), edits_log=[])

--- a/api/src/app/agent_tasks/layer2_tasks/agents/tasks_validator_agent.py
+++ b/api/src/app/agent_tasks/layer2_tasks/agents/tasks_validator_agent.py
@@ -4,6 +4,7 @@ import datetime
 
 import asyncpg
 from schemas.validators import validates
+from utils.logged_agent import logged
 
 from app.event_bus import DB_URL, publish_event
 
@@ -13,6 +14,7 @@ EVENT_TOPIC_IN = "brief.edited"
 EVENT_TOPIC_OUT = "brief.validated"
 
 
+@logged("tasks_validator_agent")
 @validates(TaskBriefEdited)
 async def validate(brief: TaskBriefEdited) -> TaskBriefValidation:
     errors = []

--- a/api/src/app/agent_tasks/layer3_config/adapters/google_exporter.py
+++ b/api/src/app/agent_tasks/layer3_config/adapters/google_exporter.py
@@ -1,10 +1,14 @@
-import httpx
-import json
 import datetime
 
-from ..utils.config_to_md import render_markdown
-from app.integrations.google_client import refresh_token, DOCS_ENDPOINT
+import httpx
+from utils.logged_agent import logged
 
+from app.integrations.google_client import DOCS_ENDPOINT, refresh_token
+
+from ..utils.config_to_md import render_markdown
+
+
+@logged("google_exporter")
 async def export_to_doc(user_id: str, brief_id: str, supabase):
     # fetch latest config and integration
     cfg_row = (
@@ -63,6 +67,10 @@ async def export_to_doc(user_id: str, brief_id: str, supabase):
                 json={"requests": [{"insertText": {"location": {"index": 1}, "text": md}}]},
             )
             link = f"https://docs.google.com/document/d/{doc_id}/edit"
-            await supabase.from_("brief_configs").update({"external_url": link}).eq("id", cfg_row["id"])
+            (
+                await supabase.from_("brief_configs")
+                .update({"external_url": link})
+                .eq("id", cfg_row["id"])
+            )
 
     return link

--- a/api/src/app/agent_tasks/layer3_config/agents/config_agent.py
+++ b/api/src/app/agent_tasks/layer3_config/agents/config_agent.py
@@ -5,9 +5,11 @@ import uuid
 import asyncpg
 from schemas.config import ConfigIn, ConfigOut
 from schemas.validators import validates
+from utils.logged_agent import logged
 
 DB_URL = os.getenv("DATABASE_URL")
 
+@logged("config_agent")
 @validates(ConfigIn)
 async def generate(payload: ConfigIn) -> ConfigOut:
     brief_id = payload.brief_id

--- a/api/src/app/agent_tasks/orchestration/orch_basket_composer_agent.py
+++ b/api/src/app/agent_tasks/orchestration/orch_basket_composer_agent.py
@@ -5,6 +5,7 @@ import json
 import asyncpg
 from schemas.basket_composer import BasketComposerIn, BasketComposerOut
 from schemas.validators import validates
+from utils.logged_agent import logged
 
 from app.agent_tasks.layer2_tasks.agents.tasks_composer_agent import run as compose_run
 from app.event_bus import DB_URL, subscribe
@@ -27,6 +28,7 @@ async def _handle_event(evt) -> None:
         )
     await publish_event("basket.composed", {"basket_id": payload["basket_id"]})
 
+@logged("orch_basket_composer_agent")
 @validates(BasketComposerIn)
 async def run(_: BasketComposerIn) -> BasketComposerOut:
     print("🚀 orch_basket_composer_agent running …")

--- a/api/src/app/agent_tasks/orchestration/orch_block_manager_agent.py
+++ b/api/src/app/agent_tasks/orchestration/orch_block_manager_agent.py
@@ -8,6 +8,7 @@ from typing import Any
 import asyncpg
 from schemas.block_manager import BlockManagerIn, BlockManagerOut
 from schemas.validators import validates
+from utils.logged_agent import logged
 
 from app.event_bus import subscribe
 
@@ -46,6 +47,7 @@ async def _queue(
         reason,
     )
 
+@logged("orch_block_manager_agent")
 @validates(BlockManagerIn)
 async def run(_: BlockManagerIn) -> BlockManagerOut:
     """Entry point used by orchestration_runner."""

--- a/api/src/app/events/on_input_created.py
+++ b/api/src/app/events/on_input_created.py
@@ -1,10 +1,13 @@
 from typing import Any
 
+from utils.logged_agent import logged
+
 from ..agent_tasks.layer1_infra.utils.supabase_helpers import get_supabase
 from ..agent_tasks.orch.apply_diff_blocks import apply_diffs
 from ..agent_tasks.orch.orch_block_diff_agent import run as diff_blocks
 
 
+@logged("on_input_created")
 async def handle_event(event: dict[str, Any]) -> dict[str, Any]:
     """Handle `basket_inputs.created` events from Supabase."""
     supabase = get_supabase()

--- a/api/src/app/routes/debug.py
+++ b/api/src/app/routes/debug.py
@@ -1,0 +1,21 @@
+from os import getenv
+
+from fastapi import APIRouter
+
+from supabase import create_client
+
+supabase = create_client(getenv("SUPABASE_URL"), getenv("SUPABASE_ANON_KEY"))
+router = APIRouter(prefix="/debug", tags=["debug"])
+
+
+@router.get("/{basket_id}")
+async def get_trace(basket_id: str):
+    resp = (
+        supabase.table("agent_events")
+        .select("*")
+        .eq("basket_id", basket_id)
+        .order("created_at")
+        .execute()
+    )
+    return resp.data
+

--- a/api/src/utils/event_log.py
+++ b/api/src/utils/event_log.py
@@ -1,0 +1,24 @@
+from os import getenv
+from typing import Any, Literal
+
+from supabase import create_client
+
+supabase = create_client(getenv("SUPABASE_URL"), getenv("SUPABASE_ANON_KEY"))
+
+async def log_event(
+    *,
+    basket_id: str | None,
+    agent: str,
+    phase: Literal["start", "success", "error"],
+    payload: Any,
+) -> None:
+    # fast, fire-and-forget; no await on the returned promise
+    supabase.table("agent_events").insert(
+        {
+            "basket_id": basket_id,
+            "agent": agent,
+            "phase": phase,
+            "payload": payload,
+        }
+    ).execute()
+

--- a/api/src/utils/logged_agent.py
+++ b/api/src/utils/logged_agent.py
@@ -1,0 +1,38 @@
+from functools import wraps
+
+from utils.event_log import log_event
+
+
+def logged(agent_name: str):
+    def decorator(fn):
+        @wraps(fn)
+        async def wrapper(*args, **kwargs):
+            basket_id = kwargs.get("basket_id") or getattr(args[0], "basket_id", None)
+            await log_event(
+                basket_id=basket_id,
+                agent=agent_name,
+                phase="start",
+                payload=kwargs,
+            )
+            try:
+                result = await fn(*args, **kwargs)
+                await log_event(
+                    basket_id=basket_id,
+                    agent=agent_name,
+                    phase="success",
+                    payload=result,
+                )
+                return result
+            except Exception as e:
+                await log_event(
+                    basket_id=basket_id,
+                    agent=agent_name,
+                    phase="error",
+                    payload={"error": str(e)},
+                )
+                raise
+
+        return wrapper
+
+    return decorator
+

--- a/supabase/migrations/20240602_create_agent_events.sql
+++ b/supabase/migrations/20240602_create_agent_events.sql
@@ -1,0 +1,12 @@
+create table if not exists agent_events (
+  id           uuid primary key default gen_random_uuid(),
+  basket_id    uuid,
+  agent        text,
+  phase        text,
+  payload      jsonb,
+  created_at   timestamp with time zone default now()
+);
+
+-- Helpful composite index for traces
+create index if not exists idx_agent_events_basket_phase
+  on agent_events (basket_id, phase, created_at desc);

--- a/tests/contracts/test_event_log.py
+++ b/tests/contracts/test_event_log.py
@@ -1,0 +1,34 @@
+import importlib
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../api/src"))
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_log_insert(monkeypatch):
+    records = {}
+
+    class StubTable:
+        def insert(self, data):
+            records.update(data)
+            return self
+
+        def execute(self):
+            return None
+
+    class StubClient:
+        def table(self, name):
+            assert name == "agent_events"
+            return StubTable()
+
+    supabase_mod = importlib.import_module("supabase")
+    monkeypatch.setattr(supabase_mod, "create_client", lambda *a, **k: StubClient())
+    event_log = importlib.import_module("utils.event_log")
+
+    await event_log.log_event(basket_id="b", agent="a", phase="start", payload={})
+    assert records["agent"] == "a"
+    assert records["phase"] == "start"
+


### PR DESCRIPTION
## Summary
- add `agent_events` migration for traces
- log events via `utils.event_log.log_event`
- wrap agent entrypoints with `logged` decorator
- expose `/debug/{basket_id}` route for inspecting event traces
- test event logging behavior

## Testing
- `ruff check --fix api/src/app/agent_server.py api/src/app/events/on_input_created.py api/src/app/agent_tasks/layer1_infra/agents/infra_analyzer_agent.py api/src/app/agent_tasks/layer1_infra/agents/infra_observer_agent.py api/src/app/agent_tasks/layer1_infra/agents/infra_research_agent.py api/src/app/agent_tasks/layer2_tasks/agents/tasks_composer_agent.py api/src/app/agent_tasks/layer2_tasks/agents/tasks_editor_agent.py api/src/app/agent_tasks/layer2_tasks/agents/tasks_validator_agent.py api/src/app/agent_tasks/layer3_config/adapters/google_exporter.py api/src/app/agent_tasks/layer3_config/agents/config_agent.py api/src/app/agent_tasks/orchestration/orch_basket_composer_agent.py api/src/app/agent_tasks/orchestration/orch_block_manager_agent.py api/src/utils/event_log.py api/src/utils/logged_agent.py api/src/app/routes/debug.py tests/contracts/test_event_log.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848fd8ff384832996dc3ea32a4c85fe