### PR TITLE
Cleanup basket work routes

### DIFF
--- a/web/app/baskets/layout.tsx
+++ b/web/app/baskets/layout.tsx
@@ -5,7 +5,8 @@ import { usePathname } from "next/navigation";
 
 export default function Layout({ children }: { children: React.ReactNode }) {
     const pathname = usePathname();
-    const isWorkbench = /^\/baskets\/[^/]+\/work$/.test(pathname);
+    const isWorkbench =
+        /^\/baskets\/[^/]+(?:\/docs\/[^/]+)?\/work$/.test(pathname);
     if (isWorkbench) {
         return <>{children}</>;
     }


### PR DESCRIPTION
## Summary
- hide Shell layout on document work routes so global sidebar stays hidden

## Testing
- `make tests` *(fails: 24 failed)*

------
https://chatgpt.com/codex/tasks/task_e_687497dfdab4832997795028e8afebef