### PR TITLE
Fix OAuth redirect handling

### DIFF
--- a/web/app/auth/callback/page.tsx
+++ b/web/app/auth/callback/page.tsx
@@ -4,7 +4,6 @@ import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { createPagesBrowserClient } from "@supabase/auth-helpers-nextjs";
 import { SessionContextProvider } from "@supabase/auth-helpers-react";
-import { getRedirectPath } from "@/lib/auth/getRedirectPath";
 
 const supabase = createPagesBrowserClient();
 
@@ -25,9 +24,14 @@ export default function AuthCallbackPage() {
         return;
       }
 
-      const redirectPath = getRedirectPath();
-      console.info(`✅ Auth successful. Redirecting to ${redirectPath}...`);
-      router.replace(redirectPath);
+      let redirectPath: string | null = null;
+      if (typeof window !== "undefined") {
+        redirectPath = localStorage.getItem("redirectPath");
+        localStorage.removeItem("redirectPath");
+        sessionStorage.removeItem("redirectPath");
+      }
+      console.log("\ud83d\udd01 Redirecting to:", redirectPath ?? "/dashboard/home");
+      router.replace(redirectPath ?? "/dashboard/home");
     };
 
     run().finally(() => setLoading(false));

--- a/web/app/login/LoginClient.tsx
+++ b/web/app/login/LoginClient.tsx
@@ -29,6 +29,7 @@ export default function LoginClient() {
 
   const handleGoogleLogin = async () => {
     localStorage.setItem("redirectPath", "/dashboard/home");
+    console.log("\ud83d\udecf window.location.origin", window.location.origin);
     const { error } = await supabase.auth.signInWithOAuth({
       provider: "google",
       options: {
@@ -45,6 +46,7 @@ export default function LoginClient() {
       // ✅ Force redirect path for post-login routing
       localStorage.setItem("redirectPath", "/dashboard/home");
     }
+    console.log("\ud83d\udecf window.location.origin", window.location.origin);
     const { error } = await supabase.auth.signInWithOtp({
       email,
       options: {

--- a/web/lib/auth/getRedirectPath.ts
+++ b/web/lib/auth/getRedirectPath.ts
@@ -1,9 +1,9 @@
 // web/lib/auth/getRedirectPath.ts
 
 export function getRedirectPath(): string {
-  if (typeof window === "undefined") return "/home";
+  if (typeof window === "undefined") return "/dashboard/home";
 
-  const path = localStorage.getItem("redirectPath") ?? "/home";
+  const path = localStorage.getItem("redirectPath") ?? "/dashboard/home";
   localStorage.removeItem("redirectPath");
   sessionStorage.removeItem("redirectPath");
   return path;


### PR DESCRIPTION
## Summary
- ensure local/production OAuth flows hit `/auth/callback`
- log browser origin before triggering OAuth
- redirect after auth based on stored redirectPath
- default unknown redirects to `/dashboard/home`

## Testing
- `npm test`
- `make tests` *(fails: AttributeError/TypeError)*

------
https://chatgpt.com/codex/tasks/task_e_687b1be951448329b688a5e1b951e897