### PR TITLE
Clean login routing and orphan redirect safeguard

### DIFF
--- a/web/app/home/page.tsx
+++ b/web/app/home/page.tsx
@@ -14,18 +14,21 @@ export default function HomePage() {
         data: { user },
         error,
       } = await supabase.auth.getUser();
+
       if (error || !user) {
+        console.warn("❌ No user. Redirecting to /login.");
         router.replace("/login");
         return;
       }
 
-      const { data: workspace } = await supabase
+      const { data: workspace, error: wsError } = await supabase
         .from("workspaces")
         .select("id")
         .eq("owner_id", user.id)
         .single();
 
-      if (!workspace) {
+      if (wsError || !workspace) {
+        console.warn("⚠️ No workspace. Redirecting to /baskets/new.");
         router.replace("/baskets/new");
         return;
       }
@@ -38,15 +41,18 @@ export default function HomePage() {
         .limit(1)
         .maybeSingle();
 
-      if (!basket) {
-        router.replace("/baskets/new");
-      } else {
-        router.replace(`/baskets/${basket.id}/work`);
-      }
+      const redirectTarget = basket?.id
+        ? `/baskets/${basket.id}/work`
+        : "/baskets/new";
+
+      console.log("🧭 [HOME] Redirecting to:", redirectTarget);
+      router.replace(redirectTarget);
     };
 
     run();
   }, []);
 
-  return <p className="p-4 text-muted-foreground">Redirecting...</p>;
+  return (
+    <p className="p-4 text-muted-foreground">Preparing your workspace...</p>
+  );
 }

--- a/web/app/login/page.tsx
+++ b/web/app/login/page.tsx
@@ -25,7 +25,7 @@ export default function LoginPage() {
                 .limit(1);
 
             if (baskets && baskets.length > 0) {
-                router.replace(`/baskets/${baskets[0].id}/work?tab=dashboard`);
+                router.replace("/home");
             } else {
                 const { data: newBasket, error } = await supabase
                     .from("baskets")
@@ -40,7 +40,7 @@ export default function LoginPage() {
                     return;
                 }
 
-                router.replace(`/baskets/${newBasket.id}/work?tab=dashboard`);
+                router.replace("/home");
             }
         });
     }, [router]);

--- a/web/app/work/page.tsx
+++ b/web/app/work/page.tsx
@@ -1,0 +1,14 @@
+"use client";
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+
+export default function OrphanWorkRedirect() {
+  const router = useRouter();
+
+  useEffect(() => {
+    console.warn("🚨 Invalid /work route accessed. Redirecting to /home.");
+    router.replace("/home");
+  }, []);
+
+  return <p className="p-4 text-muted-foreground">Redirecting...</p>;
+}


### PR DESCRIPTION
## Summary
- redirect login and callback to `/home`
- make `/home` handle post-login redirect logic
- add fallback `/work` page to handle stale links

## Testing
- `make format` *(fails: reformats but not committed)*
- `make lint` *(fails: ruff errors)*
- `make tests` *(fails: various test failures)*

------
https://chatgpt.com/codex/tasks/task_e_6878ad10dbe8832991bd7cc0e2dfeeee