### PR TITLE
Add document_id to RawDump model

### DIFF
--- a/api/src/app/models/raw_dump.py
+++ b/api/src/app/models/raw_dump.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+from uuid import UUID
+
+from pydantic import BaseModel
+
+
+class RawDump(BaseModel):
+    """Raw input text unit recorded for a document."""
+
+    id: UUID
+    basket_id: UUID
+    document_id: Optional[UUID] = None
+    body_md: Optional[str] = None
+    file_refs: Optional[list[str]] = None
+    created_at: datetime
+    workspace_id: UUID
+    file_url: Optional[str] = None

--- a/api/tests/api/test_template_create.py
+++ b/api/tests/api/test_template_create.py
@@ -63,6 +63,7 @@ def test_create_from_template(monkeypatch):
     assert len(store.get("baskets", [])) == 1
     assert len(store.get("documents", [])) == 3
     assert len(store.get("raw_dumps", [])) == 3
+    assert all(rd.get("document_id") for rd in store["raw_dumps"])
     assert all(rd["file_url"] == f"f{i+1}" for i, rd in enumerate(store["raw_dumps"]))
     assert store["blocks"][0]["text"] == "{{BRAND_NAME}}"
     assert store["context_items"][0]["content"] == payload["guidelines"]

--- a/api/tests/models/test_raw_dump_model.py
+++ b/api/tests/models/test_raw_dump_model.py
@@ -1,0 +1,15 @@
+from datetime import datetime
+from uuid import uuid4
+
+from app.models.raw_dump import RawDump
+
+
+def test_raw_dump_accepts_document_id():
+    rd = RawDump(
+        id=uuid4(),
+        basket_id=uuid4(),
+        document_id=uuid4(),
+        created_at=datetime.utcnow(),
+        workspace_id=uuid4(),
+    )
+    assert rd.document_id is not None


### PR DESCRIPTION
## Summary
- add `RawDump` Pydantic model with new optional `document_id` field
- verify template creation inserts dumps with `document_id`
- unit test to ensure `RawDump` accepts `document_id`

## Testing
- `make tests` *(fails: AttributeError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_686f492c3164832998908893e96c1c2d