### PR TITLE
Add BasketLeftNav navigation

### DIFF
--- a/web/app/baskets/[id]/docs/[did]/work/page.tsx
+++ b/web/app/baskets/[id]/docs/[did]/work/page.tsx
@@ -1,4 +1,4 @@
-import WorkbenchLayout from "@/components/basket-work/WorkbenchLayout";
+import BasketWorkbenchLayout from "@/components/basket-work/BasketWorkbenchLayout";
 import ContextBlocksPanel from "@/components/basket-work/ContextBlocksPanel";
 import { createServerSupabaseClient } from "@/lib/supabaseServerClient";
 import { redirect } from "next/navigation";
@@ -25,6 +25,11 @@ export default async function DocWorkPage({ params }: PageProps) {
   if (!basket) {
     redirect("/404");
   }
+
+  const { data: documents } = await supabase
+    .from("documents")
+    .select("id, title")
+    .eq("basket_id", id);
 
   const { data: dump } = await supabase
     .from("raw_dumps")
@@ -67,8 +72,10 @@ export default async function DocWorkPage({ params }: PageProps) {
   const guidelines = [...(basketGuidelines || []), ...(docGuidelines || [])];
 
   return (
-    <WorkbenchLayout
+    <BasketWorkbenchLayout
       snapshot={snapshot}
+      documentId={did}
+      documents={documents || []}
       rightPanel={
         <ContextBlocksPanel
           basketId={id}

--- a/web/app/baskets/[id]/work/page.tsx
+++ b/web/app/baskets/[id]/work/page.tsx
@@ -1,4 +1,4 @@
-import WorkbenchLayout from "@/components/basket-work/WorkbenchLayout";
+import BasketWorkbenchLayout from "@/components/basket-work/BasketWorkbenchLayout";
 import ContextBlocksPanel from "@/components/basket-work/ContextBlocksPanel";
 import { createServerSupabaseClient } from "@/lib/supabaseServerClient";
 import { redirect } from "next/navigation";
@@ -25,6 +25,11 @@ export default async function BasketWorkPage({ params }: PageProps) {
   if (!basket) {
     redirect("/404");
   }
+
+  const { data: documents } = await supabase
+    .from("documents")
+    .select("id, title")
+    .eq("basket_id", id);
 
   const { data: firstDoc } = await supabase
     .from("documents")
@@ -85,8 +90,10 @@ export default async function BasketWorkPage({ params }: PageProps) {
   };
 
   return (
-    <WorkbenchLayout
+    <BasketWorkbenchLayout
       snapshot={snapshot}
+      documentId={selectedDocId ?? undefined}
+      documents={documents || []}
       rightPanel={
         <ContextBlocksPanel
           basketId={id}

--- a/web/components/basket-work/BasketLeftNav.tsx
+++ b/web/components/basket-work/BasketLeftNav.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import Link from "next/link";
+import { cn } from "@/lib/utils";
+import { usePathname } from "next/navigation";
+
+export interface BasketLeftNavProps {
+  basketName: string;
+  basketId: string;
+  documentId?: string;
+  contextItems: { id: string; content: string }[];
+  blocks: { id: string; content: string }[];
+  documents: { id: string; title?: string | null }[];
+}
+
+export default function BasketLeftNav({
+  basketName,
+  basketId,
+  documentId,
+  contextItems,
+  blocks,
+  documents,
+}: BasketLeftNavProps) {
+  const pathname = usePathname();
+
+  return (
+    <div className="w-64 p-4 text-sm border-r overflow-y-auto space-y-4">
+      <div className="font-semibold text-base">🧺 {basketName}</div>
+
+      <div className="space-y-1">
+        <Link
+          href={`/baskets/${basketId}/work`}
+          className={cn(
+            "block px-2 py-1 rounded hover:bg-muted",
+            pathname?.endsWith("/work") && "bg-muted font-semibold"
+          )}
+        >
+          Dashboard
+        </Link>
+        <Link
+          href={`/baskets/${basketId}/work/insights`}
+          className="block px-2 py-1 rounded hover:bg-muted"
+        >
+          Insights
+        </Link>
+        <Link
+          href={`/baskets/${basketId}/work/history`}
+          className="block px-2 py-1 rounded hover:bg-muted"
+        >
+          History
+        </Link>
+      </div>
+
+      <div>
+        <div className="text-xs mt-4 mb-1 font-medium text-muted-foreground">Context Items</div>
+        {contextItems.map((item) => (
+          <div key={item.id} className="truncate text-muted-foreground text-xs">
+            • {item.content}
+          </div>
+        ))}
+      </div>
+
+      <div>
+        <div className="text-xs mt-4 mb-1 font-medium text-muted-foreground">Blocks</div>
+        {blocks.map((block) => (
+          <div key={block.id} className="truncate text-muted-foreground text-xs">
+            • {block.content}
+          </div>
+        ))}
+      </div>
+
+      <div>
+        <div className="text-xs mt-4 mb-1 font-medium text-muted-foreground">Documents</div>
+        {documents.map((doc) => (
+          <Link
+            key={doc.id}
+            href={`/baskets/${basketId}/docs/${doc.id}/work`}
+            className={cn(
+              "block px-2 py-1 rounded hover:bg-muted text-xs",
+              documentId === doc.id && "bg-muted font-semibold"
+            )}
+          >
+            {doc.title ?? "Untitled"}
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/web/components/basket-work/BasketWorkbenchLayout.tsx
+++ b/web/components/basket-work/BasketWorkbenchLayout.tsx
@@ -1,0 +1,38 @@
+import BasketLeftNav from "./BasketLeftNav";
+import type { BasketSnapshot } from "@/lib/baskets/getSnapshot";
+
+export interface BasketWorkbenchLayoutProps {
+  snapshot: BasketSnapshot;
+  documentId?: string;
+  documents: { id: string; title?: string | null }[];
+  rightPanel?: React.ReactNode;
+  children?: React.ReactNode;
+}
+
+export default function BasketWorkbenchLayout({
+  snapshot,
+  documentId,
+  documents,
+  rightPanel,
+  children,
+}: BasketWorkbenchLayoutProps) {
+  return (
+    <div className="flex h-full">
+      <BasketLeftNav
+        basketId={snapshot.basket.id}
+        basketName={snapshot.basket.name ?? "Untitled"}
+        contextItems={[]}
+        blocks={snapshot.blocks}
+        documents={documents}
+        documentId={documentId}
+      />
+
+      <div className="flex-1 flex flex-col">
+        <div className="flex-1 grid grid-cols-3">
+          <div className="col-span-2 overflow-y-auto">{children}</div>
+          {rightPanel && <div className="col-span-1 border-l">{rightPanel}</div>}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create `BasketLeftNav` for basket work pages
- add new `BasketWorkbenchLayout` using the sidebar
- fetch documents in work pages and use the new layout

## Testing
- `npm test`
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874b84e65488329bf9d160bb021fb33