### PR TITLE
Fix DocumentWorkbenchLayout prop chain

### DIFF
--- a/web/components/CreateBasketDialog.tsx
+++ b/web/components/CreateBasketDialog.tsx
@@ -7,6 +7,7 @@ import {
   DialogContent,
   DialogHeader,
   DialogTitle,
+  DialogDescription,
   DialogFooter,
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/Input";

--- a/web/components/basket/BasketDocList.tsx
+++ b/web/components/basket/BasketDocList.tsx
@@ -2,15 +2,29 @@
 import DocumentList from "@/components/documents/DocumentList";
 import { Button } from "@/components/ui/Button";
 
+import type { Document } from "@/types/document";
+
 interface Props {
   basketId: string;
-  activeId?: string;
+  documents: Document[];
+  documentId?: string;
+  onSelect?: (id: string) => void;
 }
 
-export default function BasketDocList({ basketId, activeId }: Props) {
+export default function BasketDocList({
+  basketId,
+  documents,
+  documentId,
+  onSelect,
+}: Props) {
   return (
     <div className="flex flex-col h-full">
-      <DocumentList basketId={basketId} activeId={activeId} />
+      <DocumentList
+        basketId={basketId}
+        documents={documents}
+        documentId={documentId}
+        onSelect={onSelect}
+      />
       <div className="p-4 border-t">
         <Button size="sm" className="w-full" disabled>
           + Add Document

--- a/web/components/documents/DocumentList.tsx
+++ b/web/components/documents/DocumentList.tsx
@@ -1,17 +1,27 @@
 "use client";
 import { useRouter } from "next/navigation";
 import { useDocuments } from "../../lib/baskets/useDocuments";
+import type { Document } from "@/types/document";
 
 interface Props {
   basketId: string;
-  activeId?: string;
+  documents?: Document[];
+  documentId?: string;
+  onSelect?: (id: string) => void;
 }
 
-export default function DocumentList({ basketId, activeId }: Props) {
+export default function DocumentList({
+  basketId,
+  documents,
+  documentId,
+  onSelect,
+}: Props) {
   const { docs, isLoading, error } = useDocuments(basketId);
   const router = useRouter();
 
-  if (isLoading) {
+  const items = documents ?? docs;
+
+  if (!documents && isLoading) {
     return (
       <ul className="p-6 space-y-2 animate-pulse">
         {Array.from({ length: 3 }).map((_, idx) => (
@@ -27,7 +37,7 @@ export default function DocumentList({ basketId, activeId }: Props) {
     );
   }
 
-  if (docs.length === 0) {
+  if (items.length === 0) {
     return (
       <div className="p-6 text-sm text-muted-foreground">No documents yet</div>
     );
@@ -35,14 +45,16 @@ export default function DocumentList({ basketId, activeId }: Props) {
 
   return (
     <ul className="p-6 space-y-2 overflow-y-auto flex-1">
-      {docs.map((doc) => {
-        const isActive = doc.id === activeId;
+      {items.map((doc) => {
+        const isActive = doc.id === documentId;
         const title = doc.title || "Untitled Document";
         return (
           <li
             key={doc.id}
             onClick={() =>
-              router.push(`/baskets/${basketId}/docs/${doc.id}/work`)
+              onSelect
+                ? onSelect(doc.id)
+                : router.push(`/baskets/${basketId}/docs/${doc.id}/work`)
             }
             className={`border rounded-md p-3 flex items-center gap-3 cursor-pointer ${
               isActive ? "ring-2 ring-primary" : ""

--- a/web/components/layouts/DocumentWorkbenchLayout.tsx
+++ b/web/components/layouts/DocumentWorkbenchLayout.tsx
@@ -1,55 +1,71 @@
 "use client";
-
-import Link from "next/link";
-import { usePathname } from "next/navigation";
-import { cn } from "@/lib/utils";
+import { ReactNode } from "react";
+import BasketDocList from "@/components/basket/BasketDocList";
+import NarrativePane from "@/components/basket/NarrativePane";
+import type { BasketSnapshot } from "@/lib/baskets/getSnapshot";
+import RightPanelLayout from "@/components/common/RightPanel";
+import type { Document } from "@/types/document";
 
 interface Props {
-  basketId: string;
-  documents: { id: string; title: string }[];
-  selectedId?: string;
-  onSelect?: (id: string) => void;
+  snapshot: BasketSnapshot;
+  documents: Document[];
+  documentId?: string;
+  onSelectDocument?: (id: string) => void;
+  onRunBlockifier?: () => void;
+  runningBlockifier?: boolean;
+  onSelectBlock?: (id: string) => void;
+  rightPanel?: ReactNode;
+  children?: ReactNode;
 }
 
-export default function BasketDocList({
-  basketId,
+export default function DocumentWorkbenchLayout({
+  snapshot,
   documents,
-  selectedId,
-  onSelect,
+  documentId,
+  onSelectDocument,
+  onRunBlockifier,
+  runningBlockifier,
+  onSelectBlock,
+  rightPanel,
+  children,
 }: Props) {
-  const pathname = usePathname();
-
   return (
-    <nav className="flex flex-col gap-0.5 p-2">
-      {documents.map((doc) => {
-        const isSelected = selectedId
-          ? selectedId === doc.id
-          : pathname?.includes(doc.id);
-
-        return onSelect ? (
-          <button
-            key={doc.id}
-            onClick={() => onSelect(doc.id)}
-            className={cn(
-              "text-left px-3 py-1.5 text-sm rounded hover:bg-accent transition",
-              isSelected && "bg-accent text-primary font-medium"
-            )}
-          >
-            {doc.title || "Untitled"}
-          </button>
-        ) : (
-          <Link
-            key={doc.id}
-            href={`/baskets/${basketId}/docs/${doc.id}/work`}
-            className={cn(
-              "block px-3 py-1.5 text-sm rounded hover:bg-accent transition",
-              isSelected && "bg-accent text-primary font-medium"
-            )}
-          >
-            {doc.title || "Untitled"}
-          </Link>
-        );
-      })}
-    </nav>
+    <div className="md:flex w-full min-h-screen">
+      <aside className="hidden md:block w-[220px] shrink-0 border-r overflow-y-auto">
+        <BasketDocList
+          basketId={snapshot.basket.id}
+          documents={documents}
+          documentId={documentId}
+          onSelect={onSelectDocument}
+        />
+      </aside>
+      <div className="flex-1 flex flex-col">
+        <header className="sticky top-0 z-30 flex items-center gap-3 border-b bg-background/70 px-4 py-2 backdrop-blur">
+          <h1 className="flex-1 truncate text-sm font-medium">
+            {snapshot.basket?.name || "Untitled Basket"}
+          </h1>
+          <span className="text-xs px-2 py-0.5 bg-muted rounded">DRAFT</span>
+          {onRunBlockifier && (
+            <button
+              className="text-sm text-primary"
+              onClick={onRunBlockifier}
+              disabled={runningBlockifier}
+            >
+              {runningBlockifier ? "Running..." : "Run Blockifier"}
+            </button>
+          )}
+        </header>
+        <RightPanelLayout rightPanel={rightPanel} className="flex-1">
+          <div className="p-4 space-y-4">
+            <NarrativePane
+              rawText={snapshot.raw_dump_body}
+              blocks={snapshot.blocks || []}
+              onSelectBlock={onSelectBlock}
+            />
+            {children}
+          </div>
+        </RightPanelLayout>
+      </div>
+    </div>
   );
 }

--- a/web/lib/baskets/useDocuments.ts
+++ b/web/lib/baskets/useDocuments.ts
@@ -1,9 +1,8 @@
 import useSWR from "swr";
 import { apiGet } from "../api";
+import type { Document } from "@/types/document";
 
-export interface DocumentRow {
-  id: string;
-  title: string | null;
+export interface DocumentRow extends Document {
   updated_at: string;
 }
 

--- a/web/types/document.ts
+++ b/web/types/document.ts
@@ -1,0 +1,4 @@
+export interface Document {
+  id: string;
+  title: string | null;
+}


### PR DESCRIPTION
## Summary
- make DocumentList accept docs, `documentId`, and `onSelect`
- wire props through BasketDocList and DocumentWorkbenchLayout
- define a shared `Document` type
- update useDocuments typing

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6875cb0a7f048329b7fdd9ed6f7efd7a