### PR TITLE
Harden API_ORIGIN helper + callers

### DIFF
--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -5,10 +5,10 @@
  * Uses the Next.js rewrite from /api to the configured API base.
  */
 import { fetchWithToken } from "@/lib/fetchWithToken";
-const API_BASE = process.env.NEXT_PUBLIC_API_BASE || "";
+import { withApiOrigin } from "@/lib/apiOrigin";
 
 function withBase(path: string) {
-  return path.startsWith("/api") && API_BASE ? `${API_BASE}${path}` : path;
+  return withApiOrigin(path);
 }
 
 export async function apiGet<T = any>(path: string): Promise<T> {

--- a/web/lib/apiOrigin.ts
+++ b/web/lib/apiOrigin.ts
@@ -1,0 +1,12 @@
+export let API_ORIGIN = process.env.NEXT_PUBLIC_API_ORIGIN ?? "";
+// Runtime fallback – works in browsers only (Next.js edge / node can’t use it).
+if (!API_ORIGIN && typeof window !== "undefined") {
+  API_ORIGIN = `${window.location.protocol}//${window.location.host}`;
+}
+
+export function withApiOrigin(path: string): string {
+  if (!path.startsWith("/")) throw new Error("path must begin with /");
+  // Only prefix FastAPI routes (our whole backend lives under /api/*).
+  if (path.startsWith("/api")) return `${API_ORIGIN}${path}`;
+  return path;
+}

--- a/web/lib/baskets/createBasketNew.ts
+++ b/web/lib/baskets/createBasketNew.ts
@@ -4,17 +4,17 @@ export interface NewBasketArgs {
 }
 import { createClient } from "@/lib/supabaseClient";
 import { fetchWithToken } from "@/lib/fetchWithToken";
+import { withApiOrigin } from "@/lib/apiOrigin";
 export async function createBasketNew(
   args: NewBasketArgs,
 ): Promise<{ id: string }> {
-  const base = process.env.NEXT_PUBLIC_API_BASE_URL || '';
   const supabase = createClient();
   const { data } = await supabase.auth.getSession();
   const headers: Record<string, string> = { 'Content-Type': 'application/json' };
   const uid = data.session?.user.id;
   if (uid) headers['X-User-Id'] = uid;
   const body = { text_dump: args.text_dump, file_urls: args.file_urls ?? [] };
-  const res = await fetchWithToken(`${base}/api/baskets/new`, {
+  const res = await fetchWithToken(withApiOrigin("/api/baskets/new"), {
     method: 'POST',
     headers,
     body: JSON.stringify(body),

--- a/web/lib/baskets/getAllBaskets.ts
+++ b/web/lib/baskets/getAllBaskets.ts
@@ -1,16 +1,17 @@
 // web/lib/baskets/getAllBaskets.ts
-import { supabase } from "@/lib/supabaseClient";
+import { fetchWithToken } from "@/lib/fetchWithToken";
 import { Database } from "@/lib/dbTypes";
+import { withApiOrigin } from "@/lib/apiOrigin";
 
 export type BasketOverview =
   Database["public"]["Views"]["v_basket_overview"]["Row"];
 
 export async function getAllBaskets() {
-  const { data, error } = await supabase
-    .from("v_basket_overview")
-    .select("*")
-    .order("created_at", { ascending: false });
-
-  if (error) throw error;
-  return data as BasketOverview[];
+  // direct Supabase view – no /api prefix, so withApiOrigin() is a no-op
+  const url = withApiOrigin(
+    `${process.env.NEXT_PUBLIC_SUPABASE_URL}/rest/v1/v_basket_overview?select=*&order=created_at.desc`
+  );
+  const res = await fetchWithToken(url);
+  if (!res.ok) throw new Error("basket fetch failed");
+  return (await res.json()) as BasketOverview[];
 }

--- a/web/lib/baskets/getSnapshot.ts
+++ b/web/lib/baskets/getSnapshot.ts
@@ -1,5 +1,6 @@
 // web/lib/baskets/getSnapshot.ts
 import { fetchWithToken } from "@/lib/fetchWithToken";
+import { withApiOrigin } from "@/lib/apiOrigin";
 
 /** Shape returned by /api/baskets/{id}/snapshot */
 export interface BasketSnapshot {
@@ -20,11 +21,10 @@ export interface BasketSnapshot {
   }[];
 }
 
-const API = process.env.NEXT_PUBLIC_API_URL!;   // e.g. https://api.yarnnn.com
 const SNAPSHOT_PATH = "snapshot";               // route segment
 
 export async function getSnapshot(id: string): Promise<BasketSnapshot> {
-  const url = `${API}/api/baskets/${id}/${SNAPSHOT_PATH}`;
+  const url = withApiOrigin(`/api/baskets/${id}/${SNAPSHOT_PATH}`);
 
   const res = await fetchWithToken(url);
   if (!res.ok) {

--- a/web/lib/dumps/createDump.ts
+++ b/web/lib/dumps/createDump.ts
@@ -1,8 +1,9 @@
 import { Database } from "../dbTypes";
 import { fetchWithToken } from "@/lib/fetchWithToken";
+import { withApiOrigin } from "@/lib/apiOrigin";
 
 export async function createDump(basketId: string, text_dump: string, file_urls: string[] = []): Promise<{ raw_dump_id: string }> {
-  const res = await fetchWithToken(`${process.env.NEXT_PUBLIC_API_BASE_URL}/dumps/new`, {
+  const res = await fetchWithToken(withApiOrigin("/api/dumps/new"), {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ basket_id: basketId, text_dump, file_urls }),

--- a/web/lib/index.ts
+++ b/web/lib/index.ts
@@ -1,0 +1,1 @@
+export * from "./apiOrigin";  // <- already exported, ensures availability


### PR DESCRIPTION
## Summary
- improve API origin helper with runtime fallback
- safely prepend origin for internal FastAPI routes only
- adjust basket and dump APIs to use `withApiOrigin`
- re-export helper from `web/lib`

## Testing
- `npm run test`
- `make tests` *(fails: No solution found when resolving dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68563d9b5b988329b23c2ac448477985