### PR TITLE
Add tri-panel layout to basket workbench

### DIFF
--- a/web/app/baskets/[id]/work/page.tsx
+++ b/web/app/baskets/[id]/work/page.tsx
@@ -1,4 +1,4 @@
-import WorkbenchLayoutDev from "@/components/workbench/WorkbenchLayoutDev";
+import WorkbenchLayout from "@/components/workbench/WorkbenchLayout";
 import ContextBlocksPanel from "@/components/context/ContextBlocksPanel";
 import { createServerSupabaseClient } from "@/lib/supabaseServerClient";
 import { redirect } from "next/navigation";
@@ -50,8 +50,8 @@ export default async function BasketWorkPage({ params }: PageProps) {
   };
 
   return (
-    <WorkbenchLayoutDev
-      initialSnapshot={snapshot}
+    <WorkbenchLayout
+      snapshot={snapshot}
       rightPanel={
         <ContextBlocksPanel blocks={blocks || []} contextItems={contextItems || []} />
       }

--- a/web/components/basket/BasketDocList.tsx
+++ b/web/components/basket/BasketDocList.tsx
@@ -1,0 +1,21 @@
+"use client";
+import DocumentList from "@/components/documents/DocumentList";
+import { Button } from "@/components/ui/Button";
+
+interface Props {
+  basketId: string;
+  activeId?: string;
+}
+
+export default function BasketDocList({ basketId, activeId }: Props) {
+  return (
+    <div className="flex flex-col h-full">
+      <DocumentList basketId={basketId} activeId={activeId} />
+      <div className="p-4 border-t">
+        <Button size="sm" className="w-full" disabled>
+          + Add Document
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/web/components/workbench/WorkbenchLayout.tsx
+++ b/web/components/workbench/WorkbenchLayout.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { ReactNode } from "react";
-import BasketHeader from "@/components/basket/BasketHeader";
+import BasketDocList from "@/components/basket/BasketDocList";
+import WorkbenchTopBar from "@/components/workbench/WorkbenchTopBar";
 import NarrativePane from "@/components/basket/NarrativePane";
 import type { BasketSnapshot } from "@/lib/baskets/getSnapshot";
 import RightPanelLayout from "@/components/layout/RightPanel";
@@ -22,27 +23,36 @@ export default function WorkbenchLayout({
     rightPanel,
     children,
 }: Props) {
-    const scopes = Array.from(
-        new Set((snapshot.blocks || []).map((b) => b.scope).filter(Boolean)),
-    ) as string[];
-
     return (
-        <RightPanelLayout rightPanel={rightPanel}>
-            <div className="min-h-screen p-4 space-y-4">
-                <BasketHeader
+        <div className="md:flex w-full min-h-screen">
+            <aside className="hidden md:block w-[220px] shrink-0 border-r overflow-y-auto">
+                <BasketDocList basketId={snapshot.basket.id} />
+            </aside>
+            <div className="flex-1 flex flex-col">
+                <WorkbenchTopBar
                     basketName={snapshot.basket?.name || "Untitled Basket"}
                     status="DRAFT"
-                    scope={scopes}
-                    onRunBlockifier={onRunBlockifier}
-                    isRunningBlockifier={runningBlockifier}
+                    actions={onRunBlockifier ? (
+                        <button
+                            className="text-sm text-primary"
+                            onClick={onRunBlockifier}
+                            disabled={runningBlockifier}
+                        >
+                            {runningBlockifier ? "Running..." : "Run Blockifier"}
+                        </button>
+                    ) : null}
                 />
-                <NarrativePane
-                    rawText={snapshot.raw_dump_body}
-                    blocks={snapshot.blocks || []}
-                    onSelectBlock={onSelectBlock}
-                />
-                {children}
+                <RightPanelLayout rightPanel={rightPanel} className="flex-1">
+                    <div className="p-4 space-y-4">
+                        <NarrativePane
+                            rawText={snapshot.raw_dump_body}
+                            blocks={snapshot.blocks || []}
+                            onSelectBlock={onSelectBlock}
+                        />
+                        {children}
+                    </div>
+                </RightPanelLayout>
             </div>
-        </RightPanelLayout>
+        </div>
     );
 }

--- a/web/components/workbench/WorkbenchLayoutDev.tsx
+++ b/web/components/workbench/WorkbenchLayoutDev.tsx
@@ -1,8 +1,6 @@
 "use client";
 import { ReactNode } from "react";
-import BasketHeader from "@/components/basket/BasketHeader";
-import NarrativePane from "@/components/basket/NarrativePane";
-import RightPanelLayout from "@/components/layout/RightPanel";
+import WorkbenchLayout from "./WorkbenchLayout";
 
 interface Props {
   initialSnapshot: any;
@@ -11,25 +9,9 @@ interface Props {
 }
 
 export default function WorkbenchLayoutDev({ initialSnapshot, rightPanel, children }: Props) {
-  const scopes = Array.from(
-    new Set((initialSnapshot.blocks || []).map((b: any) => b.scope).filter(Boolean))
-  ) as string[];
-
   return (
-    <RightPanelLayout rightPanel={rightPanel}>
-      <div className="min-h-screen p-4 space-y-4">
-        <BasketHeader
-          basketName={initialSnapshot.basket?.name || "Untitled Basket"}
-          status="DRAFT"
-          scope={scopes}
-        />
-        <NarrativePane
-          rawText={initialSnapshot.raw_dump_body}
-          blocks={initialSnapshot.blocks || []}
-          onSelectBlock={(id) => console.log("select", id)}
-        />
-        {children}
-      </div>
-    </RightPanelLayout>
+    <WorkbenchLayout snapshot={initialSnapshot} rightPanel={rightPanel}>
+      {children}
+    </WorkbenchLayout>
   );
 }

--- a/web/components/workbench/WorkbenchTopBar.tsx
+++ b/web/components/workbench/WorkbenchTopBar.tsx
@@ -1,0 +1,19 @@
+"use client";
+import { Badge } from "@/components/ui/Badge";
+import { ReactNode } from "react";
+
+interface Props {
+  basketName: string;
+  status: string;
+  actions?: ReactNode;
+}
+
+export default function WorkbenchTopBar({ basketName, status, actions }: Props) {
+  return (
+    <header className="sticky top-0 z-30 flex items-center gap-3 border-b bg-background/70 px-4 py-2 backdrop-blur">
+      <h1 className="flex-1 truncate text-sm font-medium">{basketName}</h1>
+      <Badge variant="secondary">{status}</Badge>
+      {actions}
+    </header>
+  );
+}


### PR DESCRIPTION
## Summary
- add `BasketDocList` for navigating basket documents
- add `WorkbenchTopBar` component
- restructure `WorkbenchLayout` to include left sidebar and sticky topbar
- refactor `WorkbenchLayoutDev` to use the updated layout
- use `WorkbenchLayout` in `/baskets/[id]/work` route

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68749e61db5c8329b7bfe46d0647065f