### PR TITLE
Add jwt helper + unify util import

### DIFF
--- a/api/src/app/util/__init__.py
+++ b/api/src/app/util/__init__.py
@@ -1,1 +1,5 @@
 """Utility helpers for assembling snapshot views."""
+
+# Re-export helpers from legacy plural package so old imports keep working
+from ..utils.auth_helpers import verify_jwt            # type: ignore
+from ..utils.supabase_client import supabase_client    # type: ignore

--- a/api/src/app/util/jwt.py
+++ b/api/src/app/util/jwt.py
@@ -1,0 +1,19 @@
+"""Lightweight JWT helper used by FastAPI routes until we wire full auth."""
+from typing import Dict, Any
+
+
+def get_current_user(headers: Dict[str, str]) -> Dict[str, Any]:
+    """Extract user/workspace IDs from 'sb-access-token' header if present.
+
+    Returns {"user_id": str | None, "workspace_id": str | None}
+    without raising if the header is missing – routes will 401 later.
+    """
+    token = headers.get("sb-access-token")  # FastAPI sets .headers
+    if not token:
+        return {"user_id": None, "workspace_id": None}
+    # 🔒  In prod you’d verify JWT here (omitted for brevity).
+    # For now just return dummy so boot succeeds.
+    return {"user_id": "stub-user", "workspace_id": "stub-ws"}
+
+
+__all__ = ["get_current_user"]


### PR DESCRIPTION
## Summary
- add lightweight JWT helper for temporary auth stubs
- re-export verify_jwt and supabase_client from new util package

## Testing
- `ruff check api/src/app/util/jwt.py api/src/app/util/__init__.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68564c67f01c8329ba722257c3cf92a4