### PR TITLE
Align basket API contract & CORS

### DIFF
--- a/api/src/app/agent_server.py
+++ b/api/src/app/agent_server.py
@@ -103,7 +103,10 @@ async def health():  # pragma: no cover
 # Allow CORS from any origin (adjust in production)
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["https://www.yarnnn.com"],
+    allow_origins=[
+        "https://yarnnn.com",
+        "https://www.yarnnn.com",
+    ],
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/web/app/baskets/new/page.tsx
+++ b/web/app/baskets/new/page.tsx
@@ -21,7 +21,7 @@ export default function NewBasketPage() {
     setSubmitting(true);
     try {
       const { id } = await createBasketNew({
-        text,
+        text_dump: text,
         file_urls: files,
       });
       router.push(`/baskets/${id}/work`);

--- a/web/lib/baskets/createBasketNew.ts
+++ b/web/lib/baskets/createBasketNew.ts
@@ -6,7 +6,7 @@ import { withApiOrigin } from "@/lib/apiOrigin";
 /** Body accepted by /api/baskets/new (v1 mode) */
 export interface NewBasketArgs {
   /** Free-form markdown or plaintext that seeds the basket */
-  text: string;
+  text_dump: string;
   /** Optional previously-uploaded file URLs (≤ 5) */
   file_urls?: string[];
 }
@@ -24,7 +24,7 @@ export async function createBasketNew(
   if (uid) headers["X-User-Id"] = uid; // FastAPI route ignores it for now
 
   const body = JSON.stringify({
-    text: args.text,                // 🔺 was text_dump
+    text_dump: args.text_dump,
     file_urls: args.file_urls ?? [],
   });
 
@@ -39,7 +39,7 @@ export async function createBasketNew(
     throw new Error((await res.text()) || `createBasketNew failed: ${res.status}`);
   }
 
-  /* ── 4️⃣  FastAPI returns { "basket_id": "<uuid>" } ────────────────────── */
-  const { basket_id } = (await res.json()) as { basket_id: string };
-  return { id: basket_id };
+  /* ── 4️⃣  FastAPI returns { "id": "<uuid>" } ─────────────────────────────── */
+  const { id } = (await res.json()) as { id: string };
+  return { id };
 }

--- a/web/lib/baskets/getSnapshot.ts
+++ b/web/lib/baskets/getSnapshot.ts
@@ -29,5 +29,16 @@ export async function getSnapshot(id: string): Promise<BasketSnapshot> {
     const msg = await res.text();
     throw new Error(msg || `snapshot fetch failed (${res.status})`);
   }
-  return (await res.json()) as BasketSnapshot;
+  const payload = (await res.json()) as any;
+  const flatBlocks = [
+    ...(payload.accepted_blocks ?? []),
+    ...(payload.locked_blocks ?? []),
+    ...(payload.constants ?? []),
+  ];
+  return {
+    basket: payload.basket,
+    raw_dump_body: payload.raw_dump,
+    file_refs: payload.file_refs ?? [],
+    blocks: flatBlocks,
+  };
 }


### PR DESCRIPTION
## Summary
- send `text_dump` when creating baskets and expect `{id}` response
- flatten snapshot response for frontend
- allow both yarnnn.com variants for CORS

## Testing
- `npm run build` *(fails: `next` not found)*
- `ruff check api` *(fails: 71 errors)*

------
https://chatgpt.com/codex/tasks/task_e_685685e7ef84832986ab75147570ec44