### PR TITLE
Implement home landing page flow

### DIFF
--- a/web/app/auth/callback/page.tsx
+++ b/web/app/auth/callback/page.tsx
@@ -1,91 +1,25 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 
 export default function AuthCallbackPage() {
   const router = useRouter();
   const supabase = createClientComponentClient();
-  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    const checkSession = async () => {
+    const run = async () => {
       const {
-        data: { session },
-        error: sessionError,
-      } = await supabase.auth.getSession();
+        data: { user },
+      } = await supabase.auth.getUser();
+      if (!user) return router.replace("/login");
 
-      if (sessionError || !session?.user) {
-        setError("Authentication failed. Please try logging in again.");
-        setTimeout(() => router.replace("/login"), 1500);
-        return;
-      }
-
-      const user = session.user;
-
-      // 🧠 Optional: create workspace if not exists
-      const { data: workspace, error: workspaceError } = await supabase
-        .from("workspaces")
-        .select("id")
-        .eq("user_id", user.id)
-        .maybeSingle();
-
-      let workspaceId = workspace?.id;
-      if (!workspaceId) {
-        const { data: newWorkspace, error: createError } = await supabase
-          .from("workspaces")
-          .insert({ user_id: user.id })
-          .select("id")
-          .single();
-
-        if (createError || !newWorkspace?.id) {
-          setError("Unable to initialize workspace.");
-          return;
-        }
-
-        workspaceId = newWorkspace.id;
-      }
-
-      const storedPath =
-        typeof window !== "undefined"
-          ? localStorage.getItem("postLoginPath")
-          : null;
-
-      if (storedPath) {
-        localStorage.removeItem("postLoginPath");
-        router.replace(storedPath);
-        return;
-      }
-
-      const { data: baskets } = await supabase
-        .from("baskets")
-        .select("id")
-        .eq("workspace_id", workspaceId)
-        .order("created_at", { ascending: false })
-        .limit(1);
-
-      if (baskets && baskets.length > 0) {
-        router.replace(`/baskets/${baskets[0].id}/work?tab=dashboard`);
-      } else {
-        const { data: newBasket, error: insertError } = await supabase
-          .from("baskets")
-          .insert({ name: "Untitled Basket", workspace_id: workspaceId })
-          .select("id")
-          .single();
-
-        if (insertError || !newBasket?.id) {
-          setError("Could not create your first basket.");
-          return;
-        }
-
-        router.replace(`/baskets/${newBasket.id}/work?tab=dashboard`);
-      }
+      router.replace("/home"); // ✅ stable neutral landing
     };
 
-    checkSession();
-  }, [router, supabase]);
+    run();
+  }, []);
 
-  if (error) return <p>{error}</p>;
-  return <p>Loading...</p>;
+  return null;
 }

--- a/web/app/home/page.tsx
+++ b/web/app/home/page.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/Button";
+import { Loader2 } from "lucide-react";
+
+export default function HomePage() {
+  const supabase = createClientComponentClient();
+  const router = useRouter();
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const resolveUserState = async () => {
+      try {
+        const {
+          data: { user },
+        } = await supabase.auth.getUser();
+        if (!user) return router.replace("/login");
+
+        const { data: workspace } = await supabase
+          .from("workspaces")
+          .select("*")
+          .eq("owner_id", user.id)
+          .single();
+
+        if (!workspace) {
+          setError("Workspace not found or could not be created.");
+          setLoading(false);
+          return;
+        }
+
+        const { data: baskets } = await supabase
+          .from("baskets")
+          .select("id")
+          .eq("workspace_id", workspace.id)
+          .limit(1);
+
+        if (baskets && baskets.length > 0) {
+          router.replace(`/baskets/${baskets[0].id}/work`);
+        } else {
+          router.replace("/baskets/new?mode=wizard");
+        }
+      } catch (err) {
+        console.error("Error resolving user state:", err);
+        setError("Something went wrong while setting up your workspace.");
+        setLoading(false);
+      }
+    };
+
+    resolveUserState();
+  }, []);
+
+  return (
+    <main className="p-8 max-w-2xl mx-auto">
+      <Card>
+        <CardContent className="py-8">
+          {loading ? (
+            <div className="flex flex-col items-center justify-center space-y-2">
+              <Loader2 className="animate-spin h-6 w-6 text-muted-foreground" />
+              <p className="text-sm text-muted-foreground">
+                Preparing your workspace...
+              </p>
+            </div>
+          ) : error ? (
+            <div className="space-y-4">
+              <p className="text-sm text-destructive font-medium">{error}</p>
+              <Button onClick={() => router.push("/settings")}>Go to Settings</Button>
+            </div>
+          ) : null}
+        </CardContent>
+      </Card>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- simplify auth callback to just redirect to `/home`
- add `/home` page that resolves workspace and basket before redirecting

## Testing
- `make lint` *(fails: 158 errors)*
- `make tests` *(fails: 24 failed, 29 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68787b9438908329bfaf950e65b85903