### PR TITLE
Patch Blockifier APIResponse handling

### DIFF
--- a/api/tests/api/test_orch_block_manager.py
+++ b/api/tests/api/test_orch_block_manager.py
@@ -26,18 +26,14 @@ def _fake_supabase(store):
                 row["id"] = str(uuid.uuid4())
             store.setdefault(name, []).append(row)
             return types.SimpleNamespace(
-                execute=lambda: types.SimpleNamespace(
-                    data=[row], status_code=200, json=lambda: {"data": [row]}
-                )
+                execute=lambda: types.SimpleNamespace(data=[row], error=None)
             )
 
         def select(_cols="*"):
             def eq(col: str, val: str):
                 items = [r for r in store.get(name, []) if r.get(col) == val]
                 return types.SimpleNamespace(
-                    execute=lambda: types.SimpleNamespace(
-                        data=items, status_code=200, json=lambda: {"data": items}
-                    )
+                    execute=lambda: types.SimpleNamespace(data=items, error=None)
                 )
 
             return types.SimpleNamespace(eq=eq)
@@ -55,7 +51,7 @@ def test_run_blockifier(monkeypatch):
 
     basket_id = str(uuid.uuid4())
     dump_id = str(uuid.uuid4())
-    store["baskets"].append({"id": basket_id, "raw_dump_id": dump_id})
+    store["baskets"].append({"id": basket_id, "raw_dump_id": dump_id, "workspace_id": "ws1"})
     store["raw_dumps"].append({"id": dump_id, "basket_id": basket_id, "body_md": "d"})
 
     resp = client.post("/api/agents/orch_block_manager/run", json={"basket_id": basket_id})

--- a/tests/agent_tasks/test_agent_scaffold.py
+++ b/tests/agent_tasks/test_agent_scaffold.py
@@ -11,9 +11,9 @@ from fastapi.testclient import TestClient
 
 
 class StubResponse:
-    def __init__(self, data, status_code=200):
+    def __init__(self, data, error=None):
         self.data = data
-        self.status_code = status_code
+        self.error = error
 
     def json(self):  # pragma: no cover - simple stub
         return {"data": self.data}
@@ -42,7 +42,7 @@ class StubTable:
         rows = self.records.get(self.name, [])
         for col, val in self.filters.items():
             rows = [r for r in rows if r.get(col) == val]
-        return StubResponse(rows, self.status_code)
+        return StubResponse(rows)
 
 
 class StubClient:

--- a/tests/api/agents/test_orch_block_manager.py
+++ b/tests/api/agents/test_orch_block_manager.py
@@ -46,7 +46,7 @@ def test_run_agent_inserts_block(monkeypatch):
 
     basket_id = str(uuid4())
     dump_id = str(uuid4())
-    records["baskets"] = [{"id": basket_id, "raw_dump_id": dump_id}]
+    records["baskets"] = [{"id": basket_id, "raw_dump_id": dump_id, "workspace_id": "ws1"}]
     records["raw_dumps"] = [{"id": dump_id, "basket_id": basket_id, "body_md": "d"}]
 
     resp = client.post("/api/agents/orch_block_manager/run", json={"basket_id": basket_id})


### PR DESCRIPTION
## Summary
- handle Supabase errors using `.error` in block manager agent
- adjust stub responses in tests for new behavior
- cover error path with updated unit tests

## Testing
- `pytest tests/agent_tasks/test_orch_block_manager_agent.py tests/api/agents/test_orch_block_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_6857935998d48329b76bb2c97d452140