### PR TITLE
Fix TopBar visibility and move RightPanel

### DIFF
--- a/web/app/baskets/[id]/layout.tsx
+++ b/web/app/baskets/[id]/layout.tsx
@@ -1,4 +1,5 @@
 import { BasketProvider } from "@/lib/context/BasketContext";
+import Shell from "@/components/layout/Shell";
 
 export default async function BasketLayout({
   children,
@@ -8,5 +9,9 @@ export default async function BasketLayout({
   params: Promise<{ id: string }>;
 }) {
   const { id } = await params;
-  return <BasketProvider initialBasketId={id}>{children}</BasketProvider>;
+  return (
+    <Shell>
+      <BasketProvider initialBasketId={id}>{children}</BasketProvider>
+    </Shell>
+  );
 }

--- a/web/app/baskets/new/layout.tsx
+++ b/web/app/baskets/new/layout.tsx
@@ -1,6 +1,6 @@
 "use client";
-import { ReactNode } from "react";
 import Shell from "@/components/layout/Shell";
+
 export default function Layout({ children }: { children: React.ReactNode }) {
     return <Shell>{children}</Shell>;
 }

--- a/web/components/blocks/BlockDetailLayout.tsx
+++ b/web/components/blocks/BlockDetailLayout.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { ReactNode } from "react";
-import RightPanelLayout from "@/components/common/RightPanel";
+import RightPanelLayout from "@/components/blocks/RightPanelLayout";
 
 interface Props {
   children: ReactNode;

--- a/web/components/blocks/RightPanelLayout.tsx
+++ b/web/components/blocks/RightPanelLayout.tsx
@@ -24,9 +24,3 @@ export default function RightPanelLayout({
     </div>
   );
 }
-
-export function RightPanelSkeleton() {
-  return (
-    <div className="p-4 text-sm text-muted-foreground">Right panel ready</div>
-  );
-}

--- a/web/components/common/TopBar.tsx
+++ b/web/components/common/TopBar.tsx
@@ -9,8 +9,6 @@ export default function TopBar() {
     const { isOpen, openSidebar } = useSidebarStore();
     const pathname = usePathname();
 
-    const show = !isOpen;
-
     const pageTitle = React.useMemo(() => {
         if (!pathname || pathname === "/") return "yarnnn";
         const segments = pathname.split("/").filter(Boolean);
@@ -18,11 +16,13 @@ export default function TopBar() {
         return decodeURIComponent(last).replace(/[-_]/g, " ");
     }, [pathname]);
 
+    if (isOpen) return null;
+
     return (
         <header
             className={cn(
                 "sticky top-0 z-30 flex h-12 items-center gap-2 border-b bg-background/70 px-3 backdrop-blur",
-                show ? "lg:hidden" : "lg:hidden pointer-events-none opacity-0",
+                "lg:hidden",
             )}
         >
             <button

--- a/web/components/common/UploadArea.tsx
+++ b/web/components/common/UploadArea.tsx
@@ -1,4 +1,0 @@
-"use client";
-
-export { UploadArea } from "@/components/ui/UploadArea";
-export type { UploadAreaProps } from "@/components/ui/UploadArea";

--- a/web/components/layouts/DocumentWorkbenchLayout.tsx
+++ b/web/components/layouts/DocumentWorkbenchLayout.tsx
@@ -3,7 +3,7 @@ import { ReactNode } from "react";
 import BasketDocList from "@/components/basket/BasketDocList";
 import NarrativePane from "@/components/basket/NarrativePane";
 import type { BasketSnapshot } from "@/lib/baskets/getSnapshot";
-import RightPanelLayout from "@/components/common/RightPanel";
+import RightPanelLayout from "@/components/blocks/RightPanelLayout";
 import type { Document } from "@/types/document";
 
 interface Props {


### PR DESCRIPTION
## Summary
- move RightPanelLayout into blocks folder
- strip unused UploadArea export
- show TopBar only when sidebar is closed
- update BlockDetail and Workbench layouts

## Testing
- `make lint` *(fails: 158 errors)*
- `make format` *(fails: pyenv: black: command not found)*
- `make tests` *(fails: 24 failed tests)*

------
https://chatgpt.com/codex/tasks/task_e_6875e5aa17a88329bb40e3be72aaf408