### PR TITLE
Fix Supabase response handling in Blockifier

### DIFF
--- a/tests/agent_tasks/test_orch_block_manager_agent.py
+++ b/tests/agent_tasks/test_orch_block_manager_agent.py
@@ -84,7 +84,7 @@ def test_run_raises_on_error(monkeypatch):
                         (),
                         {
                             "data": [{"workspace_id": "ws1"}],
-                            "error": None,
+                            "status_code": 200,
                         },
                     )()
                 return type(
@@ -92,7 +92,7 @@ def test_run_raises_on_error(monkeypatch):
                     (),
                     {
                         "data": [],
-                        "error": "bad",
+                        "status_code": 500,
                     },
                 )()
 


### PR DESCRIPTION
## Summary
- check Supabase insert responses via `status_code` and `data`
- log warning when inserts fail
- adapt agent scaffold tests for new response objects
- ensure error test uses new failure conditions

## Testing
- `pytest tests/agent_tasks/test_orch_block_manager_agent.py tests/agent_tasks/test_agent_scaffold.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6857970d03ac8329a0e27619600207c7