### PR TITLE
Implement route-based collapsible sidebar

### DIFF
--- a/web/components/layouts/Shell.tsx
+++ b/web/components/layouts/Shell.tsx
@@ -10,14 +10,28 @@ export default function Shell({ children }: { children: React.ReactNode }) {
     <div className="relative flex h-full">
       {!isOpen && collapsible && (
         <button
-          className="fixed top-4 left-4 z-50 p-2 rounded bg-black text-white"
+          aria-label="Open Sidebar"
+          className="fixed top-4 left-4 z-50 p-2 rounded border border-gray-300 bg-white text-gray-600 shadow-sm hover:bg-gray-100"
           onClick={openSidebar}
         >
-          ☰
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth={1.5}
+            stroke="currentColor"
+            className="w-6 h-6"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M3.75 5.25h16.5m-16.5 6h16.5m-16.5 6h16.5"
+            />
+          </svg>
         </button>
       )}
       <Sidebar />
-      <main className="flex-1 overflow-auto">{children}</main>
+      <main className="flex-1 overflow-auto px-4 pt-16 md:pt-8 md:px-8">{children}</main>
     </div>
   );
 }

--- a/web/hooks/useAutoSidebarBehavior.ts
+++ b/web/hooks/useAutoSidebarBehavior.ts
@@ -9,5 +9,5 @@ export function useAutoSidebarBehavior() {
   useEffect(() => {
     const shouldCollapse = pathname.startsWith('/baskets') || pathname.startsWith('/blocks')
     setCollapsible(shouldCollapse)
-  }, [pathname, setCollapsible])
+  }, [pathname])
 }


### PR DESCRIPTION
## Summary
- fine tune auto sidebar hook
- style shell hamburger button and add layout padding

## Testing
- `make tests` *(fails: 22 failed)*

------
https://chatgpt.com/codex/tasks/task_e_686f5eaa33148329906a60ceb9393d7b