### PR TITLE
Fix sidebar overlay & user menu

### DIFF
--- a/web/app/components/shell/Sidebar.tsx
+++ b/web/app/components/shell/Sidebar.tsx
@@ -23,23 +23,20 @@ export default function Sidebar({ className }: SidebarProps) {
   const [baskets, setBaskets] = useState<BasketOverview[]>([]);
 
   useEffect(() => {
-    const getUser = async () => {
-      const {
-        data: { user },
-      } = await supabase.auth.getUser();
-      setUserEmail(user?.email || null);
-    };
-    getUser();
-    getAllBaskets()
-      .then(setBaskets)
-      .catch((err) => console.error('sidebar baskets', err));
+    async function init() {
+      try {
+        const {
+          data: { user },
+        } = await supabase.auth.getUser();
+        setUserEmail(user?.email || null);
+        const data = await getAllBaskets();
+        setBaskets(data);
+      } catch (err) {
+        console.error("sidebar init", err);
+      }
+    }
+    init();
   }, [supabase]);
-
-  useEffect(() => {
-    getAllBaskets()
-      .then(setBaskets)
-      .catch((err) => console.error('fetch baskets', err));
-  }, []);
 
   useEffect(() => {
     function handleClickOutside(e: MouseEvent) {
@@ -83,9 +80,15 @@ export default function Sidebar({ className }: SidebarProps) {
         <button onClick={handleBrandClick} className="font-brand text-xl tracking-tight hover:underline">
           yarnnn
         </button>
-        <button onClick={toggleSidebar} aria-label="Toggle sidebar" className="p-1.5 rounded hover:bg-muted transition">
-          <SidebarToggleIcon className="h-5 w-5 text-muted-foreground" />
-        </button>
+        {collapsible && (
+          <button
+            onClick={toggleSidebar}
+            aria-label="Toggle sidebar"
+            className="p-1.5 rounded hover:bg-muted transition"
+          >
+            <SidebarToggleIcon className="h-5 w-5 text-muted-foreground" />
+          </button>
+        )}
       </div>
       <div className="px-4 py-3 border-b">
         <button onClick={handleNewBasket} className="flex items-center space-x-2 text-sm text-gray-700 hover:text-black">
@@ -117,18 +120,22 @@ export default function Sidebar({ className }: SidebarProps) {
           ))
         )}
       </div>
-      <div className="border-t px-4 py-3 text-sm text-muted-foreground">
+      <div className="border-t px-4 py-3">
         {userEmail ? (
-          <details className="group rounded-md bg-muted/40 px-3 py-2 hover:bg-muted transition cursor-pointer">
-            <summary className="list-none text-sm text-muted-foreground hover:text-foreground">
+          <>
+            <p className="text-xs text-muted-foreground mb-1">Signed in as</p>
+            <div className="text-sm font-medium text-foreground truncate">
               {userEmail}
-            </summary>
-            <div className="mt-2 ml-2 flex flex-col space-y-1 text-sm text-muted-foreground">
-              <button onClick={handleLogout}>🔓 Sign Out</button>
             </div>
-          </details>
+            <button
+              onClick={handleLogout}
+              className="mt-2 text-sm text-destructive hover:underline"
+            >
+              🔓 Sign Out
+            </button>
+          </>
         ) : (
-          <p className="px-3 py-2">Not signed in</p>
+          <p className="text-sm text-muted-foreground">Not signed in</p>
         )}
         {showHint && (
           <p className="mt-4 text-xs hidden md:block">⇧ V to quick-dump into this basket</p>

--- a/web/components/layout/Shell.tsx
+++ b/web/components/layout/Shell.tsx
@@ -35,18 +35,25 @@ export default function Shell({ children }: { children: React.ReactNode }) {
             onDragOver={(e) => e.preventDefault()}
         >
             <FileDropOverlay isVisible={isDraggingFile} />
-            <Sidebar />
+            {/* Desktop sidebar */}
+            <div className="hidden md:block">
+                <Sidebar />
+            </div>
             <div className="flex flex-1 flex-col overflow-hidden">
                 <TopBar />
                 <main className="flex-1 overflow-y-auto px-4 pt-16 md:pt-8 md:px-8">
                     {children}
                 </main>
             </div>
+            {/* Mobile overlay sidebar */}
             {isOpen && (
-                <div
-                    className="fixed inset-0 bg-black/30 z-30 md:hidden"
-                    onClick={closeSidebar}
-                />
+                <div className="fixed inset-0 z-40 flex md:hidden">
+                    <Sidebar />
+                    <div
+                        className="flex-1 bg-black/40"
+                        onClick={closeSidebar}
+                    />
+                </div>
             )}
         </div>
     );


### PR DESCRIPTION
## Summary
- overlay sidebar only on mobile to avoid layout shift
- refresh baskets on mount
- hide toggle button on desktop
- restyle account block with sign-out button

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6879dadf7f5c8329842f21542fdabc99