### PR TITLE
Use mock snapshot for dev page

### DIFF
--- a/web/app/baskets/[id]/work-dev/page.tsx
+++ b/web/app/baskets/[id]/work-dev/page.tsx
@@ -1,7 +1,7 @@
-import { getSnapshot } from "@/lib/baskets/getSnapshot";
 import WorkbenchLayoutDev from "@/components/workbench/WorkbenchLayoutDev";
 import { redirect } from "next/navigation";
 import { createServerSupabaseClient } from "@/lib/supabaseServerClient";
+import { MOCK_SNAPSHOT } from "@/lib/baskets/mockSnapshot";
 
 // Match Next 15's PageProps expectation: `params` is a Promise.
 interface PageProps {
@@ -28,7 +28,8 @@ export default async function BasketWorkDevPage({ params }: PageProps) {
   }
 
   // 1st-paint / SEO fetch
-  const initialSnapshot = await getSnapshot(supabase, id);
+  // Use the mocked snapshot data for early development.
+  const initialSnapshot = MOCK_SNAPSHOT;
 
   return <WorkbenchLayoutDev initialSnapshot={initialSnapshot} />;
 }

--- a/web/components/basket/NarrativePane.tsx
+++ b/web/components/basket/NarrativePane.tsx
@@ -3,9 +3,7 @@
 import { useMemo } from "react";
 import { Badge } from "@/components/ui/Badge";
 import { cn } from "@/lib/utils";
-import type { BasketSnapshot } from "@/lib/baskets/getSnapshot";
-
-export type Block = BasketSnapshot["blocks"][number];
+import type { Block } from "@/types/block";
 
 interface Props {
   rawText: string;

--- a/web/components/basket/NarrativePane.tsx
+++ b/web/components/basket/NarrativePane.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useMemo } from "react";
+import { Badge } from "@/components/ui/Badge";
+import { cn } from "@/lib/utils";
+import type { BasketSnapshot } from "@/lib/baskets/getSnapshot";
+
+export type Block = BasketSnapshot["blocks"][number];
+
+interface Props {
+  rawText: string;
+  blocks: Block[];
+  onSelectBlock?: (id: string) => void;
+}
+
+function BlockBadge({ block, onClick }: { block: Block; onClick?: () => void }) {
+  const styleMap: Record<string, string> = {
+    PROPOSED: "border border-border text-muted-foreground",
+    ACCEPTED: "bg-primary text-primary-foreground",
+    LOCKED: "border border-border text-muted-foreground",
+    CONSTANT: "bg-yellow-200 text-yellow-900",
+  };
+  const iconMap: Record<string, string> = {
+    PROPOSED: "⬜",
+    ACCEPTED: "■",
+    LOCKED: "🔒",
+    CONSTANT: "✦",
+  };
+  return (
+    <span className="relative group cursor-pointer" onClick={onClick}>
+      <Badge
+        variant="secondary"
+        className={cn("px-1 py-0.5", styleMap[block.state])}
+      >
+        {iconMap[block.state]} {block.canonical_value}
+      </Badge>
+      <span className="absolute z-10 hidden group-hover:block bg-popover text-popover-foreground border border-border text-xs rounded-md p-2 whitespace-nowrap shadow-md left-1/2 -translate-x-1/2 mt-1">
+        <div>
+          <strong>{block.semantic_type}</strong>
+        </div>
+        <div className="capitalize">{block.state.toLowerCase()}</div>
+        {block.actor && <div>by {block.actor}</div>}
+        {block.created_at && (
+          <div>{new Date(block.created_at).toLocaleString()}</div>
+        )}
+      </span>
+    </span>
+  );
+}
+
+export default function NarrativePane({ rawText, blocks, onSelectBlock }: Props) {
+  const content = useMemo(() => {
+    const ranges: { start: number; end: number; block: Block }[] = [];
+    blocks.forEach((blk) => {
+      if (!blk.canonical_value) return;
+      const idx = rawText.indexOf(blk.canonical_value);
+      if (idx === -1) return;
+      if (ranges.some((r) => idx < r.end && idx + blk.canonical_value!.length > r.start)) {
+        return;
+      }
+      ranges.push({ start: idx, end: idx + blk.canonical_value.length, block: blk });
+    });
+    ranges.sort((a, b) => a.start - b.start);
+
+    const segs: React.ReactNode[] = [];
+    let last = 0;
+    ranges.forEach((r) => {
+      if (last < r.start) segs.push(rawText.slice(last, r.start));
+      segs.push(
+        <BlockBadge key={r.block.id} block={r.block} onClick={() => onSelectBlock?.(r.block.id)} />
+      );
+      last = r.end;
+    });
+    if (last < rawText.length) segs.push(rawText.slice(last));
+    return segs;
+  }, [rawText, blocks, onSelectBlock]);
+
+  return <div className="whitespace-pre-wrap text-sm leading-6 space-y-2">{content}</div>;
+}
+

--- a/web/components/workbench/WorkbenchLayoutDev.tsx
+++ b/web/components/workbench/WorkbenchLayoutDev.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { ReactNode } from "react";
 import BasketHeader from "@/components/basket/BasketHeader";
+import NarrativePane from "@/components/basket/NarrativePane";
 
 interface Props {
   initialSnapshot: any;
@@ -18,6 +19,11 @@ export default function WorkbenchLayoutDev({ initialSnapshot, children }: Props)
         basketName={initialSnapshot.basket?.name || "Untitled Basket"}
         status="DRAFT"
         scope={scopes}
+      />
+      <NarrativePane
+        rawText={initialSnapshot.raw_dump_body}
+        blocks={initialSnapshot.blocks || []}
+        onSelectBlock={(id) => console.log("select", id)}
       />
       {children}
     </div>

--- a/web/lib/baskets/getSnapshot.ts
+++ b/web/lib/baskets/getSnapshot.ts
@@ -2,6 +2,7 @@
 import { apiGet } from "@/lib/api";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@/lib/dbTypes";
+import type { Block } from "@/types/block";
 
 /** Shape returned by /api/baskets/{id}/snapshot */
 export interface BasketSnapshot {
@@ -12,14 +13,7 @@ export interface BasketSnapshot {
   };
   raw_dump_body: string;
   file_refs: string[];
-  blocks: {
-    id: string;
-    semantic_type: string;
-    content: string;
-    state: string;
-    scope: string | null;
-    canonical_value: string | null;
-  }[];
+  blocks: Block[];
 }
 
 const SNAPSHOT_PREFIX = "/api/baskets/snapshot";

--- a/web/lib/baskets/mockSnapshot.ts
+++ b/web/lib/baskets/mockSnapshot.ts
@@ -1,0 +1,43 @@
+export const MOCK_SNAPSHOT = {
+  basket: {
+    id: "f5d0cfdd-48f8-410d-8c92-3aaa4508165a",
+    name: "AI Launch Campaign",
+    status: "ACTIVE",
+    scope: ["workspace-wide"],
+  },
+  raw_dump_body: `
+Our brand voice is playful but never unprofessional.
+We target young entrepreneurs who value speed and transparency.
+Content should feel like a helpful peer, not a corporation.
+  `.trim(),
+  blocks: [
+    {
+      id: "b1",
+      canonical_value: "playful but never unprofessional",
+      semantic_type: "tone",
+      state: "PROPOSED",
+      created_at: "2025-06-25T12:00:00Z",
+    },
+    {
+      id: "b2",
+      canonical_value: "young entrepreneurs",
+      semantic_type: "audience",
+      state: "ACCEPTED",
+      created_at: "2025-06-24T09:12:00Z",
+    },
+    {
+      id: "b3",
+      canonical_value: "helpful peer",
+      semantic_type: "voice",
+      state: "LOCKED",
+      created_at: "2025-06-23T15:40:00Z",
+    },
+    {
+      id: "b4",
+      canonical_value: "transparency",
+      semantic_type: "value",
+      state: "CONSTANT",
+      created_at: "2025-06-22T08:30:00Z",
+    },
+  ],
+} as const;

--- a/web/lib/baskets/mockSnapshot.ts
+++ b/web/lib/baskets/mockSnapshot.ts
@@ -17,6 +17,7 @@ Content should feel like a helpful peer, not a corporation.
       semantic_type: "tone",
       state: "PROPOSED",
       created_at: "2025-06-25T12:00:00Z",
+      actor: "alice",
     },
     {
       id: "b2",
@@ -24,6 +25,7 @@ Content should feel like a helpful peer, not a corporation.
       semantic_type: "audience",
       state: "ACCEPTED",
       created_at: "2025-06-24T09:12:00Z",
+      actor: "bob",
     },
     {
       id: "b3",
@@ -31,6 +33,7 @@ Content should feel like a helpful peer, not a corporation.
       semantic_type: "voice",
       state: "LOCKED",
       created_at: "2025-06-23T15:40:00Z",
+      actor: "carol",
     },
     {
       id: "b4",
@@ -38,6 +41,7 @@ Content should feel like a helpful peer, not a corporation.
       semantic_type: "value",
       state: "CONSTANT",
       created_at: "2025-06-22T08:30:00Z",
+      actor: "dave",
     },
   ],
 } as const;

--- a/web/types/block.ts
+++ b/web/types/block.ts
@@ -1,0 +1,10 @@
+export type Block = {
+  id: string;
+  semantic_type: string;
+  content: string;
+  state: string;
+  scope: string | null;
+  canonical_value: string | null;
+  actor?: string;
+  created_at?: string;
+};


### PR DESCRIPTION
## Summary
- include a mock snapshot fixture for early development
- wire the work-dev route to use the mock snapshot

## Testing
- `npm run test`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'asyncpg')*

------
https://chatgpt.com/codex/tasks/task_e_685f2e3254548329b450b0b368769d9a