### PR TITLE
Fix sidebar auto-hide behavior

### DIFF
--- a/web/hooks/useAutoSidebarBehavior.ts
+++ b/web/hooks/useAutoSidebarBehavior.ts
@@ -5,9 +5,21 @@ import { useSidebarStore } from '@/lib/stores/sidebarStore'
 export function useAutoSidebarBehavior() {
   const pathname = usePathname()
   const setCollapsible = useSidebarStore((s) => s.setCollapsible)
+  const openSidebar = useSidebarStore((s) => s.openSidebar)
+  const closeSidebar = useSidebarStore((s) => s.closeSidebar)
 
   useEffect(() => {
-    const shouldCollapse = pathname.startsWith('/baskets') || pathname.startsWith('/blocks')
-    setCollapsible(shouldCollapse)
+    const hideSidebar =
+      /^\/baskets\/[^/]+\/work/.test(pathname) ||
+      pathname.startsWith('/baskets/new') ||
+      /^\/blocks\/[^/]+$/.test(pathname)
+
+    setCollapsible(hideSidebar)
+
+    if (hideSidebar) {
+      closeSidebar()
+    } else {
+      openSidebar()
+    }
   }, [pathname])
 }


### PR DESCRIPTION
## Summary
- tweak `useAutoSidebarBehavior` to close sidebar by default on selected pages

## Testing
- `make tests` *(fails: Runtime errors and 422 responses)*

------
https://chatgpt.com/codex/tasks/task_e_686f6a06c0f8832993d3951cc3ecea63