### PR TITLE
Align work page with new snapshot contract

### DIFF
--- a/web/app/baskets/[id]/work/page.tsx
+++ b/web/app/baskets/[id]/work/page.tsx
@@ -2,16 +2,17 @@
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import useSWR from "swr";
-import { apiPost, apiGet } from "@/lib/api";
-import type { Snapshot } from "@/lib/baskets/getSnapshot";
+import { apiPost } from "@/lib/api";
+import type { BasketSnapshot } from "@/lib/baskets/getSnapshot";
+import { getSnapshot } from "@/lib/baskets/getSnapshot";
 import { Button } from "@/components/ui/Button";
 import { toast } from "react-hot-toast";
 
 export default function BasketWorkPage({ params }: any) {
   const id = params.id as string;
-  const { data, error, isLoading, mutate } = useSWR<Snapshot>(
-    `/api/baskets/${id}/snapshot`,
-    apiGet
+  const { data, error, isLoading, mutate } = useSWR<BasketSnapshot>(
+    id,
+    getSnapshot
   );
 
   const runBlockifier = async () => {
@@ -27,13 +28,13 @@ export default function BasketWorkPage({ params }: any) {
   if (isLoading) return <div className="p-6">Loading…</div>;
   if (error) return <div className="p-6 text-red-600">Failed to load basket.</div>;
 
-  const raw = data?.raw_dump ?? "";
+  const raw = data?.raw_dump_body ?? "";
 
   const grouped = {
-    CONSTANT: data?.constants ?? [],
-    LOCKED: data?.locked_blocks ?? [],
-    ACCEPTED: data?.accepted_blocks ?? [],
-    PROPOSED: data?.proposed_blocks ?? [],
+    CONSTANT: data?.blocks?.filter((b) => b.state === "CONSTANT") ?? [],
+    LOCKED: data?.blocks?.filter((b) => b.state === "LOCKED") ?? [],
+    ACCEPTED: data?.blocks?.filter((b) => b.state === "ACCEPTED") ?? [],
+    PROPOSED: data?.blocks?.filter((b) => b.state === "PROPOSED") ?? [],
   };
 
   return (

--- a/web/lib/baskets/getSnapshot.ts
+++ b/web/lib/baskets/getSnapshot.ts
@@ -1,22 +1,21 @@
-import { apiGet } from '@/lib/api';
-
-export interface Block {
-  id: string;
-  content?: string;
-  semantic_type?: string;
-  state: string;
-  scope?: string;
-  canonical_value?: string;
+import { fetchWithToken } from "@/lib/fetchWithToken";
+export interface BasketSnapshot {
+  basket: { id: string; name: string | null; created_at: string };
+  raw_dump_body: string;
+  file_refs: string[];
+  blocks: {
+    id: string;
+    semantic_type: string;
+    content: string;
+    state: string;
+    scope: string | null;
+    canonical_value: string | null;
+  }[];
 }
-
-export interface Snapshot {
-  raw_dump: string;
-  accepted_blocks: Block[];
-  locked_blocks: Block[];
-  constants: Block[];
-  proposed_blocks: Block[];
-}
-
-export async function getSnapshot(basketId: string): Promise<Snapshot> {
-  return apiGet(`/api/baskets/${basketId}/snapshot`);
+export async function getSnapshot(id: string) {
+  const res = await fetchWithToken(
+    `${process.env.NEXT_PUBLIC_API_URL}/baskets/${id}/snapshot`
+  );
+  if (!res.ok) throw new Error("snapshot fetch failed");
+  return (await res.json()) as BasketSnapshot;
 }

--- a/web/tests/e2e/run_blockifier.spec.ts
+++ b/web/tests/e2e/run_blockifier.spec.ts
@@ -2,22 +2,27 @@ import { test, expect } from '@playwright/test';
 
 // Simulated snapshot responses before and after running Blockifier
 const firstSnapshot = {
-  raw_dump: '# dump',
-  accepted_blocks: [],
-  locked_blocks: [],
-  constants: [],
-  proposed_blocks: [],
+  raw_dump_body: '# dump',
+  file_refs: [],
+  blocks: [],
 };
 const secondSnapshot = {
   ...firstSnapshot,
-  proposed_blocks: [
-    { id: 'p1', content: 'hello', state: 'PROPOSED', semantic_type: 'note' },
+  blocks: [
+    {
+      id: 'p1',
+      content: 'hello',
+      state: 'PROPOSED',
+      semantic_type: 'note',
+      scope: null,
+      canonical_value: null,
+    },
   ],
 };
 
 test('run blockifier flow', async ({ page }) => {
   let snapCall = 0;
-  await page.route('**/api/baskets/test-basket/snapshot', async (route) => {
+  await page.route('**/baskets/test-basket/snapshot', async (route) => {
     snapCall += 1;
     await route.fulfill({
       status: 200,


### PR DESCRIPTION
## Summary
- fetch snapshots via new helper using `fetchWithToken`
- display snapshot data from `raw_dump_body` and `blocks`
- update e2e test to match new snapshot response structure

## Testing
- `npm run e2e:test` *(fails: fetch errors and missing resources)*

------
https://chatgpt.com/codex/tasks/task_e_685637af1f488329be9c3d9cca08d55b