### PR TITLE
feat: workbench document list

### DIFF
--- a/web/__tests__/DocumentList.test.tsx
+++ b/web/__tests__/DocumentList.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { vi } from "vitest";
+import DocumentList from "../components/documents/DocumentList";
+
+vi.mock("../lib/baskets/useDocuments", () => ({
+  useDocuments: vi.fn(),
+}));
+
+import { useDocuments } from "../lib/baskets/useDocuments";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+
+it("renders docs and highlights active", () => {
+  useDocuments.mockReturnValue({
+    docs: [
+      { id: "d1", title: "Doc A", updated_at: "2025-01-01" },
+      { id: "d2", title: null, updated_at: "2025-01-02" },
+      { id: "d3", title: "Doc C", updated_at: "2025-01-03" },
+    ],
+    isLoading: false,
+    error: null,
+  });
+
+  render(<DocumentList basketId="b1" activeId="d2" />);
+
+  expect(screen.getByText("Doc A")).toBeInTheDocument();
+  expect(screen.getByText("Untitled Document")).toBeInTheDocument();
+  const active = screen.getByText("Untitled Document").closest("li");
+  expect(active).toHaveClass("ring-2");
+});
+
+it("skeleton visible during isLoading", () => {
+  useDocuments.mockReturnValue({ docs: [], isLoading: true, error: null });
+  render(<DocumentList basketId="b1" />);
+  expect(screen.getAllByRole("listitem")).toHaveLength(3);
+});

--- a/web/components/documents/DocumentList.tsx
+++ b/web/components/documents/DocumentList.tsx
@@ -1,10 +1,6 @@
 "use client";
-import Link from "next/link";
-import dayjs from "dayjs";
-import relativeTime from "dayjs/plugin/relativeTime";
-import { useDocuments } from "@/lib/baskets/useDocuments";
-
-dayjs.extend(relativeTime);
+import { useRouter } from "next/navigation";
+import { useDocuments } from "../../lib/baskets/useDocuments";
 
 interface Props {
   basketId: string;
@@ -13,6 +9,7 @@ interface Props {
 
 export default function DocumentList({ basketId, activeId }: Props) {
   const { docs, isLoading, error } = useDocuments(basketId);
+  const router = useRouter();
 
   if (isLoading) {
     return (
@@ -30,26 +27,28 @@ export default function DocumentList({ basketId, activeId }: Props) {
     );
   }
 
+  if (docs.length === 0) {
+    return (
+      <div className="p-6 text-sm text-muted-foreground">No documents yet</div>
+    );
+  }
+
   return (
     <ul className="p-6 space-y-2 overflow-y-auto flex-1">
       {docs.map((doc) => {
         const isActive = doc.id === activeId;
+        const title = doc.title || "Untitled Document";
         return (
           <li
             key={doc.id}
-            className={`border rounded-md p-3 flex items-center gap-3 ${
+            onClick={() =>
+              router.push(`/baskets/${basketId}/docs/${doc.id}/work`)
+            }
+            className={`border rounded-md p-3 flex items-center gap-3 cursor-pointer ${
               isActive ? "ring-2 ring-primary" : ""
             }`}
           >
-            <Link
-              href={`/baskets/${basketId}/docs/${doc.id}/work`}
-              className="flex-1 truncate"
-            >
-              {doc.title}
-            </Link>
-            <span className="text-[10px] text-muted-foreground shrink-0">
-              {dayjs(doc.updated_at).fromNow()}
-            </span>
+            <span className="flex-1 truncate">{title}</span>
           </li>
         );
       })}

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -1,7 +1,7 @@
 /**
  * Simple wrapper for API calls to your FastAPI server at api.yarnnn.com.
  */
-import { fetchWithToken } from "@/lib/fetchWithToken";
+import { fetchWithToken } from "./fetchWithToken";
 
 export const API_BASE_URL =
   process.env.NEXT_PUBLIC_API_BASE_URL || "https://api.yarnnn.com";

--- a/web/lib/baskets/useDocuments.ts
+++ b/web/lib/baskets/useDocuments.ts
@@ -1,9 +1,9 @@
 import useSWR from "swr";
-import { apiGet } from "@/lib/api";
+import { apiGet } from "../api";
 
 export interface DocumentRow {
   id: string;
-  title: string;
+  title: string | null;
   updated_at: string;
 }
 
@@ -13,6 +13,7 @@ export function useDocuments(basketId: string) {
   const { data, error, isLoading } = useSWR(
     () => (basketId ? `/api/baskets/${basketId}/docs` : null),
     fetcher,
+    { refreshInterval: 10_000 },
   );
   return { docs: data ?? [], isLoading, error };
 }

--- a/web/lib/fetchWithToken.ts
+++ b/web/lib/fetchWithToken.ts
@@ -1,4 +1,4 @@
-import { createClient } from "@/lib/supabaseClient";
+import { createClient } from "./supabaseClient";
 
 export async function fetchWithToken(
   input: RequestInfo | URL,


### PR DESCRIPTION
## Summary
- list basket documents via new `useDocuments` hook
- show document list with active/highlighted doc and skeleton loader
- adjust API utils to use relative imports
- add unit test for `DocumentList`

## Testing
- `npx vitest run web/__tests__/DocumentList.test.tsx` *(fails: Cannot find package '@testing-library/react')*

------
https://chatgpt.com/codex/tasks/task_e_687207e0d76c8329b376e0ff65ad71b9