### PR TITLE
Add event_log stub

### DIFF
--- a/api/src/app/utils/event_log.py
+++ b/api/src/app/utils/event_log.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+
+def log_event(kind: str, payload: dict | None = None) -> None:
+    """Placeholder logger.  In future this will insert into the
+    `events` table or send to telemetry.  For now it is a no-op.
+    """
+    return None

--- a/tests/utils/test_event_log.py
+++ b/tests/utils/test_event_log.py
@@ -1,0 +1,10 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../api/src"))
+
+from app.utils.event_log import log_event  # noqa: E402
+
+
+def test_log_event_returns_none():
+    assert log_event("doc_scaffold_finished", {"basket_id": "123"}) is None


### PR DESCRIPTION
## Summary
- add placeholder `log_event` in `app.utils`
- test that `log_event` returns `None`

## Testing
- `.venv/bin/pytest tests/utils/test_event_log.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6872024413b083299e12bf80f0744c54