### PR TITLE
Refactor sidebar toggle and isolate workbench layout

### DIFF
--- a/web/app/baskets/layout.tsx
+++ b/web/app/baskets/layout.tsx
@@ -1,7 +1,13 @@
 "use client";
 import { ReactNode } from "react";
 import Shell from "@/components/layouts/Shell";
+import { usePathname } from "next/navigation";
 
 export default function Layout({ children }: { children: React.ReactNode }) {
-  return <Shell>{children}</Shell>;
+    const pathname = usePathname();
+    const isWorkbench = /^\/baskets\/[^/]+\/work$/.test(pathname);
+    if (isWorkbench) {
+        return <>{children}</>;
+    }
+    return <Shell>{children}</Shell>;
 }

--- a/web/app/components/layout/Sidebar.tsx
+++ b/web/app/components/layout/Sidebar.tsx
@@ -5,136 +5,136 @@ import { usePathname, useRouter } from "next/navigation";
 import clsx from "clsx";
 import { supabase } from "@/lib/supabaseClient";
 import { useEffect, useState } from "react";
-import { X } from "lucide-react";
+import SidebarToggleIcon from "@/components/icons/SidebarToggleIcon.svg";
 import { useSidebarStore } from "@/lib/stores/sidebarStore";
 
 const baseItems = [
-  { href: "/dashboard", label: "🧶 Dashboard" },
-  { href: "/baskets", label: "🧺 Baskets" },
-  { href: "/baskets/new?mode=wizard", label: "➕ New Basket (guided)" },
-  { href: "/baskets/new?mode=scratch", label: "➕ New Basket (blank)" },
-  { href: "/blocks", label: "◾ Blocks" },
-  { href: "/settings", label: "⚙️ Settings" },
+    { href: "/dashboard", label: "🧶 Dashboard" },
+    { href: "/baskets", label: "🧺 Baskets" },
+    { href: "/baskets/new?mode=wizard", label: "➕ New Basket (guided)" },
+    { href: "/baskets/new?mode=scratch", label: "➕ New Basket (blank)" },
+    { href: "/blocks", label: "◾ Blocks" },
+    { href: "/settings", label: "⚙️ Settings" },
 ];
 
 interface SidebarProps {
-  className?: string;
+    className?: string;
 }
 
 const Sidebar = ({ className }: SidebarProps) => {
-  const { isOpen, collapsible, closeSidebar } = useSidebarStore();
-  const pathname = usePathname();
-  const router = useRouter();
-  const [userEmail, setUserEmail] = useState<string | null>(null);
+    const { isOpen, collapsible, toggleSidebar, closeSidebar } =
+        useSidebarStore();
+    const pathname = usePathname();
+    const router = useRouter();
+    const [userEmail, setUserEmail] = useState<string | null>(null);
 
-  useEffect(() => {
-    const getSession = async () => {
-      const {
-        data: { session },
-      } = await supabase.auth.getSession();
-      setUserEmail(session?.user?.email || null);
+    useEffect(() => {
+        const getSession = async () => {
+            const {
+                data: { session },
+            } = await supabase.auth.getSession();
+            setUserEmail(session?.user?.email || null);
+        };
+        getSession();
+    }, [supabase]);
+
+    useEffect(() => {
+        function handleClickOutside(e: MouseEvent) {
+            if (!collapsible) return;
+            if (!(e.target as HTMLElement).closest(".sidebar")) {
+                closeSidebar();
+            }
+        }
+        document.addEventListener("click", handleClickOutside);
+        return () => document.removeEventListener("click", handleClickOutside);
+    }, [collapsible, closeSidebar]);
+
+    const handleLogout = async () => {
+        await supabase.auth.signOut();
+        router.push("/");
     };
-    getSession();
-  }, [supabase]);
 
-  useEffect(() => {
-    function handleClickOutside(e: MouseEvent) {
-      if (!collapsible) return;
-      if (!(e.target as HTMLElement).closest('.sidebar')) {
-        closeSidebar();
-      }
-    }
-    document.addEventListener('click', handleClickOutside);
-    return () => document.removeEventListener('click', handleClickOutside);
-  }, [collapsible, closeSidebar]);
+    const handleBrandClick = async () => {
+        const {
+            data: { session },
+        } = await supabase.auth.getSession();
+        if (session?.user) {
+            router.push("/dashboard");
+        } else {
+            router.push("/");
+        }
+    };
 
-  const handleLogout = async () => {
-    await supabase.auth.signOut();
-    router.push("/");
-  };
+    const showHint = /^\/baskets\/[^/]+/.test(pathname || "");
 
-  const handleBrandClick = async () => {
-    const {
-      data: { session },
-    } = await supabase.auth.getSession();
-    if (session?.user) {
-      router.push("/dashboard");
-    } else {
-      router.push("/");
-    }
-  };
-
-  const showHint = /^\/baskets\/[^/]+/.test(pathname || "");
-
-  return (
-    <aside
-      className={`sidebar fixed top-0 left-0 z-40 h-screen w-64 bg-background border-r border-border shadow-md transition-transform duration-300
+    return (
+        <aside
+            className={`sidebar fixed top-0 left-0 z-40 h-screen w-64 bg-background border-r border-border shadow-md transition-all duration-300
         ${isOpen ? "translate-x-0" : "-translate-x-full"}
         ${collapsible ? "md:relative md:translate-x-0" : ""}
         ${className ?? ""}`}
-    >
-      <button
-        className={clsx(
-          "absolute top-3 left-3 p-1 rounded-md hover:bg-muted",
-          !collapsible && "md:hidden"
-        )}
-        onClick={closeSidebar}
-        aria-label="Close sidebar"
-      >
-        <X className="h-5 w-5" />
-      </button>
-      <div className="h-full flex flex-col justify-between py-6 px-4">
-        {/* Top: Brand + Nav */}
-        <div className="space-y-6">
-          <div className="flex justify-center">
-            <button
-              onClick={handleBrandClick}
-              className="font-brand text-xl tracking-tight hover:underline"
-            >
-              yarnnn
-            </button>
-          </div>
-          <nav className="flex flex-col space-y-2 text-sm">
-            {baseItems.map((item) => (
-              <Link
-                key={item.href}
-                href={item.href}
-                className={clsx(
-                  "rounded-md px-3 py-2 transition hover:bg-muted hover:text-foreground",
-                  pathname === item.href
-                    ? "bg-muted text-foreground font-medium"
-                    : "text-muted-foreground"
-                )}
-              >
-                {item.label}
-              </Link>
-            ))}
-          </nav>
-        </div>
+        >
+            <div className="flex items-center justify-between px-4 py-3">
+                <button
+                    onClick={handleBrandClick}
+                    className="font-brand text-xl tracking-tight hover:underline"
+                >
+                    yarnnn
+                </button>
+                <button
+                    onClick={toggleSidebar}
+                    aria-label="Toggle sidebar"
+                    className="p-1.5 rounded hover:bg-muted transition"
+                >
+                    <SidebarToggleIcon className="h-5 w-5 text-muted-foreground" />
+                </button>
+            </div>
+            <div className="h-full flex flex-col justify-between py-6 px-4">
+                {/* Top: Brand + Nav */}
+                <div className="space-y-6">
+                    <nav className="flex flex-col space-y-2 text-sm">
+                        {baseItems.map((item) => (
+                            <Link
+                                key={item.href}
+                                href={item.href}
+                                className={clsx(
+                                    "rounded-md px-3 py-2 transition hover:bg-muted hover:text-foreground",
+                                    pathname === item.href
+                                        ? "bg-muted text-foreground font-medium"
+                                        : "text-muted-foreground",
+                                )}
+                            >
+                                {item.label}
+                            </Link>
+                        ))}
+                    </nav>
+                </div>
 
-        {/* Bottom: Email / User Menu */}
-        <div className="text-sm text-muted-foreground border-t border-border pt-4">
-          {userEmail ? (
-            <details className="group px-3 py-2 rounded-md bg-muted/40 hover:bg-muted transition cursor-pointer">
-              <summary className="list-none text-sm text-muted-foreground hover:text-foreground">
-                {userEmail}
-              </summary>
-              <div className="mt-2 ml-2 flex flex-col space-y-1 text-sm text-muted-foreground">
-                <button onClick={handleLogout}>🔓 Sign Out</button>
-              </div>
-            </details>
-          ) : (
-            <p className="px-3 py-2">Not signed in</p>
-          )}
-          {showHint && (
-            <p className="mt-4 text-xs hidden md:block">
-              ⇧ V to quick-dump into this basket
-            </p>
-          )}
-        </div>
-      </div>
-    </aside>
-  );
+                {/* Bottom: Email / User Menu */}
+                <div className="text-sm text-muted-foreground border-t border-border pt-4">
+                    {userEmail ? (
+                        <details className="group px-3 py-2 rounded-md bg-muted/40 hover:bg-muted transition cursor-pointer">
+                            <summary className="list-none text-sm text-muted-foreground hover:text-foreground">
+                                {userEmail}
+                            </summary>
+                            <div className="mt-2 ml-2 flex flex-col space-y-1 text-sm text-muted-foreground">
+                                <button onClick={handleLogout}>
+                                    🔓 Sign Out
+                                </button>
+                            </div>
+                        </details>
+                    ) : (
+                        <p className="px-3 py-2">Not signed in</p>
+                    )}
+                    {showHint && (
+                        <p className="mt-4 text-xs hidden md:block">
+                            ⇧ V to quick-dump into this basket
+                        </p>
+                    )}
+                </div>
+            </div>
+        </aside>
+    );
 };
 
 export default Sidebar;

--- a/web/components/layout/TopBar.tsx
+++ b/web/components/layout/TopBar.tsx
@@ -1,41 +1,41 @@
 "use client";
-import { LayoutPanelLeft } from "lucide-react";
+import SidebarToggleIcon from "@/components/icons/SidebarToggleIcon.svg";
 import { useSidebarStore } from "@/lib/stores/sidebarStore";
 import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils";
 import React from "react";
 
 export default function TopBar() {
-  const { isOpen, open } = useSidebarStore();
-  const pathname = usePathname();
+    const { isOpen, openSidebar } = useSidebarStore();
+    const pathname = usePathname();
 
-  const forceShow = /^\/baskets\/[^/]+\/work$/.test(pathname);
+    const show = !isOpen;
 
-  const show = !isOpen || forceShow;
+    const pageTitle = React.useMemo(() => {
+        if (!pathname || pathname === "/") return "yarnnn";
+        const segments = pathname.split("/").filter(Boolean);
+        const last = segments[segments.length - 1] || "yarnnn";
+        return decodeURIComponent(last).replace(/[-_]/g, " ");
+    }, [pathname]);
 
-  const pageTitle = React.useMemo(() => {
-    if (!pathname || pathname === "/") return "yarnnn";
-    const segments = pathname.split("/").filter(Boolean);
-    const last = segments[segments.length - 1] || "yarnnn";
-    return decodeURIComponent(last).replace(/[-_]/g, " ");
-  }, [pathname]);
-
-  return (
-    <header
-      className={cn(
-        "sticky top-0 z-30 flex h-12 items-center gap-2 border-b bg-background/70 px-3 backdrop-blur",
-        show ? "lg:hidden" : "lg:hidden pointer-events-none opacity-0"
-      )}
-    >
-      <button
-        aria-label="Open sidebar"
-        className="rounded p-1.5 hover:bg-muted"
-        onClick={open}
-      >
-        <LayoutPanelLeft className="h-5 w-5" />
-      </button>
-      <span className="flex-1 truncate text-sm font-medium">{pageTitle}</span>
-      <div className="w-5" />
-    </header>
-  );
+    return (
+        <header
+            className={cn(
+                "sticky top-0 z-30 flex h-12 items-center gap-2 border-b bg-background/70 px-3 backdrop-blur",
+                show ? "lg:hidden" : "lg:hidden pointer-events-none opacity-0",
+            )}
+        >
+            <button
+                aria-label="Open sidebar"
+                className="p-1.5 rounded hover:bg-muted transition"
+                onClick={openSidebar}
+            >
+                <SidebarToggleIcon className="h-5 w-5 text-muted-foreground" />
+            </button>
+            <span className="flex-1 truncate text-sm font-medium">
+                {pageTitle}
+            </span>
+            <div className="w-5" />
+        </header>
+    );
 }

--- a/web/components/layouts/Shell.tsx
+++ b/web/components/layouts/Shell.tsx
@@ -6,31 +6,32 @@ import { useSidebarStore } from "@/lib/stores/sidebarStore";
 import { usePathname } from "next/navigation";
 
 export default function Shell({ children }: { children: React.ReactNode }) {
-  const pathname = usePathname();
-  const { openSidebar, closeSidebar, setCollapsible } = useSidebarStore();
+    const pathname = usePathname();
+    const { openSidebar, closeSidebar, setCollapsible } = useSidebarStore();
 
-  useEffect(() => {
-    const hideSidebar =
-      /^\/baskets\/[^/]+\/work$/.test(pathname) ||
-      pathname.startsWith("/baskets/new") ||
-      /^\/blocks\/[^/]+$/.test(pathname);
+    useEffect(() => {
+        const hideSidebar =
+            pathname.startsWith("/baskets/new") ||
+            /^\/blocks\/[^/]+$/.test(pathname);
 
-    setCollapsible(hideSidebar);
+        setCollapsible(hideSidebar);
 
-    if (hideSidebar) {
-      closeSidebar();
-    } else {
-      openSidebar();
-    }
-  }, [pathname, setCollapsible, openSidebar, closeSidebar]);
+        if (hideSidebar) {
+            closeSidebar();
+        } else {
+            openSidebar();
+        }
+    }, [pathname, setCollapsible, openSidebar, closeSidebar]);
 
-  return (
-    <div className="flex h-screen overflow-hidden">
-      <Sidebar />
-      <div className="flex flex-1 flex-col">
-        <TopBar />
-        <main className="flex-1 overflow-y-auto px-4 pt-16 md:pt-8 md:px-8">{children}</main>
-      </div>
-    </div>
-  );
+    return (
+        <div className="flex h-screen overflow-hidden">
+            <Sidebar />
+            <div className="flex flex-1 flex-col">
+                <TopBar />
+                <main className="flex-1 overflow-y-auto px-4 pt-16 md:pt-8 md:px-8">
+                    {children}
+                </main>
+            </div>
+        </div>
+    );
 }

--- a/web/lib/stores/sidebarStore.ts
+++ b/web/lib/stores/sidebarStore.ts
@@ -1,26 +1,29 @@
-import { create } from 'zustand'
+import { create } from "zustand";
 
 interface SidebarState {
-  isOpen: boolean
-  collapsible: boolean
-  openSidebar: () => void
-  closeSidebar: () => void
-  /** Convenient alias for opening the sidebar */
-  open: () => void
-  /** Convenient alias for closing the sidebar */
-  close: () => void
-  /** Toggle open state */
-  toggle: () => void
-  setCollapsible: (value: boolean) => void
+    isOpen: boolean;
+    collapsible: boolean;
+    openSidebar: () => void;
+    closeSidebar: () => void;
+    /** Toggle open state */
+    toggleSidebar: () => void;
+    /** Convenient alias for opening the sidebar */
+    open: () => void;
+    /** Convenient alias for closing the sidebar */
+    close: () => void;
+    /** Toggle open state */
+    toggle: () => void;
+    setCollapsible: (value: boolean) => void;
 }
 
 export const useSidebarStore = create<SidebarState>((set) => ({
-  isOpen: true,
-  collapsible: false,
-  openSidebar: () => set({ isOpen: true }),
-  closeSidebar: () => set({ isOpen: false }),
-  open: () => set({ isOpen: true }),
-  close: () => set({ isOpen: false }),
-  toggle: () => set((s) => ({ isOpen: !s.isOpen })),
-  setCollapsible: (value) => set({ collapsible: value }),
-}))
+    isOpen: true,
+    collapsible: false,
+    openSidebar: () => set({ isOpen: true }),
+    closeSidebar: () => set({ isOpen: false }),
+    toggleSidebar: () => set((s) => ({ isOpen: !s.isOpen })),
+    open: () => set({ isOpen: true }),
+    close: () => set({ isOpen: false }),
+    toggle: () => set((s) => ({ isOpen: !s.isOpen })),
+    setCollapsible: (value) => set({ collapsible: value }),
+}));


### PR DESCRIPTION
## Summary
- isolate /baskets/:id/work from global Shell
- add toggleSidebar to store and refactor TopBar
- use custom SVG toggle in Sidebar header
- update Shell sidebar visibility logic

## Testing
- `make format` *(fails: pyenv black not found)*
- `make lint` *(fails: command failed)*
- `make tests` *(fails: runtime errors)*

------
https://chatgpt.com/codex/tasks/task_e_68746008075883299c762181bfbda524