### PR TITLE
feat: add persistent left-side creation buttons to basket work page

### DIFF
--- a/web/components/basket-work/BasketCreationNav.tsx
+++ b/web/components/basket-work/BasketCreationNav.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { Button } from "@/components/ui/Button";
+import { FileText, Blocks, StickyNote, BookOpen } from "lucide-react";
+
+interface Props {
+    onCreateContext?: () => void;
+    onCreateBlock?: () => void;
+    onCreateDocument?: () => void;
+    onCreateDump?: () => void;
+}
+
+export default function BasketCreationNav({
+    onCreateContext,
+    onCreateBlock,
+    onCreateDocument,
+    onCreateDump,
+}: Props) {
+    return (
+        <div className="flex flex-col space-y-2 p-2 w-16 border-r bg-muted/40 text-muted-foreground">
+            <Button
+                size="icon"
+                variant="ghost"
+                onClick={onCreateContext}
+                title="New Context Item"
+            >
+                <StickyNote size={18} />
+            </Button>
+            <Button
+                size="icon"
+                variant="ghost"
+                onClick={onCreateBlock}
+                title="New Block"
+            >
+                <Blocks size={18} />
+            </Button>
+            <Button
+                size="icon"
+                variant="ghost"
+                onClick={onCreateDocument}
+                title="New Document"
+            >
+                <FileText size={18} />
+            </Button>
+            <Button
+                size="icon"
+                variant="ghost"
+                onClick={onCreateDump}
+                title="New Raw Dump"
+            >
+                <BookOpen size={18} />
+            </Button>
+        </div>
+    );
+}

--- a/web/components/basket-work/BasketCreationNav.tsx
+++ b/web/components/basket-work/BasketCreationNav.tsx
@@ -19,7 +19,7 @@ export default function BasketCreationNav({
     return (
         <div className="flex flex-col space-y-2 p-2 w-16 border-r bg-muted/40 text-muted-foreground">
             <Button
-                size="icon"
+                size="sm"
                 variant="ghost"
                 onClick={onCreateContext}
                 title="New Context Item"
@@ -27,7 +27,7 @@ export default function BasketCreationNav({
                 <StickyNote size={18} />
             </Button>
             <Button
-                size="icon"
+                size="sm"
                 variant="ghost"
                 onClick={onCreateBlock}
                 title="New Block"
@@ -35,7 +35,7 @@ export default function BasketCreationNav({
                 <Blocks size={18} />
             </Button>
             <Button
-                size="icon"
+                size="sm"
                 variant="ghost"
                 onClick={onCreateDocument}
                 title="New Document"
@@ -43,7 +43,7 @@ export default function BasketCreationNav({
                 <FileText size={18} />
             </Button>
             <Button
-                size="icon"
+                size="sm"
                 variant="ghost"
                 onClick={onCreateDump}
                 title="New Raw Dump"

--- a/web/components/basket-work/BasketWorkbenchLayout.tsx
+++ b/web/components/basket-work/BasketWorkbenchLayout.tsx
@@ -1,38 +1,53 @@
 import BasketLeftNav from "./BasketLeftNav";
+import BasketCreationNav from "./BasketCreationNav";
 import type { BasketSnapshot } from "@/lib/baskets/getSnapshot";
 
 export interface BasketWorkbenchLayoutProps {
-  snapshot: BasketSnapshot;
-  documentId?: string;
-  documents: { id: string; title?: string | null }[];
-  rightPanel?: React.ReactNode;
-  children?: React.ReactNode;
+    snapshot: BasketSnapshot;
+    documentId?: string;
+    documents: { id: string; title?: string | null }[];
+    rightPanel?: React.ReactNode;
+    children?: React.ReactNode;
 }
 
 export default function BasketWorkbenchLayout({
-  snapshot,
-  documentId,
-  documents,
-  rightPanel,
-  children,
+    snapshot,
+    documentId,
+    documents,
+    rightPanel,
+    children,
 }: BasketWorkbenchLayoutProps) {
-  return (
-    <div className="flex h-full">
-      <BasketLeftNav
-        basketId={snapshot.basket.id}
-        basketName={snapshot.basket.name ?? "Untitled"}
-        contextItems={[]}
-        blocks={snapshot.blocks}
-        documents={documents}
-        documentId={documentId}
-      />
+    return (
+        <div className="flex h-full">
+            {/* Left-side creation buttons */}
+            <BasketCreationNav
+                onCreateContext={() => console.log("Create Context")}
+                onCreateBlock={() => console.log("Create Block")}
+                onCreateDocument={() => console.log("Create Document")}
+                onCreateDump={() => console.log("Create Dump")}
+            />
 
-      <div className="flex-1 flex flex-col">
-        <div className="flex-1 grid grid-cols-3">
-          <div className="col-span-2 overflow-y-auto">{children}</div>
-          {rightPanel && <div className="col-span-1 border-l">{rightPanel}</div>}
+            <BasketLeftNav
+                basketId={snapshot.basket.id}
+                basketName={snapshot.basket.name ?? "Untitled"}
+                contextItems={[]}
+                blocks={snapshot.blocks}
+                documents={documents}
+                documentId={documentId}
+            />
+
+            <div className="flex-1 flex flex-col">
+                <div className="flex-1 grid grid-cols-3">
+                    <div className="col-span-2 overflow-y-auto p-4">
+                        {children}
+                    </div>
+                    {rightPanel && (
+                        <div className="col-span-1 border-l p-4">
+                            {rightPanel}
+                        </div>
+                    )}
+                </div>
+            </div>
         </div>
-      </div>
-    </div>
-  );
+    );
 }


### PR DESCRIPTION
## Summary
- add `BasketCreationNav` component with creation buttons for context items, blocks, documents, and raw dumps
- integrate `BasketCreationNav` into `BasketWorkbenchLayout`
- provide simple console.log handlers and add padding for main panels

## Testing
- `make lint` *(fails: Found 158 errors)*
- `make tests` *(fails: 24 failed, 29 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6875940b390c83299d365b1ec0cce69f