### PR TITLE
Refactor server Supabase usage

### DIFF
--- a/web/app/baskets/[id]/work/BasketWorkClient.tsx
+++ b/web/app/baskets/[id]/work/BasketWorkClient.tsx
@@ -10,6 +10,7 @@ import { useRouter } from "next/navigation";
 import { isAuthError } from "@/lib/utils";
 import type { BasketSnapshot } from "@/lib/baskets/getSnapshot";
 import { getSnapshot } from "@/lib/baskets/getSnapshot";
+import { createBrowserSupabaseClient } from "@/lib/supabaseClient";
 
 export interface Props {
   id: string;
@@ -18,10 +19,11 @@ export interface Props {
 
 export default function BasketWorkClient({ id, initialData }: Props) {
   const router = useRouter();
+  const supabase = createBrowserSupabaseClient();
 
   const { data, error, isLoading, mutate } = useSWR<BasketSnapshot>(
     id,
-    getSnapshot,
+    () => getSnapshot(supabase, id),
     { fallbackData: initialData }
   );
 

--- a/web/app/baskets/[id]/work/page.tsx
+++ b/web/app/baskets/[id]/work/page.tsx
@@ -1,6 +1,8 @@
 // web/app/baskets/[id]/work/page.tsx
 import { getSnapshot } from "@/lib/baskets/getSnapshot";
+import { cookies } from "next/headers";
 import BasketWorkClient from "./BasketWorkClient";
+import { createServerSupabaseClient } from "@/lib/supabaseClient";
 
 // Match Next 15's PageProps expectation: `params` is a Promise.
 interface PageProps {
@@ -11,8 +13,17 @@ export default async function BasketWorkPage({ params }: PageProps) {
   // Unwrap the promise that Next hands us
   const { id } = await params;
 
+  const supabase = createServerSupabaseClient(cookies());
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+  const token = session?.access_token;
+  if (!token) {
+    return <div className="p-6 text-red-600">Not authenticated</div>;
+  }
+
   // 1st-paint / SEO fetch
-  const initialData = await getSnapshot(id);
+  const initialData = await getSnapshot(supabase, id);
 
   return <BasketWorkClient id={id} initialData={initialData} />;
 }

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -11,8 +11,8 @@ export function apiUrl(path: string) {
   return `${API_BASE_URL}${path}`;
 }
 
-export async function apiGet<T = any>(path: string): Promise<T> {
-  const res = await fetchWithToken(apiUrl(path));
+export async function apiGet<T = any>(path: string, token?: string): Promise<T> {
+  const res = await fetchWithToken(apiUrl(path), {}, token);
   if (!res.ok) {
     console.warn(`[apiGet] Non-OK response (${res.status}) for ${path}`);
     throw new Error(`API error: ${res.status}`);
@@ -29,12 +29,20 @@ export async function apiGet<T = any>(path: string): Promise<T> {
   }
 }
 
-export async function apiPost<T = any>(path: string, body: any): Promise<T> {
-  const res = await fetchWithToken(apiUrl(path), {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(body),
-  });
+export async function apiPost<T = any>(
+  path: string,
+  body: any,
+  token?: string,
+): Promise<T> {
+  const res = await fetchWithToken(
+    apiUrl(path),
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    },
+    token,
+  );
   if (!res.ok) {
     const text = await res.text();
     throw new Error(text || `apiPost ${path} failed with status ${res.status}`);
@@ -42,12 +50,20 @@ export async function apiPost<T = any>(path: string, body: any): Promise<T> {
   return (await res.json()) as T;
 }
 
-export async function apiPut<T = any>(path: string, body: any): Promise<T> {
-  const res = await fetchWithToken(apiUrl(path), {
-    method: "PUT",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(body),
-  });
+export async function apiPut<T = any>(
+  path: string,
+  body: any,
+  token?: string,
+): Promise<T> {
+  const res = await fetchWithToken(
+    apiUrl(path),
+    {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    },
+    token,
+  );
   if (!res.ok) {
     const text = await res.text();
     throw new Error(text || `apiPut ${path} failed with status ${res.status}`);

--- a/web/lib/baskets/getSnapshot.ts
+++ b/web/lib/baskets/getSnapshot.ts
@@ -1,5 +1,7 @@
 // web/lib/baskets/getSnapshot.ts
 import { apiGet } from "@/lib/api";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@/lib/dbTypes";
 
 /** Shape returned by /api/baskets/{id}/snapshot */
 export interface BasketSnapshot {
@@ -22,8 +24,15 @@ export interface BasketSnapshot {
 
 const SNAPSHOT_PREFIX = "/api/baskets/snapshot";
 
-export async function getSnapshot(id: string): Promise<BasketSnapshot> {
-  const res = await apiGet<any>(`${SNAPSHOT_PREFIX}/${id}`);
+export async function getSnapshot(
+  supabase: SupabaseClient<Database>,
+  id: string,
+): Promise<BasketSnapshot> {
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+  const token = session?.access_token ?? "";
+  const res = await apiGet<any>(`${SNAPSHOT_PREFIX}/${id}`, token);
   const payload = res as any;
   const flatBlocks = [
     ...(payload.accepted_blocks ?? []),

--- a/web/lib/fetchWithToken.ts
+++ b/web/lib/fetchWithToken.ts
@@ -2,22 +2,26 @@ import { createClient } from "@/lib/supabaseClient";
 
 export async function fetchWithToken(
   input: RequestInfo | URL,
-  init: RequestInit = {}
+  init: RequestInit = {},
+  token?: string,
 ) {
-  const supabase = createClient();
-  const {
-    data: { session },
-  } = await supabase.auth.getSession();
-  const token = session?.access_token ?? "";
-  if (!token) {
+  let jwt = token;
+  if (!jwt) {
+    const supabase = createClient();
+    const {
+      data: { session },
+    } = await supabase.auth.getSession();
+    jwt = session?.access_token ?? "";
+  }
+  if (!jwt) {
     throw new Error("No access token found. Please log in to continue.");
   }
   return fetch(input, {
     ...init,
     headers: {
       ...(init.headers || {}),
-      "sb-access-token": token,
-      Authorization: `Bearer ${token}`,
+      "sb-access-token": jwt,
+      Authorization: `Bearer ${jwt}`,
       apikey: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
       "Content-Type": "application/json",
     },

--- a/web/lib/supabaseClient.ts
+++ b/web/lib/supabaseClient.ts
@@ -1,14 +1,28 @@
 //web/lib/supabaseClient.ts
+import { createServerClient } from "@supabase/ssr";
 import { createPagesBrowserClient } from "@supabase/auth-helpers-nextjs";
 import type { SupabaseClient } from "@supabase/supabase-js";
+import type { ReadonlyRequestCookies } from "next/dist/server/web/spec-extension/adapters/request-cookies";
 import type { Database } from "./dbTypes";
 
 /**
  * “Factory” in case you ever need a fresh client
  * (e.g. inside server components or tests).
  */
-export const createClient = (): SupabaseClient<Database> =>
+export const createServerSupabaseClient = (
+  cookies: ReadonlyRequestCookies | Headers,
+): SupabaseClient<Database> =>
+  createServerClient<Database>(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    { cookies },
+  );
+
+export const createBrowserSupabaseClient = (): SupabaseClient<Database> =>
   createPagesBrowserClient<Database>();
+
+// Legacy alias used throughout the codebase
+export const createClient = createBrowserSupabaseClient;
 
 /**
  * Shared browser-side client for the whole app.


### PR DESCRIPTION
## Summary
- add server/browser Supabase client helpers
- support custom token in fetchWithToken and api helpers
- update BasketWork components to use server Supabase client
- inject Supabase instance into getSnapshot

## Testing
- `npm test`
- `make tests` *(fails: no solution found when resolving dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6858d226d43c832981c55d264e97dbfc