### PR TITLE
Refactor Sidebar responsive behavior

### DIFF
--- a/web/app/components/shell/Sidebar.tsx
+++ b/web/app/components/shell/Sidebar.tsx
@@ -70,17 +70,24 @@ export default function Sidebar({ className }: SidebarProps) {
 
   return (
     <aside
-      className={`sidebar fixed top-0 left-0 z-40 h-screen w-64 bg-background border-r border-border shadow-md transition-all duration-300 ${
-        isOpen ? "translate-x-0" : "-translate-x-full"
-      } ${collapsible ? "md:relative md:translate-x-0" : ""} ${className ?? ""}`}
+      className={cn(
+        "sidebar h-screen w-64 bg-background border-r border-border transition-transform duration-300",
+        collapsible
+          ? "fixed top-0 left-0 z-40 shadow-md md:relative md:translate-x-0"
+          : "relative",
+        isOpen ? "translate-x-0" : "-translate-x-full md:translate-x-0",
+        className
+      )}
     >
       <div className="sticky top-0 z-10 border-b bg-background px-4 py-3 flex items-center justify-between">
         <button onClick={handleBrandClick} className="font-brand text-xl tracking-tight hover:underline">
           yarnnn
         </button>
-        <button onClick={toggleSidebar} aria-label="Toggle sidebar" className="p-1.5 rounded hover:bg-muted transition">
-          <SidebarToggleIcon className="h-5 w-5 text-muted-foreground" />
-        </button>
+        {collapsible && (
+          <button onClick={toggleSidebar} aria-label="Toggle sidebar" className="p-1.5 rounded hover:bg-muted transition">
+            <SidebarToggleIcon className="h-5 w-5 text-muted-foreground" />
+          </button>
+        )}
       </div>
       <div className="px-4 py-3 border-b">
         <button onClick={handleNewBasket} className="flex items-center space-x-2 text-sm text-gray-700 hover:text-black">

--- a/web/components/layout/Shell.tsx
+++ b/web/components/layout/Shell.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React, { useEffect } from "react";
-import Sidebar from "@/app/components/layout/Sidebar";
+import Sidebar from "@/app/components/shell/Sidebar";
 import TopBar from "@/components/common/TopBar";
 import { useSidebarStore } from "@/lib/stores/sidebarStore";
 import { usePathname } from "next/navigation";
@@ -9,7 +9,7 @@ import { FileDropOverlay } from "@/components/FileDropOverlay";
 
 export default function Shell({ children }: { children: React.ReactNode }) {
     const pathname = usePathname();
-    const { openSidebar, closeSidebar, setCollapsible } = useSidebarStore();
+    const { openSidebar, closeSidebar, setCollapsible, isOpen } = useSidebarStore();
     const { isDraggingFile } = useFileDrag();
 
     useEffect(() => {
@@ -30,18 +30,33 @@ export default function Shell({ children }: { children: React.ReactNode }) {
 
     return (
         <div
-            className="flex h-screen overflow-hidden"
+            className="flex h-screen"
             onDrop={noopDropHandler}
             onDragOver={(e) => e.preventDefault()}
         >
             <FileDropOverlay isVisible={isDraggingFile} />
-            <Sidebar />
-            <div className="flex flex-1 flex-col">
+            {/* Desktop sidebar (inline) */}
+            <div className="hidden md:block">
+                <Sidebar />
+            </div>
+
+            <div className="flex flex-1 flex-col overflow-hidden">
                 <TopBar />
                 <main className="flex-1 overflow-y-auto px-4 pt-16 md:pt-8 md:px-8">
                     {children}
                 </main>
             </div>
+
+            {/* Mobile sidebar (overlay) */}
+            {isOpen && (
+                <div className="fixed inset-0 z-40 flex md:hidden">
+                    <Sidebar />
+                    <div
+                        className="flex-1 bg-black/40"
+                        onClick={closeSidebar}
+                    />
+                </div>
+            )}
         </div>
     );
 }


### PR DESCRIPTION
## Summary
- move `Sidebar` to `app/components/shell`
- make sidebar fixed on mobile and relative on desktop
- update `Shell` layout to use flex screen container and overlay backdrop
- ensure toggle button only shows when collapsible

## Testing
- `pre-commit` *(fails: command not found)*
- `npm run lint` *(shows 'Skipping lint')*


------
https://chatgpt.com/codex/tasks/task_e_6879cfc110d08329bbc523b67a2b1e8b