### PR TITLE
Refactor sidebar to show baskets

### DIFF
--- a/web/app/components/layout/Sidebar.tsx
+++ b/web/app/components/layout/Sidebar.tsx
@@ -1,140 +1,129 @@
 "use client";
 
-import Link from "next/link";
-import { usePathname, useRouter } from "next/navigation";
-import clsx from "clsx";
-import { supabase } from "@/lib/supabaseClient";
 import { useEffect, useState } from "react";
+import { usePathname, useRouter } from "next/navigation";
+import { Plus, Package2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { createClient } from "@/lib/supabaseClient";
 import SidebarToggleIcon from "@/components/icons/SidebarToggleIcon";
 import { useSidebarStore } from "@/lib/stores/sidebarStore";
 
-const baseItems = [
-    { href: "/dashboard", label: "🧶 Dashboard" },
-    { href: "/baskets", label: "🧺 Baskets" },
-    { href: "/baskets/new?mode=wizard", label: "➕ New Basket (guided)" },
-    { href: "/baskets/new?mode=blank", label: "➕ New Basket (blank)" },
-    { href: "/blocks", label: "◾ Blocks" },
-    { href: "/settings", label: "⚙️ Settings" },
-];
-
 interface SidebarProps {
-    className?: string;
+  className?: string;
 }
 
-const Sidebar = ({ className }: SidebarProps) => {
-    const { isOpen, collapsible, toggleSidebar, closeSidebar } =
-        useSidebarStore();
-    const pathname = usePathname();
-    const router = useRouter();
-    const [userEmail, setUserEmail] = useState<string | null>(null);
+export default function Sidebar({ className }: SidebarProps) {
+  const { isOpen, collapsible, toggleSidebar, closeSidebar } = useSidebarStore();
+  const pathname = usePathname();
+  const router = useRouter();
+  const supabase = createClient();
+  const [userEmail, setUserEmail] = useState<string | null>(null);
+  const [baskets, setBaskets] = useState<any[]>([]);
 
-    useEffect(() => {
-        const getSession = async () => {
-            const {
-                data: { session },
-            } = await supabase.auth.getSession();
-            setUserEmail(session?.user?.email || null);
-        };
-        getSession();
-    }, [supabase]);
-
-    useEffect(() => {
-        function handleClickOutside(e: MouseEvent) {
-            if (!collapsible) return;
-            if (!(e.target as HTMLElement).closest(".sidebar")) {
-                closeSidebar();
-            }
-        }
-        document.addEventListener("click", handleClickOutside);
-        return () => document.removeEventListener("click", handleClickOutside);
-    }, [collapsible, closeSidebar]);
-
-    const handleLogout = async () => {
-        await supabase.auth.signOut();
-        router.push("/");
+  useEffect(() => {
+    const getSession = async () => {
+      const { data: { session } } = await supabase.auth.getSession();
+      setUserEmail(session?.user?.email || null);
     };
+    getSession();
+  }, [supabase]);
 
-    const handleBrandClick = async () => {
-        const {
-            data: { session },
-        } = await supabase.auth.getSession();
-        if (session?.user) {
-            router.push("/dashboard");
-        } else {
-            router.push("/");
-        }
+  useEffect(() => {
+    const fetchBaskets = async () => {
+      const { data } = await supabase
+        .from("baskets")
+        .select("id, name, created_at")
+        .order("created_at", { ascending: false });
+      setBaskets(data || []);
     };
+    fetchBaskets();
+  }, [supabase]);
 
-    const showHint = /^\/baskets\/[^/]+/.test(pathname || "");
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (!collapsible) return;
+      if (!(e.target as HTMLElement).closest(".sidebar")) {
+        closeSidebar();
+      }
+    }
+    document.addEventListener("click", handleClickOutside);
+    return () => document.removeEventListener("click", handleClickOutside);
+  }, [collapsible, closeSidebar]);
 
-    return (
-        <aside
-            className={`sidebar fixed top-0 left-0 z-40 h-screen w-64 bg-background border-r border-border shadow-md transition-all duration-300
-        ${isOpen ? "translate-x-0" : "-translate-x-full"}
-        ${collapsible ? "md:relative md:translate-x-0" : ""}
-        ${className ?? ""}`}
-        >
-            <div className="flex items-center justify-between px-4 py-3">
-                <button
-                    onClick={handleBrandClick}
-                    className="font-brand text-xl tracking-tight hover:underline"
-                >
-                    yarnnn
-                </button>
-                <button
-                    onClick={toggleSidebar}
-                    aria-label="Toggle sidebar"
-                    className="p-1.5 rounded hover:bg-muted transition"
-                >
-                    <SidebarToggleIcon className="h-5 w-5 text-muted-foreground" />
-                </button>
+  const handleLogout = async () => {
+    await supabase.auth.signOut();
+    router.push("/");
+  };
+
+  const handleBrandClick = () => {
+    router.push("/baskets");
+  };
+
+  const handleNewBasket = async () => {
+    const { data } = await supabase
+      .from("baskets")
+      .insert({ name: "Untitled Basket", state: "draft" })
+      .select("id")
+      .single();
+    if (data) {
+      router.push(`/baskets/${data.id}/work`);
+    }
+  };
+
+  const showHint = /^\/baskets\/[^/]+/.test(pathname || "");
+
+  return (
+    <aside
+      className={`sidebar fixed top-0 left-0 z-40 h-screen w-64 bg-background border-r border-border shadow-md transition-all duration-300 ${
+        isOpen ? "translate-x-0" : "-translate-x-full"
+      } ${collapsible ? "md:relative md:translate-x-0" : ""} ${className ?? ""}`}
+    >
+      <div className="sticky top-0 z-10 border-b bg-background px-4 py-3 flex items-center justify-between">
+        <button onClick={handleBrandClick} className="font-brand text-xl tracking-tight hover:underline">
+          yarnnn
+        </button>
+        <button onClick={toggleSidebar} aria-label="Toggle sidebar" className="p-1.5 rounded hover:bg-muted transition">
+          <SidebarToggleIcon className="h-5 w-5 text-muted-foreground" />
+        </button>
+      </div>
+      <div className="px-4 py-3 border-b">
+        <button onClick={handleNewBasket} className="flex items-center space-x-2 text-sm text-gray-700 hover:text-black">
+          <Plus size={16} />
+          <span>New Basket</span>
+        </button>
+      </div>
+      <div className="flex-1 overflow-y-auto">
+        {baskets.map((b) => (
+          <button
+            key={b.id}
+            onClick={() => router.push(`/baskets/${b.id}/work`)}
+            className={cn(
+              "w-full text-left px-4 py-2 hover:bg-gray-100 text-sm flex items-center",
+              pathname?.includes(b.id) ? "bg-gray-100 font-semibold" : ""
+            )}
+          >
+            <Package2 size={14} className="inline-block mr-2" />
+            {b.name || "Untitled"}
+          </button>
+        ))}
+      </div>
+      <div className="border-t px-4 py-3 text-sm text-muted-foreground">
+        {userEmail ? (
+          <details className="group rounded-md bg-muted/40 px-3 py-2 hover:bg-muted transition cursor-pointer">
+            <summary className="list-none text-sm text-muted-foreground hover:text-foreground">
+              {userEmail}
+            </summary>
+            <div className="mt-2 ml-2 flex flex-col space-y-1 text-sm text-muted-foreground">
+              <button onClick={handleLogout}>🔓 Sign Out</button>
             </div>
-            <div className="h-full flex flex-col justify-between py-6 px-4">
-                {/* Top: Brand + Nav */}
-                <div className="space-y-6">
-                    <nav className="flex flex-col space-y-2 text-sm">
-                        {baseItems.map((item) => (
-                            <Link
-                                key={item.href}
-                                href={item.href}
-                                className={clsx(
-                                    "rounded-md px-3 py-2 transition hover:bg-muted hover:text-foreground",
-                                    pathname === item.href
-                                        ? "bg-muted text-foreground font-medium"
-                                        : "text-muted-foreground",
-                                )}
-                            >
-                                {item.label}
-                            </Link>
-                        ))}
-                    </nav>
-                </div>
-
-                {/* Bottom: Email / User Menu */}
-                <div className="text-sm text-muted-foreground border-t border-border pt-4">
-                    {userEmail ? (
-                        <details className="group px-3 py-2 rounded-md bg-muted/40 hover:bg-muted transition cursor-pointer">
-                            <summary className="list-none text-sm text-muted-foreground hover:text-foreground">
-                                {userEmail}
-                            </summary>
-                            <div className="mt-2 ml-2 flex flex-col space-y-1 text-sm text-muted-foreground">
-                                <button onClick={handleLogout}>
-                                    🔓 Sign Out
-                                </button>
-                            </div>
-                        </details>
-                    ) : (
-                        <p className="px-3 py-2">Not signed in</p>
-                    )}
-                    {showHint && (
-                        <p className="mt-4 text-xs hidden md:block">
-                            ⇧ V to quick-dump into this basket
-                        </p>
-                    )}
-                </div>
-            </div>
-        </aside>
-    );
-};
-
-export default Sidebar;
+          </details>
+        ) : (
+          <p className="px-3 py-2">Not signed in</p>
+        )}
+        {showHint && (
+          <p className="mt-4 text-xs hidden md:block">⇧ V to quick-dump into this basket</p>
+        )}
+      </div>
+    </aside>
+  );
+}


### PR DESCRIPTION
## Summary
- overhaul global Sidebar to mirror ChatGPT-style layout
- fetch baskets from Supabase and display them in a scrollable list
- add sticky top area with brand and new basket action

## Testing
- `npm test`
- `make tests` *(fails: see logs)*

------
https://chatgpt.com/codex/tasks/task_e_687608f298948329b0dbe0e3f1423ba0