### PR TITLE
Add multi-step create basket dialog

### DIFF
--- a/web/__tests__/createBasketDialog.test.tsx
+++ b/web/__tests__/createBasketDialog.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+import CreateBasketDialog from "@/components/CreateBasketDialog";
+
+const push = vi.fn();
+const mutate = vi.fn().mockResolvedValue("uuid-1");
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push }),
+}));
+
+vi.mock("@/hooks/useCreateBasket", () => ({
+  useCreateBasket: () => ({ mutate }),
+}));
+
+describe("CreateBasketDialog", () => {
+  it("creates basket and routes", async () => {
+    render(<CreateBasketDialog open onOpenChange={() => {}} />);
+
+    await userEvent.type(screen.getByLabelText(/basket name/i), "Test");
+    await userEvent.click(screen.getByRole("button", { name: /next/i }));
+    await userEvent.click(screen.getByRole("button", { name: /next/i }));
+    await userEvent.click(screen.getByRole("button", { name: /create basket/i }));
+
+    expect(mutate).toHaveBeenCalledWith("Test", "brand_playbook");
+    expect(push).toHaveBeenCalledWith("/baskets/uuid-1/work");
+  });
+});

--- a/web/app/baskets/page.tsx
+++ b/web/app/baskets/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 import { useEffect, useMemo, useState } from "react";
-import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useSessionContext } from "@supabase/auth-helpers-react";
 import { Button } from "@/components/ui/Button";
@@ -17,11 +16,13 @@ import { EmptyState } from "@/components/ui/EmptyState";
 import BasketCard from "@/components/BasketCard";
 import { getAllBaskets, BasketOverview } from "@/lib/baskets/getAllBaskets";
 import PageHeader from "@/components/page/PageHeader";
+import CreateBasketDialog from "@/components/CreateBasketDialog";
 
 export default function BasketsPage() {
   const { session, isLoading } = useSessionContext();
   const router = useRouter();
   const [baskets, setBaskets] = useState<BasketOverview[]>([]);
+  const [open, setOpen] = useState(false);
   const [search, setSearch] = useState("");
   const [sort, setSort] = useState("created");
   const [page, setPage] = useState(1);
@@ -70,9 +71,8 @@ export default function BasketsPage() {
         description="Lightweight containers for your tasks, context, and thoughts"
         actions={
           <div className="flex flex-wrap gap-2">
-            <Button asChild>
-              <Link href="/baskets/new">+ Create Basket</Link>
-            </Button>
+            <Button onClick={() => setOpen(true)}>+ New Basket</Button>
+            <CreateBasketDialog open={open} onOpenChange={setOpen} />
             <Select value={sort} onValueChange={(v) => setSort(v)}>
               <SelectTrigger className="w-[150px]">
                 <SelectValue placeholder="Sort by" />

--- a/web/components/CreateBasketDialog.tsx
+++ b/web/components/CreateBasketDialog.tsx
@@ -37,7 +37,7 @@ export default function CreateBasketDialog({
     try {
       setLoading(true);
       const id = await mutate(basketName, templateSlug);
-      router.push(`/baskets/${id}/work`);
+      await router.push(`/baskets/${id}/work`);
       onOpenChange(false);
     } catch (err: any) {
       console.error(err);

--- a/web/components/CreateBasketDialog.tsx
+++ b/web/components/CreateBasketDialog.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/Input";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { Button } from "@/components/ui/Button";
+import { useCreateBasket } from "@/hooks/useCreateBasket";
+import { toast } from "react-hot-toast";
+
+export interface CreateBasketDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export default function CreateBasketDialog({
+  open,
+  onOpenChange,
+}: CreateBasketDialogProps) {
+  const router = useRouter();
+  const { mutate } = useCreateBasket();
+  const [step, setStep] = useState<0 | 1 | 2>(0);
+  const [basketName, setBasketName] = useState("");
+  const [templateSlug, setTemplateSlug] = useState<"brand_playbook" | "blank">(
+    "brand_playbook",
+  );
+  const [loading, setLoading] = useState(false);
+
+  const handleCreate = async () => {
+    try {
+      setLoading(true);
+      const id = await mutate(basketName, templateSlug);
+      router.push(`/baskets/${id}/work`);
+      onOpenChange(false);
+    } catch (err: any) {
+      console.error(err);
+      toast.error("Failed to create basket");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Create Basket</DialogTitle>
+        </DialogHeader>
+
+        <div className={step === 0 ? "space-y-4" : "hidden"}>
+          <label className="text-sm font-medium">Basket Name</label>
+          <Input
+            autoFocus
+            value={basketName}
+            onChange={(e) => setBasketName(e.target.value)}
+          />
+        </div>
+
+        <div className={step === 1 ? "space-y-4" : "hidden"}>
+          <RadioGroup
+            value={templateSlug}
+            onValueChange={(v) =>
+              setTemplateSlug(v as "brand_playbook" | "blank")
+            }
+            className="space-y-2"
+          >
+            <div className="flex items-center space-x-2">
+              <RadioGroupItem value="brand_playbook" id="tpl-brand" />
+              <label htmlFor="tpl-brand" className="text-sm">
+                Brand Playbook
+              </label>
+            </div>
+            <div className="flex items-center space-x-2">
+              <RadioGroupItem value="blank" id="tpl-blank" />
+              <label htmlFor="tpl-blank" className="text-sm">
+                Blank Basket
+              </label>
+            </div>
+          </RadioGroup>
+        </div>
+
+        <div className={step === 2 ? "space-y-4 text-center" : "hidden"}>
+          <p>Drag files here — coming soon</p>
+          <Button
+            variant="ghost"
+            type="button"
+            onClick={handleCreate}
+            disabled={loading}
+          >
+            Skip for now
+          </Button>
+        </div>
+
+        <DialogFooter className="pt-4">
+          {step > 0 && (
+            <Button
+              variant="ghost"
+              type="button"
+              onClick={() => setStep((s) => (s > 0 ? (s - 1) as 0 | 1 | 2 : s))}
+            >
+              Back
+            </Button>
+          )}
+          {step < 2 ? (
+            <Button
+              onClick={() => setStep((s) => (s + 1) as 0 | 1 | 2)}
+              disabled={basketName.trim() === "" || loading}
+            >
+              Next
+            </Button>
+          ) : (
+            <Button
+              onClick={handleCreate}
+              disabled={basketName.trim() === "" || loading}
+            >
+              {loading ? "Creating…" : "Create Basket"}
+            </Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/components/ui/radio-group.tsx
+++ b/web/components/ui/radio-group.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import * as React from "react";
+import * as RadioGroupPrimitive from "@radix-ui/react-radio-group";
+import { cn } from "@/lib/utils";
+
+const RadioGroup = RadioGroupPrimitive.Root;
+
+const RadioGroupItem = React.forwardRef<
+  React.ElementRef<typeof RadioGroupPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Item>
+>(({ className, ...props }, ref) => (
+  <RadioGroupPrimitive.Item
+    ref={ref}
+    className={cn(
+      "aspect-square h-4 w-4 rounded-full border border-primary text-primary focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+      "data-[state=checked]:bg-primary",
+      className,
+    )}
+    {...props}
+  >
+    <RadioGroupPrimitive.Indicator className="flex items-center justify-center">
+      <div className="h-2 w-2 rounded-full bg-current" />
+    </RadioGroupPrimitive.Indicator>
+  </RadioGroupPrimitive.Item>
+));
+RadioGroupItem.displayName = RadioGroupPrimitive.Item.displayName;
+
+export { RadioGroup, RadioGroupItem };

--- a/web/hooks/useCreateBasket.ts
+++ b/web/hooks/useCreateBasket.ts
@@ -1,0 +1,18 @@
+export const useCreateBasket = () => {
+  const mutate = async (
+    name: string,
+    slug: "brand_playbook" | "blank",
+  ): Promise<string> => {
+    const res = await fetch("/api/baskets/new", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name, template_slug: slug }),
+    });
+    if (!res.ok) {
+      throw new Error("create fail");
+    }
+    const json = await res.json();
+    return json.basket_id as string;
+  };
+  return { mutate };
+};

--- a/web/hooks/useCreateBasket.ts
+++ b/web/hooks/useCreateBasket.ts
@@ -6,7 +6,8 @@ export const useCreateBasket = () => {
     const res = await fetch("/api/baskets/new", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ name, template_slug: slug }),
+      credentials: "include",
+      body: JSON.stringify({ basket_name: name, template_slug: slug }),
     });
     if (!res.ok) {
       throw new Error("create fail");

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@hookform/resolvers": "^5.0.1",
         "@radix-ui/react-dialog": "^1.1.14",
+        "@radix-ui/react-radio-group": "^1.0.6",
         "@radix-ui/react-select": "^2.2.5",
         "@radix-ui/react-slot": "^1.2.2",
         "@radix-ui/react-tabs": "^1.1.12",
@@ -1101,6 +1102,38 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-radio-group": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-radio-group/-/react-radio-group-1.3.7.tgz",
+      "integrity": "sha512-9w5XhD0KPOrm92OTTE0SysH3sYzHsSTHNvZgUBo/VZ80VdYyB5RneDbc0dKpURS24IxkoFRu/hI0i4XyfFwY6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-presence": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.10",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/web/package.json
+++ b/web/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@hookform/resolvers": "^5.0.1",
     "@radix-ui/react-dialog": "^1.1.14",
+    "@radix-ui/react-radio-group": "^1.0.6",
     "@radix-ui/react-select": "^2.2.5",
     "@radix-ui/react-slot": "^1.2.2",
     "@radix-ui/react-tabs": "^1.1.12",


### PR DESCRIPTION
## Summary
- hook `useCreateBasket` for POSTing `/api/baskets/new`
- modal `CreateBasketDialog` to collect basket name and template
- radio group ui component added
- integrate dialog with baskets page
- add unit test for dialog flow

## Testing
- `make tests` *(fails: No solution found when resolving dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6866a77653348329854b432d5c5103f1