### PR TITLE
Add GET route to proxy baskets list

### DIFF
--- a/web/app/api/baskets/list/route.ts
+++ b/web/app/api/baskets/list/route.ts
@@ -1,0 +1,14 @@
+import { NextRequest, NextResponse } from "next/server";
+import { apiFetch } from "@/lib/api";
+
+export async function GET(request: NextRequest) {
+  const headers: HeadersInit = {};
+  const auth = request.headers.get("authorization");
+  if (auth) headers["Authorization"] = auth;
+  const cookie = request.headers.get("cookie");
+  if (cookie) headers["cookie"] = cookie;
+
+  const res = await apiFetch("/baskets/list", { headers, cache: "no-store" });
+  const data = await res.json();
+  return NextResponse.json(data, { status: res.status });
+}

--- a/web/app/api/baskets/list/route.ts
+++ b/web/app/api/baskets/list/route.ts
@@ -8,7 +8,15 @@ export async function GET(request: NextRequest) {
   const cookie = request.headers.get("cookie");
   if (cookie) headers["cookie"] = cookie;
 
-  const res = await apiFetch("/baskets/list", { headers, cache: "no-store" });
-  const data = await res.json();
-  return NextResponse.json(data, { status: res.status });
+  try {
+    const res = await apiFetch("/baskets/list", { headers, cache: "no-store" });
+    const data = await res.json();
+    return NextResponse.json(data, { status: res.status });
+  } catch (err) {
+    console.error("\u274c Proxy error for /baskets/list:", err);
+    return NextResponse.json(
+      { error: "Failed to fetch baskets" },
+      { status: 500 },
+    );
+  }
 }

--- a/web/lib/baskets/getAllBaskets.ts
+++ b/web/lib/baskets/getAllBaskets.ts
@@ -1,11 +1,29 @@
 // web/lib/baskets/getAllBaskets.ts
-import { apiGet } from "@/lib/api";
 import { Database } from "@/lib/dbTypes";
 
 export type BasketOverview =
   Database["public"]["Views"]["v_basket_overview"]["Row"];
 
-export async function getAllBaskets() {
-  // Calls your FastAPI server which proxies to Supabase securely
-  return apiGet<BasketOverview[]>("/baskets/list");
+export async function getAllBaskets(): Promise<BasketOverview[]> {
+  try {
+    const res = await fetch("/api/baskets/list", {
+      method: "GET",
+      credentials: "include",
+    });
+
+    if (!res.ok) {
+      console.error(
+        "\u274c Failed to fetch baskets:",
+        res.status,
+        await res.text(),
+      );
+      return [];
+    }
+
+    const data = await res.json();
+    return data.baskets || [];
+  } catch (err) {
+    console.error("\u274c Network error while fetching baskets:", err);
+    return [];
+  }
 }


### PR DESCRIPTION
## Summary
- proxy `/api/baskets/list` to FastAPI backend

## Testing
- `npm run test`
- `PYENV_VERSION=3.11.12 pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6879828601c88329ab31523aef037d01