### PR TITLE
refactor workspace resolver calls

### DIFF
--- a/web/app/api/baskets/new/route.ts
+++ b/web/app/api/baskets/new/route.ts
@@ -16,13 +16,13 @@ export async function POST(req: NextRequest) {
   }
 
   const supabase = createServiceRoleClient();
-  const userId = req.headers.get("X-User-Id");
-  if (!userId) {
-    return NextResponse.json({ error: "Missing user ID" }, { status: 401 });
+
+  const workspace = await getServerWorkspace();
+  if (!workspace) {
+    return NextResponse.json({ error: "workspace not found" }, { status: 401 });
   }
 
-  const workspace = await getServerWorkspace(userId);
-  const workspaceId = workspace?.id;
+  const { id: workspaceId, user_id: userId } = workspace;
 
   const { data: basket, error: basketErr } = await supabase
     .from("baskets")

--- a/web/app/baskets/[id]/docs/[did]/work/page.tsx
+++ b/web/app/baskets/[id]/docs/[did]/work/page.tsx
@@ -19,7 +19,7 @@ export default async function DocWorkPage({ params }: PageProps) {
   if (!user) {
     redirect("/login");
   }
-  const workspace = await getServerWorkspace(user.id);
+  const workspace = await getServerWorkspace();
   const workspaceId = workspace?.id;
   console.debug("[DocLoader] Workspace ID:", workspaceId);
 

--- a/web/app/baskets/[id]/work/page.tsx
+++ b/web/app/baskets/[id]/work/page.tsx
@@ -24,7 +24,7 @@ export default async function BasketWorkPage({
     redirect("/login")
   }
 
-  const workspace = await getServerWorkspace(user!.id)
+  const workspace = await getServerWorkspace()
   const workspaceId = workspace?.id
   console.debug("[BasketLoader] Workspace ID:", workspaceId)
 


### PR DESCRIPTION
## Summary
- switch server side routes/pages to new `getServerWorkspace()`
- grab `workspace.user_id` in POST handler instead of header

## Testing
- `make lint` *(fails: unused imports)*
- `make format` *(fails: pyenv version not installed)*
- `make tests` *(fails: multiple test failures)*
- `npx tsc -p web/tsconfig.json` *(fails: missing React type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_6878667f79108329ba5428dae7c82afb