### PR TITLE
Enforce frontend auth tokens

### DIFF
--- a/docs/YARNNN_FRONTEND_AUTH.md
+++ b/docs/YARNNN_FRONTEND_AUTH.md
@@ -1,0 +1,16 @@
+# Yarnnn Frontend Auth
+
+This document tracks how the web client attaches the user's session token to every API request.
+
+## Token requirement
+
+All calls to the FastAPI backend must include the Supabase access token in both the `sb-access-token` and `Authorization` headers. The helper `fetchWithToken` throws an error when the token is missing. Pages should redirect the user to `/login` when this occurs.
+
+## Utilities
+
+- **fetchWithToken** – wraps `fetch` and ensures the token is present.
+- **apiGet/apiPost/apiPut** – thin wrappers that delegate to `fetchWithToken`.
+
+## Handling failures
+
+If `fetchWithToken` throws, the caller should assume the user is signed out. Redirect to `/login` or surface a message prompting them to reauthenticate.

--- a/web/app/baskets/[id]/work/page.tsx
+++ b/web/app/baskets/[id]/work/page.tsx
@@ -7,9 +7,12 @@ import type { BasketSnapshot } from "@/lib/baskets/getSnapshot";
 import { getSnapshot } from "@/lib/baskets/getSnapshot";
 import { Button } from "@/components/ui/Button";
 import { toast } from "react-hot-toast";
+import { useRouter } from "next/navigation";
+import { isAuthError } from "@/lib/utils";
 
 export default function BasketWorkPage({ params }: any) {
   const id = params.id as string;
+  const router = useRouter();
   const { data, error, isLoading, mutate } = useSWR<BasketSnapshot>(
     id,
     getSnapshot
@@ -21,7 +24,11 @@ export default function BasketWorkPage({ params }: any) {
       toast.success("Parsing complete");
       mutate();
     } catch (err) {
-      toast.error("Failed to run Blockifier");
+      if (isAuthError(err)) {
+        router.push("/login");
+      } else {
+        toast.error("Failed to run Blockifier");
+      }
     }
   };
 

--- a/web/app/baskets/new/page.tsx
+++ b/web/app/baskets/new/page.tsx
@@ -6,6 +6,7 @@ import { UploadArea } from "@/components/baskets/UploadArea";
 import { createBasketNew } from "@/lib/baskets/createBasketNew";
 import { useRouter } from "next/navigation";
 import PageHeader from "@/components/page/PageHeader";
+import { isAuthError } from "@/lib/utils";
 
 export default function NewBasketPage() {
   const router = useRouter();
@@ -27,7 +28,11 @@ export default function NewBasketPage() {
       router.push(`/baskets/${id}/work`);
     } catch (err) {
       console.error(err);
-      alert("Failed to create basket");
+      if (isAuthError(err)) {
+        router.push("/login");
+      } else {
+        alert("Failed to create basket");
+      }
     } finally {
       setSubmitting(false);
     }

--- a/web/lib/fetchWithToken.ts
+++ b/web/lib/fetchWithToken.ts
@@ -5,8 +5,13 @@ export async function fetchWithToken(
   init: RequestInit = {}
 ) {
   const supabase = createClient();
-  const { data: { session } } = await supabase.auth.getSession();
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
   const token = session?.access_token ?? "";
+  if (!token) {
+    throw new Error("No access token found. Please log in to continue.");
+  }
   return fetch(input, {
     ...init,
     headers: {

--- a/web/lib/utils.ts
+++ b/web/lib/utils.ts
@@ -4,3 +4,7 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export function isAuthError(err: unknown): boolean {
+  return err instanceof Error && err.message.includes("No access token");
+}


### PR DESCRIPTION
## Summary
- require a Supabase session token in `fetchWithToken`
- detect missing token errors with `isAuthError`
- redirect to login when token is absent on basket pages
- document token enforcement in `docs/YARNNN_FRONTEND_AUTH.md`

## Testing
- `npm run test`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68578641c5ec8329a3185412229781a0