### PR TITLE
Add sidebar divider for baskets

### DIFF
--- a/web/app/components/layout/Sidebar.tsx
+++ b/web/app/components/layout/Sidebar.tsx
@@ -92,7 +92,10 @@ export default function Sidebar({ className }: SidebarProps) {
           <span>New Basket</span>
         </button>
       </div>
-      <div className="flex-1 overflow-y-auto">
+      <div className="px-4 pt-4 pb-2 text-xs font-medium text-muted-foreground uppercase tracking-wide">
+        🧺 Baskets
+      </div>
+      <div className="flex-1 overflow-y-auto space-y-1">
         {baskets.map((b) => (
           <button
             key={b.id}


### PR DESCRIPTION
## Summary
- add a non-scrollable "🧺 Baskets" divider before the basket list
- add small vertical spacing between basket entries

## Testing
- `make lint` *(fails: found 158 errors)*
- `make tests` *(fails: 24 failed, 29 passed, 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_687610780214832984433dbc543e548e