### PR TITLE
Refactor workspace helpers

### DIFF
--- a/web/app/api/baskets/new/route.ts
+++ b/web/app/api/baskets/new/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createServiceRoleClient } from "@/lib/supabase/serviceRole";
-import { getOrCreateWorkspaceId } from "@/lib/workspaces";
+import { getServerWorkspace } from "@/lib/workspaces/getServerWorkspace";
 
 export async function POST(req: NextRequest) {
   let payload: { text: string; files?: string[]; name?: string | null };
@@ -21,7 +21,8 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Missing user ID" }, { status: 401 });
   }
 
-  const workspaceId = await getOrCreateWorkspaceId(supabase, userId);
+  const workspace = await getServerWorkspace(userId);
+  const workspaceId = workspace?.id;
 
   const { data: basket, error: basketErr } = await supabase
     .from("baskets")

--- a/web/app/baskets/[id]/docs/[did]/work/page.tsx
+++ b/web/app/baskets/[id]/docs/[did]/work/page.tsx
@@ -1,7 +1,7 @@
 import DocumentWorkbenchLayout from "@/components/layouts/DocumentWorkbenchLayout";
 import ContextBlocksPanel from "@/components/basket/ContextBlocksPanel";
 import { createServerSupabaseClient } from "@/lib/supabaseServerClient";
-import { getOrCreateWorkspaceId } from "@/lib/workspaces";
+import { getServerWorkspace } from "@/lib/workspaces/getServerWorkspace";
 import { redirect } from "next/navigation";
 
 interface PageProps {
@@ -19,7 +19,8 @@ export default async function DocWorkPage({ params }: PageProps) {
   if (!user) {
     redirect("/login");
   }
-  const workspaceId = await getOrCreateWorkspaceId(supabase, user?.id!);
+  const workspace = await getServerWorkspace(user.id);
+  const workspaceId = workspace?.id;
   console.debug("[DocLoader] Workspace ID:", workspaceId);
 
   const { data: basket } = await supabase

--- a/web/app/baskets/[id]/work/page.tsx
+++ b/web/app/baskets/[id]/work/page.tsx
@@ -1,6 +1,6 @@
 import BasketWorkLayout from "@/components/layouts/BasketWorkLayout"
 import { createServerSupabaseClient } from "@/lib/supabaseServerClient"
-import { getOrCreateWorkspaceId } from "@/lib/workspaces"
+import { getServerWorkspace } from "@/lib/workspaces/getServerWorkspace"
 import { redirect } from "next/navigation"
 
 // ✅ Next.js 15 requires params to be a Promise
@@ -20,7 +20,8 @@ export default async function BasketWorkPage({
 
   console.debug("[BasketLoader] User:", user)
 
-  const workspaceId = await getOrCreateWorkspaceId(supabase, user?.id!)
+  const workspace = await getServerWorkspace(user.id)
+  const workspaceId = workspace?.id
   console.debug("[BasketLoader] Workspace ID:", workspaceId)
 
   if (!user) {

--- a/web/app/baskets/[id]/work/page.tsx
+++ b/web/app/baskets/[id]/work/page.tsx
@@ -20,13 +20,13 @@ export default async function BasketWorkPage({
 
   console.debug("[BasketLoader] User:", user)
 
-  const workspace = await getServerWorkspace(user.id)
-  const workspaceId = workspace?.id
-  console.debug("[BasketLoader] Workspace ID:", workspaceId)
-
   if (!user) {
     redirect("/login")
   }
+
+  const workspace = await getServerWorkspace(user!.id)
+  const workspaceId = workspace?.id
+  console.debug("[BasketLoader] Workspace ID:", workspaceId)
 
   const { data: basket } = await supabase
     .from("baskets")

--- a/web/lib/workspaces/getClientWorkspace.ts
+++ b/web/lib/workspaces/getClientWorkspace.ts
@@ -1,0 +1,16 @@
+"use client";
+
+import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { getServerWorkspace } from "./getServerWorkspace";
+import { Database } from "@/types/supabase";
+
+export async function getClientWorkspace() {
+  const supabase = createClientComponentClient<Database>();
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser();
+  if (error || !user) return null;
+
+  return getServerWorkspace(user.id);
+}

--- a/web/lib/workspaces/getServerWorkspace.ts
+++ b/web/lib/workspaces/getServerWorkspace.ts
@@ -1,0 +1,15 @@
+import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
+import { cookies } from "next/headers";
+import { Database } from "@/types/supabase";
+
+export async function getServerWorkspace(userId: string) {
+  const supabase = createServerComponentClient<Database>({ cookies });
+
+  const { data: workspace } = await supabase
+    .from("workspaces")
+    .select("*")
+    .eq("user_id", userId)
+    .maybeSingle();
+
+  return workspace;
+}

--- a/web/lib/workspaces/index.ts
+++ b/web/lib/workspaces/index.ts
@@ -1,0 +1,2 @@
+export * from "./getClientWorkspace";
+export * from "./getServerWorkspace";

--- a/web/types/supabase.ts
+++ b/web/types/supabase.ts
@@ -1,0 +1,1 @@
+export * from "../lib/dbTypes";


### PR DESCRIPTION
## Summary
- add new workspace helpers for client and server usage
- use `getServerWorkspace` in server pages and API
- provide `supabase` types for imports

## Testing
- `npm install`
- `npx tsc --noEmit` *(fails: Cannot find module '@testing-library/react' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68784ea5ae808329988aeb55c8c78561