### PR TITLE
Add inline diff support on work page

### DIFF
--- a/web/__tests__/work_inline_diff.test.tsx
+++ b/web/__tests__/work_inline_diff.test.tsx
@@ -1,0 +1,44 @@
+import { render } from "@testing-library/react";
+import BlocksPane from "@/components/blocks/BlocksPane";
+import type { BlockWithHistory } from "@/types/block";
+import React from "react";
+
+test("renders diff card when previous revision exists", () => {
+  const blocks: BlockWithHistory[] = [
+    {
+      id: "b1",
+      semantic_type: "tone",
+      content: "new text here",
+      prev_rev_id: "p1",
+      prev_content: "old text",
+      state: "PROPOSED",
+      scope: null,
+      canonical_value: null,
+    },
+    {
+      id: "b2",
+      semantic_type: "tone",
+      content: "another",
+      state: "PROPOSED",
+      scope: null,
+      canonical_value: null,
+    },
+  ];
+  render(<BlocksPane blocks={blocks} />);
+  expect(document.querySelector(".diff-added")).toBeInTheDocument();
+});
+
+test("renders proposed block styling for new blocks", () => {
+  const blocks: BlockWithHistory[] = [
+    {
+      id: "p1",
+      semantic_type: "tone",
+      content: "brand new",
+      state: "PROPOSED",
+      scope: null,
+      canonical_value: null,
+    },
+  ];
+  const { container } = render(<BlocksPane blocks={blocks} />);
+  expect(container.querySelector(".block-proposed")).toBeInTheDocument();
+});

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono, Pacifico } from "next/font/google";
 import "./globals.css";
+import "../styles/diff.css";
 import SupabaseProvider from "@/components/SupabaseProvider";
 import { Toaster } from "react-hot-toast";
 import AppLayout from "@/components/layout/AppLayout";

--- a/web/components/InlineDiffCard.tsx
+++ b/web/components/InlineDiffCard.tsx
@@ -1,0 +1,42 @@
+import { diffWords } from "diff";
+import { Card } from "@/components/ui/Card";
+import type { BlockWithHistory } from "@/types/block";
+
+interface Props {
+  block: BlockWithHistory;
+}
+
+export default function InlineDiffCard({ block }: Props) {
+  const pieces = diffWords(block.prev_content || "", block.content || "");
+  return (
+    <Card className="space-y-1 p-4 hover:bg-muted cursor-pointer">
+      <div className="flex justify-between items-start">
+        <span className="text-sm font-medium">
+          {block.canonical_value || block.content.slice(0, 30)}
+        </span>
+        <span className="text-xs px-2 py-0.5 bg-muted rounded">
+          {block.semantic_type}
+        </span>
+      </div>
+      <p className="text-sm text-muted-foreground">
+        {pieces.map((part, idx) => {
+          if (part.added) {
+            return (
+              <span key={idx} className="diff-added">
+                {part.value}
+              </span>
+            );
+          }
+          if (part.removed) {
+            return (
+              <span key={idx} className="diff-removed">
+                {part.value}
+              </span>
+            );
+          }
+          return <span key={idx}>{part.value}</span>;
+        })}
+      </p>
+    </Card>
+  );
+}

--- a/web/components/blocks/BlocksPane.tsx
+++ b/web/components/blocks/BlocksPane.tsx
@@ -1,9 +1,10 @@
 import { Card } from "@/components/ui/Card";
 import Link from "next/link";
-import type { Block } from "@/types/block";
+import InlineDiffCard from "@/components/InlineDiffCard";
+import type { BlockWithHistory } from "@/types/block";
 
 export interface BlocksPaneProps {
-  blocks: Block[];
+  blocks: BlockWithHistory[];
 }
 
 export default function BlocksPane({ blocks }: BlocksPaneProps) {
@@ -19,20 +20,32 @@ export default function BlocksPane({ blocks }: BlocksPaneProps) {
     <div className="p-4 space-y-2">
       {proposed.map((block) => (
         <Link key={block.id} href={`/blocks/${block.id}`} className="block">
-          <Card className="space-y-1 p-4 hover:bg-muted cursor-pointer">
-            <div className="flex justify-between items-start">
-              <span className="text-sm font-medium">
-                {block.canonical_value || block.content.slice(0, 30)}
-              </span>
-              <span className="text-xs px-2 py-0.5 bg-muted rounded">
-                {block.semantic_type}
-              </span>
-            </div>
-            <p className="text-sm text-muted-foreground">
-              {block.content.slice(0, 120)}
-              {block.content.length > 120 ? "…" : ""}
-            </p>
-          </Card>
+          {block.prev_rev_id && block.prev_content ? (
+            <InlineDiffCard block={block} />
+          ) : (
+            <Card
+              className={`space-y-1 p-4 hover:bg-muted cursor-pointer ${
+                block.state === "PROPOSED" && !block.prev_rev_id
+                  ? "block-proposed"
+                  : ""
+              }`}
+            >
+              <div className="flex justify-between items-start">
+                <span className="text-sm font-medium">
+                  {block.canonical_value || block.content.slice(0, 30)}
+                </span>
+                <span className="text-xs px-2 py-0.5 bg-muted rounded badge">
+                  {block.semantic_type === "pending proposal"
+                    ? "PROPOSED"
+                    : block.semantic_type}
+                </span>
+              </div>
+              <p className="text-sm text-muted-foreground">
+                {block.content.slice(0, 120)}
+                {block.content.length > 120 ? "…" : ""}
+              </p>
+            </Card>
+          )}
         </Link>
       ))}
     </div>

--- a/web/lib/baskets/getSnapshot.ts
+++ b/web/lib/baskets/getSnapshot.ts
@@ -2,7 +2,7 @@
 import { apiGet } from "@/lib/api";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@/lib/dbTypes";
-import type { Block } from "@/types/block";
+import type { BlockWithHistory } from "@/types/block";
 
 /** Shape returned by /api/baskets/{id}/snapshot */
 export interface BasketSnapshot {
@@ -13,8 +13,8 @@ export interface BasketSnapshot {
   };
   raw_dump_body: string;
   file_refs: string[];
-  blocks: Block[];
-  proposed_blocks: Block[];
+  blocks: BlockWithHistory[];
+  proposed_blocks: BlockWithHistory[];
 }
 
 const SNAPSHOT_PREFIX = "/api/baskets/snapshot";
@@ -34,12 +34,20 @@ export async function getSnapshot(
     ...(payload.locked_blocks ?? []),
     ...(payload.constants ?? []),
     ...(payload.proposed_blocks ?? []),
-  ];
+  ].map((b: any) => ({
+    ...b,
+    prev_rev_id: b.prev_rev_id ?? null,
+    prev_content: b.prev_content ?? null,
+  }));
   return {
     basket: payload.basket,
     raw_dump_body: payload.raw_dump,
     file_refs: payload.file_refs ?? [],
     blocks: flatBlocks,
-    proposed_blocks: payload.proposed_blocks ?? [],
+    proposed_blocks: (payload.proposed_blocks ?? []).map((b: any) => ({
+      ...b,
+      prev_rev_id: b.prev_rev_id ?? null,
+      prev_content: b.prev_content ?? null,
+    })),
   };
 }

--- a/web/styles/diff.css
+++ b/web/styles/diff.css
@@ -1,0 +1,17 @@
+.diff-added {
+  background-color: rgba(74, 222, 128, 0.35);
+}
+.diff-removed {
+  background-color: rgba(239, 68, 68, 0.35);
+  text-decoration: line-through;
+}
+
+.block-proposed {
+  border-left: 4px solid var(--yellow-400);
+  background: var(--yellow-50);
+}
+
+.block-proposed .badge {
+  background: var(--yellow-200);
+  color: var(--yellow-900);
+}

--- a/web/types/block.ts
+++ b/web/types/block.ts
@@ -8,3 +8,8 @@ export type Block = {
   actor?: string;
   created_at?: string;
 };
+
+export type BlockWithHistory = Block & {
+  prev_rev_id?: string | null;
+  prev_content?: string | null;
+};


### PR DESCRIPTION
## Summary
- export new `InlineDiffCard` component with diff highlighting
- apply diff styles globally
- map `prev_rev_id` and `prev_content` in basket snapshot
- render diff cards for changed blocks in `BlocksPane`
- style newly proposed blocks and update unit test

Smoke test steps:
1. Accept a Block, edit it, save.
2. Refresh `/work` → edited Block shows red/green overlay.


------
https://chatgpt.com/codex/tasks/task_e_6866b8e5913083299d25698241e87a91