### PR TITLE
refactor: unify workspace helpers

### DIFF
--- a/web/lib/workspaces/getClientWorkspace.ts
+++ b/web/lib/workspaces/getClientWorkspace.ts
@@ -1,16 +1,20 @@
 "use client";
 
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
-import { getServerWorkspace } from "./getServerWorkspace";
-import { Database } from "@/types/supabase";
 
 export async function getClientWorkspace() {
-  const supabase = createClientComponentClient<Database>();
+  const supabase = createClientComponentClient();
   const {
     data: { user },
-    error,
   } = await supabase.auth.getUser();
-  if (error || !user) return null;
 
-  return getServerWorkspace(user.id);
+  if (!user) return null;
+
+  const { data: workspace } = await supabase
+    .from("workspaces")
+    .select("*")
+    .eq("user_id", user.id)
+    .single();
+
+  return workspace ?? null;
 }

--- a/web/lib/workspaces/getServerWorkspace.ts
+++ b/web/lib/workspaces/getServerWorkspace.ts
@@ -1,15 +1,14 @@
 import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
 import { cookies } from "next/headers";
-import { Database } from "@/types/supabase";
 
 export async function getServerWorkspace(userId: string) {
-  const supabase = createServerComponentClient<Database>({ cookies });
+  const supabase = createServerComponentClient({ cookies });
 
   const { data: workspace } = await supabase
     .from("workspaces")
     .select("*")
     .eq("user_id", userId)
-    .maybeSingle();
+    .single();
 
-  return workspace;
+  return workspace ?? null;
 }


### PR DESCRIPTION
## Summary
- return workspace from the client-side helper directly
- simplify server helper

## Testing
- `npx tsc --noEmit` *(fails: Cannot find name 'vi', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68785277a3688329abf819d2dff7dc16