### PR TITLE
Fix TopBar import and convert SVG icon

### DIFF
--- a/web/app/components/layout/Sidebar.tsx
+++ b/web/app/components/layout/Sidebar.tsx
@@ -5,7 +5,7 @@ import { usePathname, useRouter } from "next/navigation";
 import clsx from "clsx";
 import { supabase } from "@/lib/supabaseClient";
 import { useEffect, useState } from "react";
-import SidebarToggleIcon from "@/components/icons/SidebarToggleIcon.svg";
+import SidebarToggleIcon from "@/components/icons/SidebarToggleIcon";
 import { useSidebarStore } from "@/lib/stores/sidebarStore";
 
 const baseItems = [

--- a/web/components/icons/SidebarToggleIcon.tsx
+++ b/web/components/icons/SidebarToggleIcon.tsx
@@ -1,0 +1,16 @@
+import { SVGProps } from "react";
+
+export default function SidebarToggleIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg width="60" height="60" viewBox="0 0 60 60" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+      <g clipPath="url(#clip0_412_2)">
+        <path fillRule="evenodd" clipRule="evenodd" d="M46.8844 52.5694H13.1447C10.0425 52.5694 7.52441 50.0512 7.52441 46.9491V13.1888C7.52441 10.0875 10.0425 7.56938 13.1447 7.56938H46.8844C49.9866 7.56938 52.5047 10.0875 52.5047 13.1888V46.9491C52.5047 50.0512 49.9866 52.5694 46.8844 52.5694ZM22.5244 48.8194V11.3194H14.0757C12.5288 11.3203 11.2735 12.5756 11.2735 14.1216V46.0172C11.2735 47.5631 12.5288 48.8194 14.0757 48.8194H22.5244ZM45.9535 11.3194H26.2744V48.8194H45.9535C47.5003 48.8194 48.7557 47.5631 48.7557 46.0172V14.1216C48.7557 12.5756 47.5003 11.3203 45.9535 11.3194Z" fill="currentColor" />
+      </g>
+      <defs>
+        <clipPath id="clip0_412_2">
+          <rect width="60" height="60" fill="white" />
+        </clipPath>
+      </defs>
+    </svg>
+  );
+}

--- a/web/components/layout/TopBar.tsx
+++ b/web/components/layout/TopBar.tsx
@@ -1,5 +1,5 @@
 "use client";
-import SidebarToggleIcon from "@/components/icons/SidebarToggleIcon.svg";
+import SidebarToggleIcon from "@/components/icons/SidebarToggleIcon";
 import { useSidebarStore } from "@/lib/stores/sidebarStore";
 import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils";


### PR DESCRIPTION
## Summary
- convert `SidebarToggleIcon.svg` to a React component
- use the new component in `TopBar` and `Sidebar`

## Testing
- `make format` *(fails: `mise` missing python 3.11.9, then succeeds after install)*
- `make lint` *(fails: many ruff errors)*
- `make tests` *(fails: multiple test failures)*
- `npm run build` in `web`

------
https://chatgpt.com/codex/tasks/task_e_68746b56f8d08329acd6c48915617c7e