### PR TITLE
Enable sidebar toggle on work pages

### DIFF
--- a/web/components/layouts/Shell.tsx
+++ b/web/components/layouts/Shell.tsx
@@ -16,11 +16,11 @@ export default function Shell({ children, collapseSidebar = false }: ShellProps)
         pathname?.includes("/baskets/") &&
         (pathname.endsWith("/work") || pathname.endsWith("/work-dev"));
     const shouldCollapse = collapseSidebar || hideSidebarByPath;
-    const [open, setOpen] = useState(false);
+    const [sidebarVisible, setSidebarVisible] = useState(!hideSidebarByPath);
 
     useEffect(() => {
         const handleEsc = (e: KeyboardEvent) => {
-            if (e.key === "Escape") setOpen(false);
+            if (e.key === "Escape") setSidebarVisible(false);
         };
         window.addEventListener("keydown", handleEsc);
         return () => window.removeEventListener("keydown", handleEsc);
@@ -29,25 +29,23 @@ export default function Shell({ children, collapseSidebar = false }: ShellProps)
     return (
         <div className="min-h-screen md:flex">
             {/* Screen overlay */}
-            {open && (
+            {sidebarVisible && shouldCollapse && (
                 <div
-                    className={cn(
-                        "fixed inset-0 z-40 bg-black/50",
-                        shouldCollapse ? undefined : "md:hidden"
-                    )}
-                    onClick={() => setOpen(false)}
+                    className="fixed inset-0 z-40 bg-black/50 md:hidden"
+                    onClick={() => setSidebarVisible(false)}
                 />
             )}
-            <Sidebar
-                open={shouldCollapse ? open : true}
-                onClose={() => setOpen(false)}
-                collapsible={shouldCollapse}
-                className={hideSidebarByPath && !open ? "hidden md:hidden" : undefined}
-            />
+            {sidebarVisible && (
+                <Sidebar
+                    open={true}
+                    onClose={() => setSidebarVisible(false)}
+                    collapsible={shouldCollapse}
+                />
+            )}
             <main className="p-6 flex-1">
                 <div className={cn("mb-4", shouldCollapse ? undefined : "md:hidden")}
                 >
-                    <MobileSidebarToggle onClick={() => setOpen(true)} />
+                    <MobileSidebarToggle onClick={() => setSidebarVisible(!sidebarVisible)} />
                 </div>
                 {children}
             </main>


### PR DESCRIPTION
## Summary
- allow sidebar to toggle open/closed via state
- hide the sidebar on initial load of `/work` and `/work-dev`
- keep hamburger button active so the sidebar can be opened

## Testing
- `npm test`
- `npm run lint`
- `npm --prefix web run lint` *(fails: Parsing error: Unexpected token <)*

------
https://chatgpt.com/codex/tasks/task_e_68619b27b5b08329b3d455e54f495cfe