### PR TITLE
Update login to persist redirect path

### DIFF
--- a/web/app/login/LoginClient.tsx
+++ b/web/app/login/LoginClient.tsx
@@ -28,10 +28,7 @@ export default function LoginClient() {
   }, [searchParams]);
 
   const handleGoogleLogin = async () => {
-    if (typeof window !== "undefined") {
-      // ✅ Force redirect path for post-login routing
-      localStorage.setItem("redirectPath", "/dashboard/home");
-    }
+    localStorage.setItem("redirectPath", "/dashboard/home");
     const { error } = await supabase.auth.signInWithOAuth({
       provider: "google",
       options: {


### PR DESCRIPTION
## Summary
- ensure the login button saves `/dashboard/home` in `localStorage` before starting OAuth

## Testing
- `make lint` *(fails: Found 171 errors)*
- `make tests` *(fails: 21 failed, 32 passed)*

------
https://chatgpt.com/codex/tasks/task_e_687b16f203f08329a25e7680dcb93a80