### PR TITLE
Add template wizard creation toggle

### DIFF
--- a/web/__tests__/CreateModeToggle.test.tsx
+++ b/web/__tests__/CreateModeToggle.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+import NewBasketPage from "@/app/baskets/new/page";
+
+let currentSearch = "";
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(currentSearch),
+}));
+
+afterEach(() => {
+  localStorage.clear();
+  currentSearch = "";
+});
+
+test("default renders wizard", () => {
+  render(<NewBasketPage />);
+  expect(screen.getByTestId("wizard")).toBeInTheDocument();
+});
+
+test("query ?mode=scratch shows ScratchCreation", () => {
+  currentSearch = "?mode=scratch";
+  render(<NewBasketPage />);
+  expect(screen.getByTestId("scratch")).toBeInTheDocument();
+});
+
+test("toggling updates localStorage", async () => {
+  const user = userEvent.setup();
+  render(<NewBasketPage />);
+  await user.click(screen.getByRole("tab", { name: /blank/i }));
+  expect(localStorage.getItem("rn-create-mode")).toBe("scratch");
+});

--- a/web/app/baskets/new/page.tsx
+++ b/web/app/baskets/new/page.tsx
@@ -1,72 +1,25 @@
 "use client";
-import { useState } from "react";
-import { Button } from "@/components/ui/Button";
-import SmartDropZone from "@/components/SmartDropZone";
-import { UploadArea } from "@/components/baskets/UploadArea";
-import { createBasketNew } from "@/lib/baskets/createBasketNew";
-import { useRouter } from "next/navigation";
-import PageHeader from "@/components/page/PageHeader";
-import { isAuthError } from "@/lib/utils";
+export const dynamic = "force-dynamic";
+import { CreationModeToggle } from "@/components/template-wizard/CreationModeToggle";
+import { TemplateWizard } from "@/components/template-wizard/TemplateWizard";
+import { ScratchCreation } from "@/components/template-wizard/ScratchCreation";
+import { useCreationMode } from "@/lib/hooks/useCreationMode";
+import { Suspense } from "react";
+
+function NewBasketInner() {
+  const { mode, setMode } = useCreationMode();
+  return (
+    <div className="flex flex-col items-center pt-8">
+      <CreationModeToggle mode={mode} onChange={setMode} />
+      {mode === "wizard" ? <TemplateWizard /> : <ScratchCreation />}
+    </div>
+  );
+}
 
 export default function NewBasketPage() {
-  const router = useRouter();
-  const [text, setText] = useState("");
-  const [files, setFiles] = useState<string[]>([]);
-  const [submitting, setSubmitting] = useState(false);
-
-  const handleCreate = async () => {
-    if (!text.trim()) {
-      alert("Please enter some text 😊");
-      return;
-    }
-    setSubmitting(true);
-    try {
-      const { id } = await createBasketNew({
-        text_dump: text,
-        file_urls: files,
-      });
-      router.push(`/baskets/${id}/work`);
-    } catch (err) {
-      console.error(err);
-      if (isAuthError(err)) {
-        router.push("/login");
-      } else {
-        alert("Failed to create basket");
-      }
-    } finally {
-      setSubmitting(false);
-    }
-  };
-
   return (
-    <div className="max-w-4xl mx-auto space-y-6">
-      <PageHeader
-        emoji="🆕"
-        title="Create New Basket"
-        description="Begin a fresh container for your ideas and files"
-      />
-
-      <div className="space-y-4">
-        <SmartDropZone
-          className="w-full min-h-[200px] border rounded-md p-3"
-          placeholder="Drop your thoughts here..."
-          value={text}
-          onChange={(e) => setText(e.target.value)}
-          readOnly={submitting}
-        />
-
-        <UploadArea
-          prefix="dump"
-          maxFiles={5}
-          onUpload={(url) => setFiles((prev) => [...prev, url])}
-        />
-
-        <div className="flex justify-end">
-          <Button onClick={handleCreate} disabled={submitting || !text.trim()}>
-            {submitting ? "Creating…" : "Create"}
-          </Button>
-        </div>
-      </div>
-    </div>
+    <Suspense>
+      <NewBasketInner />
+    </Suspense>
   );
 }

--- a/web/app/components/layout/Sidebar.tsx
+++ b/web/app/components/layout/Sidebar.tsx
@@ -10,7 +10,8 @@ import { X } from "lucide-react";
 const baseItems = [
   { href: "/dashboard", label: "🧶 Dashboard" },
   { href: "/baskets", label: "🧺 Baskets" },
-  { href: "/baskets/new", label: "➕ New Basket" },
+  { href: "/baskets/new?mode=wizard", label: "➕ New Basket (guided)" },
+  { href: "/baskets/new?mode=scratch", label: "➕ New Basket (blank)" },
   { href: "/blocks", label: "◾ Blocks" },
   { href: "/settings", label: "⚙️ Settings" },
 ];

--- a/web/components/layouts/DashboardNav.tsx
+++ b/web/components/layouts/DashboardNav.tsx
@@ -14,7 +14,8 @@ interface NavItem {
 const navItems: NavItem[] = [
   { title: "Dashboard", href: "/dashboard", icon: Home },
   { title: "Baskets", href: "/baskets", icon: User },
-  { title: "New Basket", href: "/baskets/new", icon: User },
+  { title: "New Basket (guided)", href: "/baskets/new?mode=wizard", icon: User },
+  { title: "New Basket (blank)", href: "/baskets/new?mode=scratch", icon: User },
   { title: "Blocks", href: "/blocks", icon: User },
   { title: "Queue", href: "/queue", icon: User },
 ];

--- a/web/components/template-wizard/CreationModeToggle.tsx
+++ b/web/components/template-wizard/CreationModeToggle.tsx
@@ -1,0 +1,19 @@
+"use client";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import type { CreationMode } from "@/lib/hooks/useCreationMode";
+
+interface Props {
+  mode: CreationMode;
+  onChange: (mode: CreationMode) => void;
+}
+
+export function CreationModeToggle({ mode, onChange }: Props) {
+  return (
+    <Tabs value={mode} onValueChange={(v) => onChange(v as CreationMode)} className="mb-4">
+      <TabsList>
+        <TabsTrigger value="wizard">Guided</TabsTrigger>
+        <TabsTrigger value="scratch">Blank</TabsTrigger>
+      </TabsList>
+    </Tabs>
+  );
+}

--- a/web/components/template-wizard/ScratchCreation.tsx
+++ b/web/components/template-wizard/ScratchCreation.tsx
@@ -1,0 +1,72 @@
+"use client";
+import { useState } from "react";
+import { Button } from "@/components/ui/Button";
+import SmartDropZone from "@/components/SmartDropZone";
+import { UploadArea } from "@/components/baskets/UploadArea";
+import { createBasketNew } from "@/lib/baskets/createBasketNew";
+import { useRouter } from "next/navigation";
+import PageHeader from "@/components/page/PageHeader";
+import { isAuthError } from "@/lib/utils";
+
+export function ScratchCreation() {
+  const router = useRouter();
+  const [text, setText] = useState("");
+  const [files, setFiles] = useState<string[]>([]);
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleCreate = async () => {
+    if (!text.trim()) {
+      alert("Please enter some text 😊");
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const { id } = await createBasketNew({
+        text_dump: text,
+        file_urls: files,
+      });
+      router.push(`/baskets/${id}/work`);
+    } catch (err) {
+      console.error(err);
+      if (isAuthError(err)) {
+        router.push("/login");
+      } else {
+        alert("Failed to create basket");
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="max-w-4xl mx-auto space-y-6" data-testid="scratch">
+      <PageHeader
+        emoji="🆕"
+        title="Create New Basket"
+        description="Begin a fresh container for your ideas and files"
+      />
+
+      <div className="space-y-4">
+        <SmartDropZone
+          className="w-full min-h-[200px] border rounded-md p-3"
+          placeholder="Drop your thoughts here..."
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          readOnly={submitting}
+        />
+
+        <UploadArea
+          prefix="dump"
+          maxFiles={5}
+          onUpload={(url) => setFiles((prev) => [...prev, url])}
+        />
+
+        <div className="flex justify-end">
+          <Button onClick={handleCreate} disabled={submitting || !text.trim()}>
+            {submitting ? "Creating…" : "Create"}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/components/template-wizard/TemplateWizard.tsx
+++ b/web/components/template-wizard/TemplateWizard.tsx
@@ -1,0 +1,31 @@
+"use client";
+import { Button } from "@/components/ui/Button";
+import { ProgressStepper } from "@/components/ui/ProgressStepper";
+import { useTemplateWizard } from "@/lib/hooks/useTemplateWizard";
+
+const stepLabels = ["Start", "Upload", "Guidelines", "Review"];
+
+export function TemplateWizard() {
+  const { step, next, back, createBasket } = useTemplateWizard();
+
+  return (
+    <div className="w-full max-w-2xl space-y-4" data-testid="wizard">
+      <ProgressStepper current={step + 1} steps={stepLabels} />
+      <div className="border rounded-md p-6 text-center min-h-[150px]">
+        <p>Wizard step {step + 1}</p>
+      </div>
+      <div className="flex justify-between">
+        {step > 0 && (
+          <Button variant="ghost" onClick={back}>
+            Back
+          </Button>
+        )}
+        {step < 3 ? (
+          <Button onClick={next}>Next</Button>
+        ) : (
+          <Button onClick={createBasket}>Create Basket</Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/lib/hooks/useCreationMode.ts
+++ b/web/lib/hooks/useCreationMode.ts
@@ -1,0 +1,32 @@
+import { useEffect, useState } from "react";
+import { useSearchParams } from "next/navigation";
+
+export type CreationMode = "wizard" | "scratch";
+
+export function useCreationMode() {
+  const searchParams = useSearchParams();
+  const [mode, setModeState] = useState<CreationMode>("wizard");
+
+  useEffect(() => {
+    const param = searchParams?.get("mode");
+    let initial: CreationMode | null = null;
+    if (param === "wizard" || param === "scratch") {
+      initial = param;
+    } else if (typeof window !== "undefined") {
+      const stored = localStorage.getItem("rn-create-mode");
+      if (stored === "wizard" || stored === "scratch") {
+        initial = stored as CreationMode;
+      }
+    }
+    setModeState(initial ?? "wizard");
+  }, [searchParams]);
+
+  const setMode = (m: CreationMode) => {
+    setModeState(m);
+    if (typeof window !== "undefined") {
+      localStorage.setItem("rn-create-mode", m);
+    }
+  };
+
+  return { mode, setMode };
+}

--- a/web/lib/hooks/useTemplateWizard.ts
+++ b/web/lib/hooks/useTemplateWizard.ts
@@ -1,0 +1,16 @@
+import { useState } from "react";
+
+export type WizardStep = 0 | 1 | 2 | 3;
+
+export function useTemplateWizard() {
+  const [step, setStep] = useState<WizardStep>(0);
+
+  const next = () => setStep((s) => (s < 3 ? ((s + 1) as WizardStep) : s));
+  const back = () => setStep((s) => (s > 0 ? ((s - 1) as WizardStep) : s));
+
+  const createBasket = () => {
+    console.log("createBasket stub");
+  };
+
+  return { step, next, back, setStep, createBasket };
+}


### PR DESCRIPTION
## Summary
- implement a creation-mode toggle with persistent localStorage
- move old basket creation form into `ScratchCreation`
- add a stub template wizard and mode hook
- route `/baskets/new` loads wizard or scratch based on toggle
- update navigation links for guided vs blank creation
- add tests for mode selection behaviour

## Testing
- `npm run build`
- `make tests` *(fails: unsatisfiable dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6869fd8d12ec8329a7074e64eefde117