### PR TITLE
Add block detail page

### DIFF
--- a/web/app/api/context-blocks/[id]/route.ts
+++ b/web/app/api/context-blocks/[id]/route.ts
@@ -2,14 +2,14 @@ import { NextRequest, NextResponse } from "next/server";
 import { createServiceRoleClient } from "@/lib/supabase/serviceRole";
 export async function GET(
   req: NextRequest,
-  context: { params: { id: string } },
+  { params }: { params: Promise<{ id: string }> },
 ) {
-  const { params } = context;
+  const { id } = await params;
   const supabase = createServiceRoleClient();
   const { data, error } = await supabase
     .from("blocks")
     .select("*")
-    .eq("id", params.id)
+    .eq("id", id)
     .single();
   if (error) {
     return NextResponse.json({ error: error.message }, { status: 500 });
@@ -19,14 +19,14 @@ export async function GET(
 
 export async function DELETE(
   req: NextRequest,
-  context: { params: { id: string } },
+  { params }: { params: Promise<{ id: string }> },
 ) {
-  const { params } = context;
+  const { id } = await params;
   const supabase = createServiceRoleClient();
   const { error } = await supabase
     .from("blocks")
     .delete()
-    .eq("id", params.id);
+    .eq("id", id);
   if (error) {
     return NextResponse.json({ error: error.message }, { status: 500 });
   }

--- a/web/app/api/context-blocks/[id]/route.ts
+++ b/web/app/api/context-blocks/[id]/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createServiceRoleClient } from "@/lib/supabase/serviceRole";
+
+export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+  const supabase = createServiceRoleClient();
+  const { data, error } = await supabase
+    .from("blocks")
+    .select("*")
+    .eq("id", params.id)
+    .single();
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+  return NextResponse.json(data, { status: 200 });
+}
+
+export async function DELETE(req: NextRequest, { params }: { params: { id: string } }) {
+  const supabase = createServiceRoleClient();
+  const { error } = await supabase.from("blocks").delete().eq("id", params.id);
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+  return NextResponse.json({ success: true }, { status: 200 });
+}

--- a/web/app/api/context-blocks/[id]/route.ts
+++ b/web/app/api/context-blocks/[id]/route.ts
@@ -1,15 +1,16 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createServiceRoleClient } from "@/lib/supabase/serviceRole";
+import type { Params } from "next/dist/shared/lib/router/utils/route-matcher";
 
 export async function GET(
   req: NextRequest,
-  context: { params: { id: string } },
+  { params }: { params: Params },
 ) {
   const supabase = createServiceRoleClient();
   const { data, error } = await supabase
     .from("blocks")
     .select("*")
-    .eq("id", context.params.id)
+    .eq("id", params.id)
     .single();
   if (error) {
     return NextResponse.json({ error: error.message }, { status: 500 });
@@ -19,13 +20,13 @@ export async function GET(
 
 export async function DELETE(
   req: NextRequest,
-  context: { params: { id: string } },
+  { params }: { params: Params },
 ) {
   const supabase = createServiceRoleClient();
   const { error } = await supabase
     .from("blocks")
     .delete()
-    .eq("id", context.params.id);
+    .eq("id", params.id);
   if (error) {
     return NextResponse.json({ error: error.message }, { status: 500 });
   }

--- a/web/app/api/context-blocks/[id]/route.ts
+++ b/web/app/api/context-blocks/[id]/route.ts
@@ -1,12 +1,15 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createServiceRoleClient } from "@/lib/supabase/serviceRole";
 
-export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+export async function GET(
+  req: NextRequest,
+  context: { params: { id: string } },
+) {
   const supabase = createServiceRoleClient();
   const { data, error } = await supabase
     .from("blocks")
     .select("*")
-    .eq("id", params.id)
+    .eq("id", context.params.id)
     .single();
   if (error) {
     return NextResponse.json({ error: error.message }, { status: 500 });
@@ -14,9 +17,15 @@ export async function GET(req: NextRequest, { params }: { params: { id: string }
   return NextResponse.json(data, { status: 200 });
 }
 
-export async function DELETE(req: NextRequest, { params }: { params: { id: string } }) {
+export async function DELETE(
+  req: NextRequest,
+  context: { params: { id: string } },
+) {
   const supabase = createServiceRoleClient();
-  const { error } = await supabase.from("blocks").delete().eq("id", params.id);
+  const { error } = await supabase
+    .from("blocks")
+    .delete()
+    .eq("id", context.params.id);
   if (error) {
     return NextResponse.json({ error: error.message }, { status: 500 });
   }

--- a/web/app/api/context-blocks/[id]/route.ts
+++ b/web/app/api/context-blocks/[id]/route.ts
@@ -1,11 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createServiceRoleClient } from "@/lib/supabase/serviceRole";
-import type { Params } from "next/dist/shared/lib/router/utils/route-matcher";
-
 export async function GET(
   req: NextRequest,
-  { params }: { params: Params },
+  context: { params: { id: string } },
 ) {
+  const { params } = context;
   const supabase = createServiceRoleClient();
   const { data, error } = await supabase
     .from("blocks")
@@ -20,8 +19,9 @@ export async function GET(
 
 export async function DELETE(
   req: NextRequest,
-  { params }: { params: Params },
+  context: { params: { id: string } },
 ) {
+  const { params } = context;
   const supabase = createServiceRoleClient();
   const { error } = await supabase
     .from("blocks")

--- a/web/app/blocks/[id]/page.tsx
+++ b/web/app/blocks/[id]/page.tsx
@@ -6,11 +6,11 @@ import { Button } from "@/components/ui/Button";
 import BlockDetailLayout from "@/components/blocks/BlockDetailLayout";
 import { fetchBlock, updateBlock, deleteBlock } from "@/lib/supabase/blocks";
 
-type PageProps = {
+export default function BlockDetailPage({
+  params,
+}: {
   params: { id: string };
-  searchParams?: { [key: string]: string | string[] };
-};
-export default function BlockDetailPage({ params }: PageProps) {
+}) {
   const router = useRouter();
   const [block, setBlock] = useState<any | null>(null);
   const [edit, setEdit] = useState(false);

--- a/web/app/blocks/[id]/page.tsx
+++ b/web/app/blocks/[id]/page.tsx
@@ -1,0 +1,122 @@
+"use client";
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Input } from "@/components/ui/Input";
+import { Button } from "@/components/ui/Button";
+import BlockDetailLayout from "@/components/blocks/BlockDetailLayout";
+import { fetchBlock, updateBlock, deleteBlock } from "@/lib/supabase/blocks";
+
+export default function BlockDetailPage({ params }: { params: { id: string } }) {
+  const router = useRouter();
+  const [block, setBlock] = useState<any | null>(null);
+  const [edit, setEdit] = useState(false);
+  const [form, setForm] = useState({
+    label: "",
+    semantic_type: "",
+    content: "",
+    meta_tags: "",
+  });
+
+  useEffect(() => {
+    const load = async () => {
+      const { data } = await fetchBlock(params.id);
+      if (data) {
+        setBlock(data);
+        setForm({
+          label: data.label || "",
+          semantic_type: data.semantic_type || "",
+          content: data.content || "",
+          meta_tags: (data.meta_tags || []).join(", "),
+        });
+      }
+    };
+    load();
+  }, [params.id]);
+
+  const handleSave = async () => {
+    if (!block) return;
+    await updateBlock(block.id, {
+      label: form.label,
+      semantic_type: form.semantic_type,
+      content: form.content,
+      meta_tags: form.meta_tags
+        .split(",")
+        .map((t) => t.trim())
+        .filter(Boolean),
+    });
+    setBlock({ ...block, ...form, meta_tags: form.meta_tags.split(",").map((t) => t.trim()).filter(Boolean) });
+    setEdit(false);
+  };
+
+  const handleCancel = () => {
+    if (!block) return;
+    setForm({
+      label: block.label || "",
+      semantic_type: block.semantic_type || "",
+      content: block.content || "",
+      meta_tags: (block.meta_tags || []).join(", "),
+    });
+    setEdit(false);
+  };
+
+  const handleDelete = async () => {
+    if (!block) return;
+    await deleteBlock(block.id);
+    router.push("/blocks");
+  };
+
+  if (!block) return <div className="p-6">Loading…</div>;
+
+  return (
+    <BlockDetailLayout>
+      <h1 className="text-2xl font-bold mb-4">Block Detail</h1>
+      <div className="space-y-4">
+        <div>
+          <label className="block text-sm font-medium text-muted-foreground">Title</label>
+          <Input
+            value={form.label}
+            disabled={!edit}
+            onChange={(e) => setForm({ ...form, label: e.target.value })}
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-muted-foreground">Type</label>
+          <Input
+            value={form.semantic_type}
+            disabled={!edit}
+            onChange={(e) => setForm({ ...form, semantic_type: e.target.value })}
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-muted-foreground">Tags</label>
+          <Input
+            value={form.meta_tags}
+            disabled={!edit}
+            onChange={(e) => setForm({ ...form, meta_tags: e.target.value })}
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-muted-foreground">Body</label>
+          <textarea
+            className="mt-1 w-full border rounded p-2"
+            rows={6}
+            value={form.content}
+            disabled={!edit}
+            onChange={(e) => setForm({ ...form, content: e.target.value })}
+          />
+        </div>
+      </div>
+      <div className="pt-4 space-x-2">
+        {edit ? (
+          <>
+            <Button size="sm" onClick={handleSave}>Save</Button>
+            <Button size="sm" variant="outline" onClick={handleCancel}>Cancel</Button>
+          </>
+        ) : (
+          <Button size="sm" onClick={() => setEdit(true)}>Edit</Button>
+        )}
+        <Button size="sm" variant="destructive" onClick={handleDelete}>Delete</Button>
+      </div>
+    </BlockDetailLayout>
+  );
+}

--- a/web/app/blocks/[id]/page.tsx
+++ b/web/app/blocks/[id]/page.tsx
@@ -6,7 +6,11 @@ import { Button } from "@/components/ui/Button";
 import BlockDetailLayout from "@/components/blocks/BlockDetailLayout";
 import { fetchBlock, updateBlock, deleteBlock } from "@/lib/supabase/blocks";
 
-export default function BlockDetailPage({ params }: { params: { id: string } }) {
+type PageProps = {
+  params: { id: string };
+  searchParams?: { [key: string]: string | string[] };
+};
+export default function BlockDetailPage({ params }: PageProps) {
   const router = useRouter();
   const [block, setBlock] = useState<any | null>(null);
   const [edit, setEdit] = useState(false);

--- a/web/components/blocks/BlockDetailLayout.tsx
+++ b/web/components/blocks/BlockDetailLayout.tsx
@@ -1,0 +1,16 @@
+"use client";
+import { ReactNode } from "react";
+import RightPanelLayout from "@/components/layout/RightPanel";
+
+interface Props {
+  children: ReactNode;
+  sidePanel?: ReactNode;
+}
+
+export default function BlockDetailLayout({ children, sidePanel }: Props) {
+  return (
+    <RightPanelLayout rightPanel={sidePanel} className="max-w-4xl mx-auto p-6">
+      {children}
+    </RightPanelLayout>
+  );
+}

--- a/web/components/blocks/BlocksPane.tsx
+++ b/web/components/blocks/BlocksPane.tsx
@@ -1,4 +1,5 @@
 import { Card } from "@/components/ui/Card";
+import Link from "next/link";
 import type { Block } from "@/types/block";
 
 export interface BlocksPaneProps {
@@ -17,20 +18,22 @@ export default function BlocksPane({ blocks }: BlocksPaneProps) {
   return (
     <div className="p-4 space-y-2">
       {proposed.map((block) => (
-        <Card key={block.id} className="space-y-1 p-4">
-          <div className="flex justify-between items-start">
-            <span className="text-sm font-medium">
-              {block.canonical_value || block.content.slice(0, 30)}
-            </span>
-            <span className="text-xs px-2 py-0.5 bg-muted rounded">
-              {block.semantic_type}
-            </span>
-          </div>
-          <p className="text-sm text-muted-foreground">
-            {block.content.slice(0, 120)}
-            {block.content.length > 120 ? "…" : ""}
-          </p>
-        </Card>
+        <Link key={block.id} href={`/blocks/${block.id}`} className="block">
+          <Card className="space-y-1 p-4 hover:bg-muted cursor-pointer">
+            <div className="flex justify-between items-start">
+              <span className="text-sm font-medium">
+                {block.canonical_value || block.content.slice(0, 30)}
+              </span>
+              <span className="text-xs px-2 py-0.5 bg-muted rounded">
+                {block.semantic_type}
+              </span>
+            </div>
+            <p className="text-sm text-muted-foreground">
+              {block.content.slice(0, 120)}
+              {block.content.length > 120 ? "…" : ""}
+            </p>
+          </Card>
+        </Link>
       ))}
     </div>
   );

--- a/web/generated-route-registry.json
+++ b/web/generated-route-registry.json
@@ -16,5 +16,6 @@
   "/api/task-types",
   "/api/baskets/new",
   "/api/baskets/snapshot/[id]",
-  "/api/agents/[name]/run"
+  "/api/agents/[name]/run",
+  "/api/context-blocks/[id]"
 ]

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -70,3 +70,21 @@ export async function apiPut<T = any>(
   }
   return (await res.json()) as T;
 }
+
+export async function apiDelete<T = any>(path: string, token?: string): Promise<T> {
+  const res = await fetchWithToken(
+    apiUrl(path),
+    { method: "DELETE" },
+    token,
+  );
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(text || `apiDelete ${path} failed with status ${res.status}`);
+  }
+  try {
+    const txt = await res.text();
+    return txt ? (JSON.parse(txt) as T) : ({} as T);
+  } catch {
+    return {} as T;
+  }
+}

--- a/web/lib/supabase/blocks.ts
+++ b/web/lib/supabase/blocks.ts
@@ -1,7 +1,7 @@
 // ✅ File: lib/supabase/blocks.ts
 
 import { createClient } from "@/lib/supabaseClient";
-import { apiPost, apiPut } from "@/lib/api";
+import { apiPost, apiPut, apiDelete } from "@/lib/api";
 
 export interface BlockInsert {
   user_id: string;
@@ -43,4 +43,22 @@ export async function toggleAuto(id: string, enable: boolean) {
     id,
     update_policy: enable ? "auto" : "manual",
   });
+}
+
+export async function fetchBlock(id: string) {
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from("blocks")
+    .select("*")
+    .eq("id", id)
+    .single();
+  return { data, error };
+}
+
+export async function updateBlock(id: string, updates: Record<string, any>) {
+  return apiPut("/api/context-blocks/update", { id, ...updates });
+}
+
+export async function deleteBlock(id: string) {
+  return apiDelete(`/api/context-blocks/${id}`);
 }

--- a/web/route-contracts.json
+++ b/web/route-contracts.json
@@ -16,5 +16,6 @@
   "/api/task-types",
   "/api/baskets/new",
   "/api/baskets/snapshot/[id]",
-  "/api/agents/[name]/run"
+  "/api/agents/[name]/run",
+  "/api/context-blocks/[id]"
 ]


### PR DESCRIPTION
## Summary
- add CRUD API route for blocks by id
- expand API helpers with `apiDelete`
- add fetch/update/delete helpers for blocks
- stub `BlockDetailLayout`
- create `/blocks/[id]` page to view and edit blocks
- update route registry files
- link proposed blocks in the right panel to the detail page

## Testing
- `npm run test`
- `python3 -m pytest -q` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_68621ef4b81c83299c0bd93e9ce9950f