### PR TITLE
feat(workbench): right panel tabs + block CRUD

### DIFF
--- a/api/src/app/routes/blocks.py
+++ b/api/src/app/routes/blocks.py
@@ -1,10 +1,11 @@
 import logging
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Body
 
 from ..utils.supabase_client import supabase_client as supabase
 from ..utils.jwt import verify_jwt
 from ..utils.workspace import get_or_create_workspace
+from ..utils.errors import raise_on_supabase_error
 
 router = APIRouter(tags=["blocks"])
 
@@ -26,4 +27,47 @@ def list_blocks(basket_id: str, user: dict = Depends(verify_jwt)):
         return resp.data  # type: ignore[attr-defined]
     except Exception as err:
         logger.exception("list_blocks failed")
+        raise HTTPException(status_code=500, detail="internal error") from err
+
+
+@router.put("/blocks/{block_id}")
+def update_block(
+    block_id: str,
+    body: dict = Body(...),
+    user: dict = Depends(verify_jwt),
+):
+    """Update a block if it belongs to the caller's workspace."""
+    try:
+        workspace_id = get_or_create_workspace(user["user_id"])
+        resp = (
+            supabase.table("blocks")
+            .update(body)
+            .eq("id", block_id)
+            .eq("workspace_id", workspace_id)
+            .execute()
+        )
+        raise_on_supabase_error(resp)
+        data = resp.data[0] if hasattr(resp, "data") else resp.json()[0]
+        return data
+    except Exception as err:  # pragma: no cover - network failure
+        logger.exception("update_block failed")
+        raise HTTPException(status_code=500, detail="internal error") from err
+
+
+@router.delete("/blocks/{block_id}", status_code=204)
+def delete_block(block_id: str, user: dict = Depends(verify_jwt)):
+    """Delete a block if it belongs to the caller's workspace."""
+    try:
+        workspace_id = get_or_create_workspace(user["user_id"])
+        resp = (
+            supabase.table("blocks")
+            .delete()
+            .eq("id", block_id)
+            .eq("workspace_id", workspace_id)
+            .execute()
+        )
+        raise_on_supabase_error(resp)
+        return
+    except Exception as err:  # pragma: no cover - network failure
+        logger.exception("delete_block failed")
         raise HTTPException(status_code=500, detail="internal error") from err

--- a/api/tests/api/test_blocks.py
+++ b/api/tests/api/test_blocks.py
@@ -1,0 +1,112 @@
+import types
+import uuid
+import sys
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import os
+os.environ.setdefault("SUPABASE_URL", "http://localhost")
+
+os.environ.setdefault("SUPABASE_SERVICE_ROLE_KEY", "svc.key")
+sys.modules.setdefault("supabase", types.SimpleNamespace(create_client=lambda *a, **k: None))
+
+from app.routes.blocks import router as blocks_router, verify_jwt, get_or_create_workspace
+
+app = FastAPI()
+app.include_router(blocks_router, prefix="/api")
+app.dependency_overrides[verify_jwt] = lambda: {"user_id": "00000000-0000-0000-0000-000000000000"}
+app.dependency_overrides[get_or_create_workspace] = lambda: "ws1"
+client = TestClient(app)
+
+
+class Resp:
+    def __init__(self, data=None, status_code=200, error=None):
+        self.data = data
+        self.status_code = status_code
+        self.error = error
+
+    def json(self):  # pragma: no cover - compatibility
+        return self.data
+
+
+def _fake_table(name, store):
+    def update(data):
+        q_filters = []
+
+        def eq(col, val):
+            q_filters.append((col, val))
+            return query
+
+        def execute():
+            rows = store.get(name, [])
+            updated = None
+            for row in rows:
+                if all(row.get(c) == v for c, v in q_filters):
+                    row.update(data)
+                    updated = row
+                    break
+            return Resp([updated] if updated else [])
+
+        query = types.SimpleNamespace(eq=eq, execute=execute)
+        return query
+
+    def delete():
+        q_filters = []
+
+        def eq(col, val):
+            q_filters.append((col, val))
+            return query
+
+        def execute():
+            rows = store.get(name, [])
+            store[name] = [r for r in rows if not all(r.get(c) == v for c, v in q_filters)]
+            return Resp()
+
+        query = types.SimpleNamespace(eq=eq, execute=execute)
+        return query
+
+    def select(cols="*"):
+        q_filters = []
+        single = False
+
+        def eq(col, val):
+            q_filters.append((col, val))
+            return query
+
+        def order(_c):
+            return query
+
+        def execute():
+            rows = store.get(name, [])
+            for c, v in q_filters:
+                rows = [r for r in rows if r.get(c) == v]
+            data = rows[0] if single else rows
+            return Resp(data)
+
+        query = types.SimpleNamespace(eq=eq, order=order, single=lambda: query, execute=execute)
+        return query
+
+    return types.SimpleNamespace(update=update, delete=delete, select=select)
+
+
+def _fake_supabase(store):
+    return types.SimpleNamespace(table=lambda n: _fake_table(n, store))
+
+
+def test_block_update_delete(monkeypatch):
+    store = {"blocks": [{"id": "b1", "workspace_id": "ws1", "basket_id": "bx", "content": "old"}]}
+    fake = _fake_supabase(store)
+    monkeypatch.setattr("app.routes.blocks.supabase", fake)
+    monkeypatch.setattr(
+        "app.routes.blocks.verify_jwt",
+        lambda *_a, **_k: {"user_id": "00000000-0000-0000-0000-000000000000"},
+    )
+    monkeypatch.setattr("app.routes.blocks.get_or_create_workspace", lambda *_a, **_k: "ws1")
+
+    r = client.put("/api/blocks/b1", json={"content": "new"})
+    assert r.status_code == 200
+    assert store["blocks"][0]["content"] == "new"
+
+    r = client.delete("/api/blocks/b1")
+    assert r.status_code == 204
+    assert store["blocks"] == []

--- a/docs/CONTEXT_ITEMS_API.md
+++ b/docs/CONTEXT_ITEMS_API.md
@@ -4,9 +4,9 @@ Context items are short snippets of guidance attached to a basket. Each item bel
 
 ## Endpoints
 
-- `POST /api/context-items` – create an item
-- `GET /api/context-items` – list items for the active basket
-- `GET /api/context-items/{id}` – fetch a single item
-- `PUT /api/context-items/{id}` – update content or status
-- `DELETE /api/context-items/{id}` – remove an item
+- `POST /api/context_items` – create an item
+- `GET /api/context_items` – list items for the active basket
+- `GET /api/context_items/{id}` – fetch a single item
+- `PUT /api/context_items/{id}` – update content or status
+- `DELETE /api/context_items/{id}` – remove an item
 

--- a/web/app/baskets/[id]/docs/[did]/work/page.tsx
+++ b/web/app/baskets/[id]/docs/[did]/work/page.tsx
@@ -1,6 +1,5 @@
 import WorkbenchLayoutDev from "@/components/workbench/WorkbenchLayoutDev";
-import ContextPanel from "@/components/context/ContextPanel";
-import BlockLegend from "@/components/documents/BlockLegend";
+import RightPanelTabs from "@/components/workbench/RightPanelTabs";
 import { createServerSupabaseClient } from "@/lib/supabaseServerClient";
 import { redirect } from "next/navigation";
 
@@ -69,10 +68,11 @@ export default async function DocWorkPage({ params }: PageProps) {
     <WorkbenchLayoutDev
       initialSnapshot={snapshot}
       rightPanel={
-        <div>
-          <ContextPanel items={guidelines} />
-          <BlockLegend />
-        </div>
+        <RightPanelTabs
+          basketId={id}
+          blocks={blocks || []}
+          contextItems={guidelines}
+        />
       }
     />
   );

--- a/web/components/context/ContextPanel.tsx
+++ b/web/components/context/ContextPanel.tsx
@@ -2,7 +2,9 @@
 
 export interface ContextItem {
   id: string;
+  type?: string;
   content: string;
+  status: "active" | "verified";
 }
 
 export default function ContextPanel({ items }: { items: ContextItem[] }) {

--- a/web/components/context/ContextPanel.tsx
+++ b/web/components/context/ContextPanel.tsx
@@ -4,7 +4,8 @@ export interface ContextItem {
   id: string;
   type?: string;
   content: string;
-  status: "active" | "verified";
+  /** undefined = active (back-compat) */
+  status?: "active" | "verified";
 }
 
 export default function ContextPanel({ items }: { items: ContextItem[] }) {

--- a/web/components/ui/Skeleton.tsx
+++ b/web/components/ui/Skeleton.tsx
@@ -1,0 +1,13 @@
+"use client";
+import { cn } from "@/lib/utils";
+
+export function Skeleton({ className }: { className?: string }) {
+  return (
+    <div
+      className={cn(
+        "animate-pulse bg-muted rounded-md w-full h-4",
+        className
+      )}
+    />
+  );
+}

--- a/web/components/workbench/RightPanelTabs.tsx
+++ b/web/components/workbench/RightPanelTabs.tsx
@@ -1,0 +1,122 @@
+"use client";
+import { useState } from "react";
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+import { Button } from "@/components/ui/Button";
+import ContextPanel, { ContextItem } from "@/components/context/ContextPanel";
+import { createContextItem, updateContextItem, deleteContextItem } from "@/lib/contextItems";
+import { apiDelete, apiPut } from "@/lib/api";
+
+interface Block {
+  id: string;
+  content: string;
+  state: string;
+  scope?: string | null;
+}
+
+export default function RightPanelTabs({
+  basketId,
+  blocks: initialBlocks,
+  contextItems: initialItems,
+}: {
+  basketId: string;
+  blocks: Block[];
+  contextItems: ContextItem[];
+}) {
+  const [tab, setTab] = useState("context");
+  const [blocks, setBlocks] = useState(initialBlocks);
+  const [items, setItems] = useState(initialItems);
+
+  async function handleDeleteBlock(id: string) {
+    if (!window.confirm("Are you sure you want to delete this block?")) return;
+    await apiDelete(`/api/blocks/${id}`);
+    setBlocks((b) => b.filter((blk) => blk.id !== id));
+    console.log("log_event", "block_deleted", { id });
+  }
+
+  async function handleEditBlock(block: Block) {
+    const content = window.prompt("Edit block text", block.content);
+    if (content === null) return;
+    const scope = window.prompt("Scope", block.scope || "") || null;
+    const res = await apiPut(`/api/blocks/${block.id}`, { content, scope });
+    setBlocks((b) => b.map((blk) => (blk.id === block.id ? { ...blk, content, scope } : blk)));
+    console.log("log_event", "block_updated", res);
+  }
+
+  async function handleToggleItem(it: ContextItem, verified: boolean) {
+    const status = verified ? "verified" : "active";
+    await updateContextItem(it.id, { status });
+    setItems((arr) => arr.map((i) => (i.id === it.id ? { ...i, status } : i)));
+  }
+
+  async function handleEditItem(it: ContextItem) {
+    const content = window.prompt("Edit content", it.content);
+    if (content === null) return;
+    await updateContextItem(it.id, { content });
+    setItems((arr) => arr.map((i) => (i.id === it.id ? { ...i, content } : i)));
+  }
+
+  async function handleAdd() {
+    const type = window.prompt("Type", "guideline");
+    if (!type) return;
+    const content = window.prompt("Content");
+    if (!content) return;
+    const res = await createContextItem({ basket_id: basketId, type, content, status: "active" });
+    setItems((arr) => [...arr, res as any]);
+  }
+
+  return (
+    <Tabs value={tab} onValueChange={setTab} defaultValue="context" className="w-full">
+      <TabsList className="grid grid-cols-2 m-2">
+        <TabsTrigger value="context">Context</TabsTrigger>
+        <TabsTrigger value="blocks">Blocks</TabsTrigger>
+      </TabsList>
+      <TabsContent value="context">
+        <div className="p-2">
+          <Button size="sm" onClick={handleAdd} className="mb-2">
+            + Add Context Item
+          </Button>
+          {items.length === 0 ? (
+            <div className="text-sm text-muted-foreground">No context items.</div>
+          ) : (
+            items.map((it) => (
+              <div key={it.id} className="border rounded p-2 mb-2 flex justify-between text-sm">
+                <span>{it.content}</span>
+                <span className="space-x-2">
+                  <label className="text-xs">
+                    ✔ Verified
+                    <input
+                      type="checkbox"
+                      className="ml-1"
+                      checked={it.status === "verified"}
+                      onChange={(e) => handleToggleItem(it, e.target.checked)}
+                    />
+                  </label>
+                  <button onClick={() => handleEditItem(it)}>✏️</button>
+                </span>
+              </div>
+            ))
+          )}
+        </div>
+      </TabsContent>
+      <TabsContent value="blocks">
+        <div className="p-2">
+          {blocks.length === 0 ? (
+            <div className="text-sm text-muted-foreground">No blocks.</div>
+          ) : (
+            blocks.map((b) => (
+              <div key={b.id} className="border rounded p-2 mb-2 text-sm flex justify-between">
+                <span>{b.content.slice(0, 80)}</span>
+                {b.state !== "LOCKED" && (
+                  <span className="space-x-2">
+                    <button onClick={() => handleEditBlock(b)}>✏️</button>
+                    <button onClick={() => handleDeleteBlock(b.id)}>🗑</button>
+                  </span>
+                )}
+              </div>
+            ))
+          )}
+        </div>
+      </TabsContent>
+    </Tabs>
+  );
+}

--- a/web/components/workbench/RightPanelTabs.tsx
+++ b/web/components/workbench/RightPanelTabs.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { Button } from "@/components/ui/Button";
 import ContextPanel, { ContextItem } from "@/components/context/ContextPanel";
+import { Skeleton } from "@/components/ui/Skeleton";
 import { createContextItem, updateContextItem, deleteContextItem } from "@/lib/contextItems";
 import { apiDelete, apiPut } from "@/lib/api";
 
@@ -19,8 +20,8 @@ export default function RightPanelTabs({
   contextItems: initialItems,
 }: {
   basketId: string;
-  blocks: Block[];
-  contextItems: ContextItem[];
+  blocks?: Block[];
+  contextItems?: ContextItem[];
 }) {
   const [tab, setTab] = useState("context");
   const [blocks, setBlocks] = useState(initialBlocks);
@@ -75,7 +76,9 @@ export default function RightPanelTabs({
           <Button size="sm" onClick={handleAdd} className="mb-2">
             + Add Context Item
           </Button>
-          {items.length === 0 ? (
+          {items === undefined ? (
+            <Skeleton className="h-6 mb-2" />
+          ) : items.length === 0 ? (
             <div className="text-sm text-muted-foreground">No context items.</div>
           ) : (
             items.map((it) => (
@@ -100,7 +103,9 @@ export default function RightPanelTabs({
       </TabsContent>
       <TabsContent value="blocks">
         <div className="p-2">
-          {blocks.length === 0 ? (
+          {blocks === undefined ? (
+            <Skeleton className="h-6 mb-2" />
+          ) : blocks.length === 0 ? (
             <div className="text-sm text-muted-foreground">No blocks.</div>
           ) : (
             blocks.map((b) => (

--- a/web/lib/contextItems.ts
+++ b/web/lib/contextItems.ts
@@ -9,13 +9,13 @@ export interface ContextItemPayload {
 }
 
 export function createContextItem(body: ContextItemPayload) {
-  return apiPost('/api/context-items', body);
+  return apiPost('/api/context_items', body);
 }
 
 export function updateContextItem(id: string, body: Partial<ContextItemPayload>) {
-  return apiPut(`/api/context-items/${id}`, body);
+  return apiPut(`/api/context_items/${id}`, body);
 }
 
 export function deleteContextItem(id: string) {
-  return apiDelete(`/api/context-items/${id}`);
+  return apiDelete(`/api/context_items/${id}`);
 }

--- a/web/lib/contextItems.ts
+++ b/web/lib/contextItems.ts
@@ -1,0 +1,21 @@
+import { apiPost, apiPut, apiDelete } from './api';
+
+export interface ContextItemPayload {
+  basket_id?: string;
+  document_id?: string | null;
+  type: string;
+  content: string;
+  status?: string;
+}
+
+export function createContextItem(body: ContextItemPayload) {
+  return apiPost('/api/context-items', body);
+}
+
+export function updateContextItem(id: string, body: Partial<ContextItemPayload>) {
+  return apiPut(`/api/context-items/${id}`, body);
+}
+
+export function deleteContextItem(id: string) {
+  return apiDelete(`/api/context-items/${id}`);
+}


### PR DESCRIPTION
## Summary
- add update/delete endpoints for blocks
- implement `RightPanelTabs` with basic CRUD for blocks & context
- wire tabs into document work page
- provide small API client helpers
- test block update/delete logic

## Testing
- `pytest tests/api/test_blocks.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687306b4b0e8832980defaf55d28b848