### PR TITLE
Add AuthGuard to protect home page

### DIFF
--- a/web/app/components/AuthGuard.tsx
+++ b/web/app/components/AuthGuard.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+
+export default function AuthGuard({ children }: { children: React.ReactNode }) {
+  const [checking, setChecking] = useState(true);
+  const router = useRouter();
+  const supabase = createClientComponentClient();
+
+  useEffect(() => {
+    const checkAuth = async () => {
+      const {
+        data: { user },
+        error,
+      } = await supabase.auth.getUser();
+
+      if (!user || error) {
+        console.warn("🔒 No session found. Redirecting to /login.");
+        router.replace("/login");
+      } else {
+        setChecking(false);
+      }
+    };
+
+    checkAuth();
+  }, []);
+
+  if (checking) {
+    return <p className="p-4 text-muted-foreground">Checking authentication...</p>;
+  }
+
+  return <>{children}</>;
+}

--- a/web/app/home/page.tsx
+++ b/web/app/home/page.tsx
@@ -1,41 +1,16 @@
 "use client";
 
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
-import { useEffect, useState } from "react";
+import AuthGuard from "@/components/AuthGuard";
 
 export default function HomePage() {
-  const supabase = createClientComponentClient();
-  const [loading, setLoading] = useState(true);
-  const [userEmail, setUserEmail] = useState<string | null>(null);
-
-  useEffect(() => {
-    const run = async () => {
-      const {
-        data: { user },
-        error,
-      } = await supabase.auth.getUser();
-      if (error || !user) {
-        console.warn("❌ No user. Redirecting to /login.");
-        window.location.href = "/login";
-        return;
-      }
-
-      setUserEmail(user.email ?? null);
-      setLoading(false);
-    };
-
-    run();
-  }, []);
-
-  if (loading) return <p className="p-4 text-muted-foreground">Loading...</p>;
-
   return (
-    <div className="p-4">
-      <h1 className="text-2xl font-bold">👋 Welcome back</h1>
-      <p className="text-muted-foreground">
-        You are logged in as <strong>{userEmail}</strong>
-      </p>
-      <p className="mt-4">Use the left sidebar to select or create a basket.</p>
-    </div>
+    <AuthGuard>
+      <div className="p-6">
+        <h1 className="text-2xl font-semibold mb-2">👋 Welcome back</h1>
+        <p className="text-muted-foreground">
+          Use the sidebar to select or create a basket to get started.
+        </p>
+      </div>
+    </AuthGuard>
   );
 }


### PR DESCRIPTION
## Summary
- add `AuthGuard` component to enforce auth
- wrap `/home` route in the guard for immediate redirect

## Test Plan
- `make format`
- `make lint` *(fails: ruff errors)*
- `npm run test`
- `pytest -q` *(fails: missing tensorflow contrib)*

------
https://chatgpt.com/codex/tasks/task_e_6878b514fef48329afabeb1aaf79c60a