### PR TITLE
Hide sidebar by default on work pages

### DIFF
--- a/web/app/components/layout/Sidebar.tsx
+++ b/web/app/components/layout/Sidebar.tsx
@@ -19,9 +19,10 @@ interface SidebarProps {
   open: boolean;
   onClose: () => void;
   collapsible?: boolean;
+  className?: string;
 }
 
-const Sidebar = ({ open, onClose, collapsible = false }: SidebarProps) => {
+const Sidebar = ({ open, onClose, collapsible = false, className }: SidebarProps) => {
   const pathname = usePathname();
   const router = useRouter();
   const [userEmail, setUserEmail] = useState<string | null>(null);
@@ -60,7 +61,8 @@ const Sidebar = ({ open, onClose, collapsible = false }: SidebarProps) => {
         "fixed top-0 left-0 z-50 h-screen w-64 bg-background border-r border-border shadow-md transform transition-transform",
         collapsible ? "md:fixed" : "md:relative md:block md:min-h-screen",
         open ? "translate-x-0" : "-translate-x-full",
-        !collapsible && "md:translate-x-0"
+        !collapsible && "md:translate-x-0",
+        className
       )}
     >
       <button

--- a/web/components/layouts/Shell.tsx
+++ b/web/components/layouts/Shell.tsx
@@ -3,6 +3,7 @@ import React, { ReactNode, useEffect, useState } from "react";
 import Sidebar from "@/app/components/layout/Sidebar";
 import MobileSidebarToggle from "@/components/MobileSidebarToggle";
 import { cn } from "@/lib/utils";
+import { usePathname } from "next/navigation";
 
 interface ShellProps {
     children: ReactNode;
@@ -10,6 +11,11 @@ interface ShellProps {
 }
 
 export default function Shell({ children, collapseSidebar = false }: ShellProps) {
+    const pathname = usePathname();
+    const hideSidebarByPath =
+        pathname?.includes("/baskets/") &&
+        (pathname.endsWith("/work") || pathname.endsWith("/work-dev"));
+    const shouldCollapse = collapseSidebar || hideSidebarByPath;
     const [open, setOpen] = useState(false);
 
     useEffect(() => {
@@ -21,24 +27,25 @@ export default function Shell({ children, collapseSidebar = false }: ShellProps)
     }, []);
 
     return (
-        <div className="min-h-screen md:grid md:grid-cols-[16rem_1fr]">
+        <div className="min-h-screen md:flex">
             {/* Screen overlay */}
             {open && (
                 <div
                     className={cn(
                         "fixed inset-0 z-40 bg-black/50",
-                        collapseSidebar ? undefined : "md:hidden"
+                        shouldCollapse ? undefined : "md:hidden"
                     )}
                     onClick={() => setOpen(false)}
                 />
             )}
             <Sidebar
-                open={collapseSidebar ? open : true}
+                open={shouldCollapse ? open : true}
                 onClose={() => setOpen(false)}
-                collapsible={collapseSidebar}
+                collapsible={shouldCollapse}
+                className={hideSidebarByPath && !open ? "hidden md:hidden" : undefined}
             />
-            <main className="p-6">
-                <div className={cn("mb-4", collapseSidebar ? undefined : "md:hidden")}
+            <main className="p-6 flex-1">
+                <div className={cn("mb-4", shouldCollapse ? undefined : "md:hidden")}
                 >
                     <MobileSidebarToggle onClick={() => setOpen(true)} />
                 </div>


### PR DESCRIPTION
## Summary
- detect work and work-dev routes inside `Shell`
- auto-collapse sidebar on those routes
- allow `Sidebar` to accept extra class names
- switch container layout to flex so main area fills space when sidebar is hidden

## Testing
- `npm run test`
- `pytest -q` *(fails: pyenv missing Python 3.11.9)*

------
https://chatgpt.com/codex/tasks/task_e_6860731a8fd88329bae836777a98a32b