### PR TITLE
Add proposed blocks to snapshot API

### DIFF
--- a/api/src/app/routes/basket_snapshot.py
+++ b/api/src/app/routes/basket_snapshot.py
@@ -61,7 +61,7 @@ def get_basket_snapshot(basket_id: str) -> dict:
                 "id, semantic_type, content, state, scope, canonical_value"
             )
             .eq("basket_id", basket_id)
-            .in_("state", ["CONSTANT", "LOCKED", "ACCEPTED"])
+            .in_("state", ["CONSTANT", "LOCKED", "ACCEPTED", "PROPOSED"])
             .execute()
         )
         blocks = blocks_res.data or []

--- a/api/src/app/utils/snapshot_assembler.py
+++ b/api/src/app/utils/snapshot_assembler.py
@@ -17,6 +17,7 @@ def assemble_snapshot(
         "constants": [b for b in blocks if b.get("state") == "CONSTANT"],
         "locked_blocks": [b for b in blocks if b.get("state") == "LOCKED"],
         "accepted_blocks": [b for b in blocks if b.get("state") == "ACCEPTED"],
+        "proposed_blocks": [b for b in blocks if b.get("state") == "PROPOSED"],
     }
 
     return {"raw_dump": latest["body_md"], **grouped}

--- a/api/tests/api/test_basket_snapshot.py
+++ b/api/tests/api/test_basket_snapshot.py
@@ -45,6 +45,7 @@ def test_snapshot_empty(monkeypatch):
         "accepted_blocks": [],
         "locked_blocks": [],
         "constants": [],
+        "proposed_blocks": [],
     }
 
 
@@ -65,3 +66,4 @@ def test_snapshot_filters(monkeypatch):
     assert body["raw_dump"] == "d"
     assert len(body["accepted_blocks"]) == 1
     assert len(body["locked_blocks"]) == 1
+    assert len(body["proposed_blocks"]) == 1

--- a/api/tests/util/test_snapshot_assembler.py
+++ b/api/tests/util/test_snapshot_assembler.py
@@ -12,5 +12,6 @@ def test_assemble_filters_states():
     snap = assemble_snapshot(raw, blocks)
     assert len(snap["accepted_blocks"]) == 1
     assert len(snap["locked_blocks"]) == 1
+    assert len(snap["proposed_blocks"]) == 1
     assert len(snap["constants"]) == 1
     assert snap["raw_dump"] == "a"

--- a/web/lib/baskets/getSnapshot.ts
+++ b/web/lib/baskets/getSnapshot.ts
@@ -34,10 +34,11 @@ export async function getSnapshot(
   const token = session?.access_token ?? "";
   const res = await apiGet<any>(`${SNAPSHOT_PREFIX}/${id}`, token);
   const payload = res as any;
-  const flatBlocks = [
+const flatBlocks = [
     ...(payload.accepted_blocks ?? []),
     ...(payload.locked_blocks ?? []),
     ...(payload.constants ?? []),
+    ...(payload.proposed_blocks ?? []),
   ];
   return {
     basket: payload.basket,


### PR DESCRIPTION
## Summary
- include PROPOSED blocks in snapshot grouping logic
- extend snapshot route query to return PROPOSED blocks
- update frontend getter to flatten proposed blocks into block list
- adjust snapshot tests for new proposed block support

## Testing
- `make tests` *(fails: No solution found when resolving dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68590da72c3083299a54fa6c0c1c0307