### PR TITLE
Scaffold basket dashboard sections

### DIFF
--- a/web/components/layouts/BasketDashboardLayout.tsx
+++ b/web/components/layouts/BasketDashboardLayout.tsx
@@ -1,6 +1,7 @@
 import DocumentList from "@/components/documents/DocumentList";
 import { Card } from "@/components/ui/Card";
 import { Button } from "@/components/ui/Button";
+import { EmptyState } from "@/components/ui/EmptyState";
 
 interface Props {
   basketId: string;
@@ -9,25 +10,61 @@ interface Props {
 
 export default function BasketDashboardLayout({ basketId, dumpBody }: Props) {
   return (
-    <div className="space-y-6">
-      <section>
-        <h2 className="font-medium mb-2">Documents</h2>
-        <Card className="p-4">
+    <div className="md:flex w-full min-h-screen">
+      {/* Sidebar document list for desktop */}
+      <aside className="hidden md:block w-[220px] shrink-0 border-r overflow-y-auto">
+        <div className="flex flex-col h-full">
           <DocumentList basketId={basketId} />
-          <div className="pt-4">
+          <div className="p-4 border-t">
             <Button size="sm" disabled className="w-full">
               + Create Document
             </Button>
           </div>
-        </Card>
-      </section>
-      <section>
-        <h2 className="font-medium mb-2">Latest Dump</h2>
-        <Card className="p-4 whitespace-pre-wrap text-sm">
-          {dumpBody ? dumpBody : "No dumps yet."}
-        </Card>
-      </section>
-      {/* TODO: blocks and context cards */}
+        </div>
+      </aside>
+      {/* Main dashboard content */}
+      <div className="flex-1 p-4 space-y-6">
+        {/* Mobile document list */}
+        <section className="md:hidden">
+          <h2 className="font-medium mb-2">Documents</h2>
+          <Card className="p-4">
+            <DocumentList basketId={basketId} />
+            <div className="pt-4">
+              <Button size="sm" disabled className="w-full">
+                + Create Document
+              </Button>
+            </div>
+          </Card>
+        </section>
+
+        <section>
+          <h2 className="font-medium mb-2">Blocks</h2>
+          <Card className="p-4 text-sm">
+            <EmptyState title="No blocks yet." />
+          </Card>
+        </section>
+
+        <section>
+          <h2 className="font-medium mb-2">Context</h2>
+          <Card className="p-4 text-sm">
+            <EmptyState title="Add context to guide your basket." />
+          </Card>
+        </section>
+
+        <section>
+          <h2 className="font-medium mb-2">Outputs</h2>
+          <Card className="p-4 text-sm">
+            <EmptyState title="No outputs yet." />
+          </Card>
+        </section>
+
+        <section>
+          <h2 className="font-medium mb-2">Latest Dump</h2>
+          <Card className="p-4 whitespace-pre-wrap text-sm">
+            {dumpBody ? dumpBody : "No dumps yet."}
+          </Card>
+        </section>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- scaffold BasketDashboardLayout so `/baskets/[id]/work` always shows sections
- add placeholder panels for Blocks, Context, and Outputs
- move document list to sidebar on desktop and keep mobile version

## Testing
- `npm test`
- `make tests` *(fails: many tests error with status 422)*

------
https://chatgpt.com/codex/tasks/task_e_6875d43fadc88329b99f5f9bbd942b74