### PR TITLE
Seed brand_playbook starter template

### DIFF
--- a/api/src/templates/brand_playbook/basket.json
+++ b/api/src/templates/brand_playbook/basket.json
@@ -1,0 +1,3 @@
+{
+  "name": "Brand Playbook"
+}

--- a/api/src/templates/brand_playbook/blocks.json
+++ b/api/src/templates/brand_playbook/blocks.json
@@ -1,0 +1,9 @@
+[
+  {
+    "label": "Brand Name",
+    "semantic_type": "IDENTIFIER",
+    "content": "<Edit me>",
+    "state": "LOCKED",
+    "is_required": true
+  }
+]

--- a/api/src/templates/brand_playbook/docs/brand_brief.md
+++ b/api/src/templates/brand_playbook/docs/brand_brief.md
@@ -1,0 +1,8 @@
+# Brand Brief
+
+Replace this text with your real brand story, mission, and
+elevator pitch.
+
+- **Founded :** 20XX  
+- **Mission :** <Edit me>  
+- **Tone    :** Friendly · Confident · Human


### PR DESCRIPTION
## Summary
- add `brand_playbook` starter template files to API templates

## Testing
- `make -C api test` *(fails: ModuleNotFoundError due to missing dependencies)*
- `curl -X POST http://localhost:8000/api/baskets/new -H "Authorization: Bearer $TOKEN" -d '{"basket_name":"Demo","template_slug":"brand_playbook"}'` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6865cdde18408329a13f5e4a26c1163a