### PR TITLE
Add right panel blocks pane

### DIFF
--- a/web/app/baskets/[id]/work-dev/layout.tsx
+++ b/web/app/baskets/[id]/work-dev/layout.tsx
@@ -1,0 +1,5 @@
+import Shell from "@/components/layouts/Shell";
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <Shell collapseSidebar>{children}</Shell>;
+}

--- a/web/app/baskets/[id]/work-dev/page.tsx
+++ b/web/app/baskets/[id]/work-dev/page.tsx
@@ -1,6 +1,8 @@
 import WorkbenchLayoutDev from "@/components/workbench/WorkbenchLayoutDev";
 import { redirect } from "next/navigation";
 import { MOCK_SNAPSHOT } from "@/lib/baskets/mockSnapshot";
+import BlocksPane from "@/components/blocks/BlocksPane";
+import { DEV_MOCK_BLOCKS } from "@/lib/blocks/dev_mock_blocks";
 
 // Match Next 15's PageProps expectation: `params` is a Promise.
 interface PageProps {
@@ -17,5 +19,14 @@ export default async function BasketWorkDevPage({ params }: PageProps) {
   // 🚧 Skip Supabase auth + server fetch — use mock directly
   const initialSnapshot = MOCK_SNAPSHOT;
 
-  return <WorkbenchLayoutDev initialSnapshot={initialSnapshot} />;
+  return (
+    <WorkbenchLayoutDev
+      initialSnapshot={initialSnapshot}
+      rightPanel={
+        <div className="right-panel">
+          <BlocksPane blocks={DEV_MOCK_BLOCKS} />
+        </div>
+      }
+    />
+  );
 }

--- a/web/app/baskets/[id]/work/BasketWorkClient.tsx
+++ b/web/app/baskets/[id]/work/BasketWorkClient.tsx
@@ -9,14 +9,16 @@ import type { BasketSnapshot } from "@/lib/baskets/getSnapshot";
 import { getSnapshot } from "@/lib/baskets/getSnapshot";
 import { createBrowserSupabaseClient } from "@/lib/supabaseClient";
 import WorkbenchLayout from "@/components/workbench/WorkbenchLayout";
+import { RightPanelSkeleton } from "@/components/layout/RightPanel";
 import { useState } from "react";
 
 export interface Props {
     id: string;
     initialData: BasketSnapshot;
+    rightPanel?: React.ReactNode;
 }
 
-export default function BasketWorkClient({ id, initialData }: Props) {
+export default function BasketWorkClient({ id, initialData, rightPanel }: Props) {
     const router = useRouter();
     const supabase = createBrowserSupabaseClient();
     const [running, setRunning] = useState(false);
@@ -54,6 +56,7 @@ export default function BasketWorkClient({ id, initialData }: Props) {
             onRunBlockifier={runBlockifier}
             runningBlockifier={running}
             onSelectBlock={(bid) => console.log("select", bid)}
+            rightPanel={rightPanel || <RightPanelSkeleton />}
         />
     );
 }

--- a/web/app/baskets/[id]/work/layout.tsx
+++ b/web/app/baskets/[id]/work/layout.tsx
@@ -1,0 +1,5 @@
+import Shell from "@/components/layouts/Shell";
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <Shell collapseSidebar>{children}</Shell>;
+}

--- a/web/app/baskets/[id]/work/page.tsx
+++ b/web/app/baskets/[id]/work/page.tsx
@@ -1,5 +1,6 @@
 import { getSnapshot } from "@/lib/baskets/getSnapshot";
 import BasketWorkClient from "./BasketWorkClient";
+import BlocksPane from "@/components/blocks/BlocksPane";
 import { createServerSupabaseClient } from "@/lib/supabaseServerClient";
 import { cookies } from "next/headers";
 
@@ -27,5 +28,15 @@ export default async function BasketWorkPage({ params }: PageProps) {
   // 1st-paint / SEO fetch
   const initialData = await getSnapshot(supabase, id);
 
-  return <BasketWorkClient id={id} initialData={initialData} />;
+  return (
+    <BasketWorkClient
+      id={id}
+      initialData={initialData}
+      rightPanel={
+        <div className="right-panel">
+          <BlocksPane blocks={initialData.proposed_blocks} />
+        </div>
+      }
+    />
+  );
 }

--- a/web/app/components/layout/Sidebar.tsx
+++ b/web/app/components/layout/Sidebar.tsx
@@ -18,9 +18,10 @@ const baseItems = [
 interface SidebarProps {
   open: boolean;
   onClose: () => void;
+  collapsible?: boolean;
 }
 
-const Sidebar = ({ open, onClose }: SidebarProps) => {
+const Sidebar = ({ open, onClose, collapsible = false }: SidebarProps) => {
   const pathname = usePathname();
   const router = useRouter();
   const [userEmail, setUserEmail] = useState<string | null>(null);
@@ -56,12 +57,17 @@ const Sidebar = ({ open, onClose }: SidebarProps) => {
   return (
     <aside
       className={clsx(
-        "fixed top-0 left-0 z-50 h-screen w-64 bg-background border-r border-border shadow-md transform transition-transform md:relative md:translate-x-0 md:block md:min-h-screen",
-        open ? "translate-x-0" : "-translate-x-full md:translate-x-0"
+        "fixed top-0 left-0 z-50 h-screen w-64 bg-background border-r border-border shadow-md transform transition-transform",
+        collapsible ? "md:fixed" : "md:relative md:block md:min-h-screen",
+        open ? "translate-x-0" : "-translate-x-full",
+        !collapsible && "md:translate-x-0"
       )}
     >
       <button
-        className="absolute top-3 left-3 md:hidden p-1 rounded-md hover:bg-muted"
+        className={clsx(
+          "absolute top-3 left-3 p-1 rounded-md hover:bg-muted",
+          !collapsible && "md:hidden"
+        )}
         onClick={onClose}
         aria-label="Close sidebar"
       >

--- a/web/components/blocks/BlocksPane.tsx
+++ b/web/components/blocks/BlocksPane.tsx
@@ -1,0 +1,37 @@
+import { Card } from "@/components/ui/Card";
+import type { Block } from "@/types/block";
+
+export interface BlocksPaneProps {
+  blocks: Block[];
+}
+
+export default function BlocksPane({ blocks }: BlocksPaneProps) {
+  const proposed = (blocks || []).filter((b) => b.state === "PROPOSED");
+  if (proposed.length === 0) {
+    return (
+      <div className="p-4 text-sm text-muted-foreground">
+        No proposed blocks yet.
+      </div>
+    );
+  }
+  return (
+    <div className="p-4 space-y-2">
+      {proposed.map((block) => (
+        <Card key={block.id} className="space-y-1 p-4">
+          <div className="flex justify-between items-start">
+            <span className="text-sm font-medium">
+              {block.canonical_value || block.content.slice(0, 30)}
+            </span>
+            <span className="text-xs px-2 py-0.5 bg-muted rounded">
+              {block.semantic_type}
+            </span>
+          </div>
+          <p className="text-sm text-muted-foreground">
+            {block.content.slice(0, 120)}
+            {block.content.length > 120 ? "…" : ""}
+          </p>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/web/components/layout/RightPanel.tsx
+++ b/web/components/layout/RightPanel.tsx
@@ -1,0 +1,32 @@
+"use client";
+import { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+interface RightPanelLayoutProps {
+  children: ReactNode;
+  rightPanel?: ReactNode;
+  className?: string;
+}
+
+export default function RightPanelLayout({
+  children,
+  rightPanel,
+  className,
+}: RightPanelLayoutProps) {
+  return (
+    <div className={cn("md:flex w-full", className)}>
+      <div className="flex-1">{children}</div>
+      {rightPanel && (
+        <aside className="hidden md:block w-[320px] shrink-0 border-l bg-gray-50 overflow-y-auto">
+          {rightPanel}
+        </aside>
+      )}
+    </div>
+  );
+}
+
+export function RightPanelSkeleton() {
+  return (
+    <div className="p-4 text-sm text-muted-foreground">Right panel ready</div>
+  );
+}

--- a/web/components/layouts/Shell.tsx
+++ b/web/components/layouts/Shell.tsx
@@ -2,12 +2,14 @@
 import React, { ReactNode, useEffect, useState } from "react";
 import Sidebar from "@/app/components/layout/Sidebar";
 import MobileSidebarToggle from "@/components/MobileSidebarToggle";
+import { cn } from "@/lib/utils";
 
 interface ShellProps {
     children: ReactNode;
+    collapseSidebar?: boolean;
 }
 
-export default function Shell({ children }: ShellProps) {
+export default function Shell({ children, collapseSidebar = false }: ShellProps) {
     const [open, setOpen] = useState(false);
 
     useEffect(() => {
@@ -20,16 +22,24 @@ export default function Shell({ children }: ShellProps) {
 
     return (
         <div className="min-h-screen md:grid md:grid-cols-[16rem_1fr]">
-            {/* Mobile overlay */}
+            {/* Screen overlay */}
             {open && (
                 <div
-                    className="fixed inset-0 z-40 bg-black/50 md:hidden"
+                    className={cn(
+                        "fixed inset-0 z-40 bg-black/50",
+                        collapseSidebar ? undefined : "md:hidden"
+                    )}
                     onClick={() => setOpen(false)}
                 />
             )}
-            <Sidebar open={open} onClose={() => setOpen(false)} />
+            <Sidebar
+                open={collapseSidebar ? open : true}
+                onClose={() => setOpen(false)}
+                collapsible={collapseSidebar}
+            />
             <main className="p-6">
-                <div className="mb-4 md:hidden">
+                <div className={cn("mb-4", collapseSidebar ? undefined : "md:hidden")}
+                >
                     <MobileSidebarToggle onClick={() => setOpen(true)} />
                 </div>
                 {children}

--- a/web/components/workbench/WorkbenchLayout.tsx
+++ b/web/components/workbench/WorkbenchLayout.tsx
@@ -3,12 +3,14 @@ import { ReactNode } from "react";
 import BasketHeader from "@/components/basket/BasketHeader";
 import NarrativePane from "@/components/basket/NarrativePane";
 import type { BasketSnapshot } from "@/lib/baskets/getSnapshot";
+import RightPanelLayout from "@/components/layout/RightPanel";
 
 interface Props {
     snapshot: BasketSnapshot;
     onRunBlockifier?: () => void;
     runningBlockifier?: boolean;
     onSelectBlock?: (id: string) => void;
+    rightPanel?: ReactNode;
     children?: ReactNode;
 }
 
@@ -17,6 +19,7 @@ export default function WorkbenchLayout({
     onRunBlockifier,
     runningBlockifier,
     onSelectBlock,
+    rightPanel,
     children,
 }: Props) {
     const scopes = Array.from(
@@ -24,20 +27,22 @@ export default function WorkbenchLayout({
     ) as string[];
 
     return (
-        <div className="min-h-screen p-4 space-y-4">
-            <BasketHeader
-                basketName={snapshot.basket?.name || "Untitled Basket"}
-                status="DRAFT"
-                scope={scopes}
-                onRunBlockifier={onRunBlockifier}
-                isRunningBlockifier={runningBlockifier}
-            />
-            <NarrativePane
-                rawText={snapshot.raw_dump_body}
-                blocks={snapshot.blocks || []}
-                onSelectBlock={onSelectBlock}
-            />
-            {children}
-        </div>
+        <RightPanelLayout rightPanel={rightPanel}>
+            <div className="min-h-screen p-4 space-y-4">
+                <BasketHeader
+                    basketName={snapshot.basket?.name || "Untitled Basket"}
+                    status="DRAFT"
+                    scope={scopes}
+                    onRunBlockifier={onRunBlockifier}
+                    isRunningBlockifier={runningBlockifier}
+                />
+                <NarrativePane
+                    rawText={snapshot.raw_dump_body}
+                    blocks={snapshot.blocks || []}
+                    onSelectBlock={onSelectBlock}
+                />
+                {children}
+            </div>
+        </RightPanelLayout>
     );
 }

--- a/web/components/workbench/WorkbenchLayoutDev.tsx
+++ b/web/components/workbench/WorkbenchLayoutDev.tsx
@@ -2,30 +2,34 @@
 import { ReactNode } from "react";
 import BasketHeader from "@/components/basket/BasketHeader";
 import NarrativePane from "@/components/basket/NarrativePane";
+import RightPanelLayout from "@/components/layout/RightPanel";
 
 interface Props {
   initialSnapshot: any;
+  rightPanel?: ReactNode;
   children?: ReactNode;
 }
 
-export default function WorkbenchLayoutDev({ initialSnapshot, children }: Props) {
+export default function WorkbenchLayoutDev({ initialSnapshot, rightPanel, children }: Props) {
   const scopes = Array.from(
     new Set((initialSnapshot.blocks || []).map((b: any) => b.scope).filter(Boolean))
   ) as string[];
 
   return (
-    <div className="min-h-screen p-4 space-y-4">
-      <BasketHeader
-        basketName={initialSnapshot.basket?.name || "Untitled Basket"}
-        status="DRAFT"
-        scope={scopes}
-      />
-      <NarrativePane
-        rawText={initialSnapshot.raw_dump_body}
-        blocks={initialSnapshot.blocks || []}
-        onSelectBlock={(id) => console.log("select", id)}
-      />
-      {children}
-    </div>
+    <RightPanelLayout rightPanel={rightPanel}>
+      <div className="min-h-screen p-4 space-y-4">
+        <BasketHeader
+          basketName={initialSnapshot.basket?.name || "Untitled Basket"}
+          status="DRAFT"
+          scope={scopes}
+        />
+        <NarrativePane
+          rawText={initialSnapshot.raw_dump_body}
+          blocks={initialSnapshot.blocks || []}
+          onSelectBlock={(id) => console.log("select", id)}
+        />
+        {children}
+      </div>
+    </RightPanelLayout>
   );
 }

--- a/web/lib/baskets/getSnapshot.ts
+++ b/web/lib/baskets/getSnapshot.ts
@@ -14,6 +14,7 @@ export interface BasketSnapshot {
   raw_dump_body: string;
   file_refs: string[];
   blocks: Block[];
+  proposed_blocks: Block[];
 }
 
 const SNAPSHOT_PREFIX = "/api/baskets/snapshot";
@@ -28,7 +29,7 @@ export async function getSnapshot(
   const token = session?.access_token ?? "";
   const res = await apiGet<any>(`${SNAPSHOT_PREFIX}/${id}`, token);
   const payload = res as any;
-const flatBlocks = [
+  const flatBlocks = [
     ...(payload.accepted_blocks ?? []),
     ...(payload.locked_blocks ?? []),
     ...(payload.constants ?? []),
@@ -39,5 +40,6 @@ const flatBlocks = [
     raw_dump_body: payload.raw_dump,
     file_refs: payload.file_refs ?? [],
     blocks: flatBlocks,
+    proposed_blocks: payload.proposed_blocks ?? [],
   };
 }

--- a/web/lib/blocks/dev_mock_blocks.ts
+++ b/web/lib/blocks/dev_mock_blocks.ts
@@ -1,0 +1,24 @@
+import type { Block } from "@/types/block";
+
+export const DEV_MOCK_BLOCKS: Block[] = [
+  {
+    id: "mock1",
+    semantic_type: "tone",
+    content: "We maintain an upbeat and friendly style that excites readers.",
+    state: "PROPOSED",
+    scope: null,
+    canonical_value: "upbeat and friendly",
+    actor: "tester",
+    created_at: new Date().toISOString(),
+  },
+  {
+    id: "mock2",
+    semantic_type: "audience",
+    content: "Our messaging targets busy founders seeking quick wins.",
+    state: "PROPOSED",
+    scope: null,
+    canonical_value: "busy founders",
+    actor: "tester",
+    created_at: new Date().toISOString(),
+  },
+];


### PR DESCRIPTION
## Summary
- create `BlocksPane` component to list proposed blocks
- extend snapshot util with `proposed_blocks`
- show live proposed blocks on `/work` page
- show mock blocks on `/work-dev` page
- supply mock block data for development preview

## Testing
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68606da30bd8832995cd43b93ed40299