### PR TITLE
Fix redirect after OAuth login

### DIFF
--- a/web/app/auth/callback/page.tsx
+++ b/web/app/auth/callback/page.tsx
@@ -21,12 +21,15 @@ export default function AuthCallbackPage() {
         return;
       }
 
-      // 🔄 Clear any stale redirect state
+      const redirectPath =
+        localStorage.getItem("redirectPath") || "/home";
       localStorage.removeItem("redirectPath");
       sessionStorage.removeItem("redirectPath");
 
-      console.info("✅ Auth successful. Redirecting to /home...");
-      router.replace("/home");
+      console.info(
+        `✅ Auth successful. Redirecting to ${redirectPath}...`
+      );
+      router.replace(redirectPath);
     };
 
     run();

--- a/web/app/baskets/[id]/docs/[did]/work/page.tsx
+++ b/web/app/baskets/[id]/docs/[did]/work/page.tsx
@@ -17,7 +17,7 @@ export default async function DocWorkPage({ params }: PageProps) {
   } = await supabase.auth.getUser();
   console.debug("[DocLoader] User:", user);
   if (!user) {
-    redirect("/login");
+    redirect(`/login?redirect=/baskets/${id}/docs/${did}/work`);
   }
   const workspace = await getServerWorkspace();
   const workspaceId = workspace?.id;

--- a/web/app/baskets/[id]/work/page.tsx
+++ b/web/app/baskets/[id]/work/page.tsx
@@ -38,6 +38,9 @@ export default function BasketWorkPage({
       const { data: { user }, error: userError } = await supabase.auth.getUser();
       if (userError || !user) {
         setError("Authentication error. Please log in again.");
+        if (typeof window !== "undefined") {
+          localStorage.setItem("redirectPath", window.location.pathname);
+        }
         return router.replace("/login");
       }
 

--- a/web/app/baskets/page.tsx
+++ b/web/app/baskets/page.tsx
@@ -31,7 +31,10 @@ export default function BasketsPage() {
   useEffect(() => {
     if (isLoading) return;
     if (!session) {
-      router.replace("/about");
+      if (typeof window !== "undefined") {
+        localStorage.setItem("redirectPath", window.location.pathname);
+      }
+      router.replace("/login");
       return;
     }
     getAllBaskets().then(setBaskets).catch(console.error);

--- a/web/app/components/AuthGuard.tsx
+++ b/web/app/components/AuthGuard.tsx
@@ -18,6 +18,9 @@ export default function AuthGuard({ children }: { children: React.ReactNode }) {
 
       if (!user || error) {
         console.warn("🔒 No session found. Redirecting to /login.");
+        if (typeof window !== "undefined") {
+          localStorage.setItem("redirectPath", window.location.pathname);
+        }
         router.replace("/login");
       } else {
         setChecking(false);

--- a/web/app/creations/page.tsx
+++ b/web/app/creations/page.tsx
@@ -14,7 +14,10 @@ export default function CreationsPage() {
   useEffect(() => {
     if (isLoading) return;
     if (!session) {
-      router.replace("/about");
+      if (typeof window !== "undefined") {
+        localStorage.setItem("redirectPath", window.location.pathname);
+      }
+      router.replace("/login");
     }
   }, [isLoading, session, router]);
 

--- a/web/app/login/page.tsx
+++ b/web/app/login/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useState } from "react";
 import Link from "next/link";
 import { supabase } from "@/lib/supabaseClient";
@@ -9,9 +9,18 @@ import Brand from "@/components/Brand";
 
 export default function LoginPage() {
     const router = useRouter();
+    const searchParams = useSearchParams();
     const [email, setEmail] = useState("");
     const [sent, setSent] = useState(false);
     const [errorMsg, setErrorMsg] = useState("");
+
+    // Capture redirect query param if present
+    useEffect(() => {
+        const param = searchParams.get("redirect");
+        if (param) {
+            localStorage.setItem("redirectPath", param);
+        }
+    }, [searchParams]);
 
     // If already signed in, redirect to the most recent basket
     useEffect(() => {
@@ -48,7 +57,7 @@ export default function LoginPage() {
     // Google OAuth
     const handleGoogleLogin = async () => {
         if (typeof window !== "undefined") {
-            localStorage.setItem("postLoginPath", window.location.pathname);
+            localStorage.setItem("redirectPath", window.location.pathname);
         }
         const { error } = await supabase.auth.signInWithOAuth({
             provider: "google",
@@ -64,7 +73,7 @@ export default function LoginPage() {
     // Dev-only Magic Link Login
     const handleMagicLinkLogin = async () => {
         if (typeof window !== "undefined") {
-            localStorage.setItem("postLoginPath", window.location.pathname);
+            localStorage.setItem("redirectPath", window.location.pathname);
         }
         const { error } = await supabase.auth.signInWithOtp({
             email,


### PR DESCRIPTION
## Summary
- capture redirect query on /login
- save current path before redirecting unauthenticated users
- read saved path during auth callback and redirect accordingly
- append redirect query for document work pages

## Testing
- `pre-commit run --files web/app/auth/callback/page.tsx web/app/login/page.tsx web/app/components/AuthGuard.tsx web/app/baskets/[id]/work/page.tsx web/app/baskets/[id]/docs/[did]/work/page.tsx web/app/baskets/page.tsx web/app/creations/page.tsx`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68799501e3c8832985b4dbe6941af9ed