### PR TITLE
Fix sidebar toggle logic for work pages

### DIFF
--- a/web/app/baskets/[id]/work-dev/layout.tsx
+++ b/web/app/baskets/[id]/work-dev/layout.tsx
@@ -1,5 +1,3 @@
-import Shell from "@/components/layouts/Shell";
-
 export default function Layout({ children }: { children: React.ReactNode }) {
-  return <Shell collapseSidebar>{children}</Shell>;
+  return <>{children}</>;
 }

--- a/web/app/baskets/[id]/work/layout.tsx
+++ b/web/app/baskets/[id]/work/layout.tsx
@@ -1,5 +1,3 @@
-import Shell from "@/components/layouts/Shell";
-
 export default function Layout({ children }: { children: React.ReactNode }) {
-  return <Shell collapseSidebar>{children}</Shell>;
+  return <>{children}</>;
 }

--- a/web/components/MobileSidebarToggle.tsx
+++ b/web/components/MobileSidebarToggle.tsx
@@ -2,11 +2,16 @@
 
 import { Menu } from "lucide-react";
 
-export default function MobileSidebarToggle({ onClick }: { onClick: () => void }) {
+interface Props {
+  onClick: () => void;
+  forceShow?: boolean;
+}
+
+export default function MobileSidebarToggle({ onClick, forceShow = false }: Props) {
   return (
     <button
       onClick={onClick}
-      className="md:hidden p-2 rounded-md border border-border bg-background"
+      className={`${forceShow ? "block" : "md:hidden"} p-2 rounded-md border border-border bg-background`}
       aria-label="Open sidebar"
     >
       <Menu className="h-5 w-5" />

--- a/web/components/layouts/Shell.tsx
+++ b/web/components/layouts/Shell.tsx
@@ -16,6 +16,7 @@ export default function Shell({ children, collapseSidebar = false }: ShellProps)
         pathname?.includes("/baskets/") &&
         (pathname.endsWith("/work") || pathname.endsWith("/work-dev"));
     const shouldCollapse = collapseSidebar || hideSidebarByPath;
+    const forceShowHamburger = hideSidebarByPath;
     const [sidebarVisible, setSidebarVisible] = useState(!hideSidebarByPath);
 
     useEffect(() => {
@@ -45,7 +46,10 @@ export default function Shell({ children, collapseSidebar = false }: ShellProps)
             <main className="p-6 flex-1">
                 <div className={cn("mb-4", shouldCollapse ? undefined : "md:hidden")}
                 >
-                    <MobileSidebarToggle onClick={() => setSidebarVisible(!sidebarVisible)} />
+                    <MobileSidebarToggle
+                        onClick={() => setSidebarVisible(!sidebarVisible)}
+                        forceShow={forceShowHamburger}
+                    />
                 </div>
                 {children}
             </main>


### PR DESCRIPTION
## Summary
- remove nested Shell layout for `/baskets/[id]/work` and `/work-dev`
- always show hamburger button when viewing work pages
- allow MobileSidebarToggle to force display on large viewports

## Testing
- `npm test`
- `npx tsc -p web/tsconfig.json` *(fails: Cannot find type definition file for 'react')*


------
https://chatgpt.com/codex/tasks/task_e_6861a070243083298f233903a05515c8