### PR TITLE
Refactor to use block_revisions table

### DIFF
--- a/api/src/app/agent_tasks/layer1_infra/agents/infra_research_agent.py
+++ b/api/src/app/agent_tasks/layer1_infra/agents/infra_research_agent.py
@@ -8,8 +8,7 @@ from schemas.validators import validates
 from src.app.agent_tasks.layer1_infra.utils.block_policy import insert_revision, is_auto
 from src.utils.logged_agent import logged
 
-from app.event_bus import DATABASE_URL
-from app.event_bus import publish_event
+from app.event_bus import DATABASE_URL, publish_event
 
 from ..schemas import RefreshReport
 
@@ -46,10 +45,8 @@ async def run(_: ResearchIn) -> ResearchOut:
                 await insert_revision(
                     conn,
                     bid,
-                    prev_content="<unchanged>",
-                    new_content="<auto-refresh>",
-                    changed_by="agent:infra_research",
-                    proposal_event={"reason": "auto-refresh"},
+                    diff_json={"prev": "<unchanged>", "new": "<auto-refresh>"},
+                    summary="auto refresh",
                 )
                 refreshed.append(bid)
             else:

--- a/api/src/app/agent_tasks/layer1_infra/utils/block_policy.py
+++ b/api/src/app/agent_tasks/layer1_infra/utils/block_policy.py
@@ -14,20 +14,27 @@ async def is_auto(conn: asyncpg.Connection, block_id: str) -> bool:
 async def insert_revision(
     conn: asyncpg.Connection,
     block_id: str,
-    prev_content: str,
-    new_content: str,
-    changed_by: str,
-    proposal_event: dict,
+    *,
+    diff_json: dict,
+    summary: str,
+    actor_id: str | None = None,
+    workspace_id: str | None = None,
 ) -> None:
+    if workspace_id is None:
+        row = await conn.fetchrow(
+            "select workspace_id from public.blocks where id=$1",
+            block_id,
+        )
+        workspace_id = row["workspace_id"] if row else None
     await conn.execute(
         """
         insert into public.block_revisions
-          (block_id, prev_content, new_content, changed_by, proposal_event)
+          (block_id, workspace_id, actor_id, summary, diff_json)
         values ($1, $2, $3, $4, $5::jsonb)
         """,
         block_id,
-        prev_content,
-        new_content,
-        changed_by,
-        proposal_event,
+        workspace_id,
+        actor_id,
+        summary,
+        diff_json,
     )

--- a/api/src/app/agent_tasks/orch/orch_block_manager_agent.py
+++ b/api/src/app/agent_tasks/orch/orch_block_manager_agent.py
@@ -1,10 +1,9 @@
+import logging
 from typing import Any
 from uuid import UUID, uuid4
 
-import logging
 from fastapi import HTTPException
 from postgrest.exceptions import APIError
-
 from src.utils.db import json_safe
 
 from app.utils.supabase_client import supabase_client as supabase
@@ -37,10 +36,10 @@ def run(basket_id: UUID) -> dict[str, Any]:
     }
     try:
         res = supabase.table("blocks").insert(json_safe(block_payload)).execute()
-    except APIError as err:
+    except APIError:
         log.exception("block insert API error for basket %s", basket_id)
         raise
-    except Exception as err:  # noqa: BLE001
+    except Exception:  # noqa: BLE001
         log.exception("block insert failed for basket %s", basket_id)
         raise
     if getattr(res, "status_code", 200) >= 400 or not res.data:
@@ -50,25 +49,24 @@ def run(basket_id: UUID) -> dict[str, Any]:
     rev_payload = {
         "block_id": block_id,
         "workspace_id": workspace_id,
-        "prev_content": None,
-        "new_content": "pending proposal",
-        "changed_by": "orch_block_manager_agent",
-        "proposal_event": {},
+        "actor_id": None,
+        "summary": "orch block proposed",
+        "diff_json": {"new_content": "pending proposal"},
     }
     try:
-        res = (
-            supabase.table("block_revisions")
-            .insert(json_safe(rev_payload))
-            .execute()
-        )
+        res = supabase.table("block_revisions").insert(json_safe(rev_payload)).execute()
     except APIError as err:
-        log.exception("revision insert API error for basket %s", basket_id)
-        raise
+        log.error(
+            "revision insert API error for basket %s: %s",
+            basket_id,
+            getattr(err, "message", str(err)),
+        )
+        raise HTTPException(status_code=500, detail="Supabase insert failed") from err
     except Exception as err:  # noqa: BLE001
         log.exception("revision insert failed for basket %s", basket_id)
-        raise
+        raise HTTPException(status_code=500, detail="Supabase insert failed") from err
     if getattr(res, "status_code", 200) >= 400 or not res.data:
-        log.warning("Supabase insert failed", extra=rev_payload)
+        log.warning("Supabase insert failed for block_revisions: %s", res.data)
         raise HTTPException(status_code=500, detail="Supabase insert failed")
 
     event_payload = {
@@ -79,15 +77,11 @@ def run(basket_id: UUID) -> dict[str, Any]:
         "payload": {},
     }
     try:
-        res = (
-            supabase.table("events")
-            .insert(json_safe(event_payload))
-            .execute()
-        )
-    except APIError as err:
+        res = supabase.table("events").insert(json_safe(event_payload)).execute()
+    except APIError:
         log.exception("event insert API error for basket %s", basket_id)
         raise
-    except Exception as err:  # noqa: BLE001
+    except Exception:  # noqa: BLE001
         log.exception("event insert failed for basket %s", basket_id)
         raise
     if getattr(res, "status_code", 200) >= 400 or not res.data:

--- a/tests/agent_tasks/test_agent_scaffold.py
+++ b/tests/agent_tasks/test_agent_scaffold.py
@@ -69,6 +69,7 @@ def _setup_supabase(monkeypatch):
 def test_orch_run_creates_block_and_revision(monkeypatch):
     records = _setup_supabase(monkeypatch)
     from pathlib import Path
+
     bid = uuid4()
     records["baskets"] = [{"id": str(bid), "workspace_id": "ws"}]
 
@@ -89,6 +90,8 @@ def test_orch_run_creates_block_and_revision(monkeypatch):
     assert "blocks" in records
     assert "block_revisions" in records
     assert records["blocks"][0]["state"] == "PROPOSED"
+    assert "summary" in records["block_revisions"][0]
+    assert "diff_json" in records["block_revisions"][0]
 
 
 def test_infra_route_ok(monkeypatch):

--- a/tests/agent_tasks/test_orch_block_manager_agent.py
+++ b/tests/agent_tasks/test_orch_block_manager_agent.py
@@ -4,6 +4,7 @@ from uuid import uuid4
 
 import pytest
 from fastapi import HTTPException
+
 from tests.agent_tasks.test_agent_scaffold import _setup_supabase
 
 
@@ -40,14 +41,14 @@ def test_run_proposes_block(monkeypatch):
     assert records["blocks"][0]["state"] == "PROPOSED"
     assert records["blocks"][0]["workspace_id"] == "ws1"
     assert records["events"][0]["workspace_id"] == "ws1"
+    assert "summary" in records["block_revisions"][0]
+    assert "diff_json" in records["block_revisions"][0]
 
 
 def test_run_raises_on_error(monkeypatch):
     records = _setup_supabase(monkeypatch)
     basket_id = uuid4()
-    records["baskets"] = [
-        {"id": str(basket_id), "workspace_id": "ws1"}
-    ]
+    records["baskets"] = [{"id": str(basket_id), "workspace_id": "ws1"}]
 
     spec = importlib.util.spec_from_file_location(
         "orch_block_manager_agent",
@@ -101,4 +102,3 @@ def test_run_raises_on_error(monkeypatch):
     monkeypatch.setattr(module, "supabase", type("S", (), {"table": bad_table}))
     with pytest.raises(HTTPException):
         module.run(basket_id)
-


### PR DESCRIPTION
## Summary
- insert proposed block revisions using `block_revisions` table
- refactor infra utils to write new diff payload
- adjust research agent revision insert
- test scaffolds now check revision fields

## Testing
- `npm run test`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'asyncpg')*
- `make tests` *(fails: dependency resolution unsatisfied)*

------
https://chatgpt.com/codex/tasks/task_e_6858f6c578ac83299aeb2aa572a73956