### PR TITLE
Display workspace ID in settings

### DIFF
--- a/web/components/settings/DisplayBox.tsx
+++ b/web/components/settings/DisplayBox.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+
+export default function DisplayBox({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="mb-4">
+      <label className="block text-sm font-medium text-muted-foreground mb-1">
+        {label}
+      </label>
+      <div className="rounded-md border bg-muted px-3 py-2 text-sm">{value}</div>
+    </div>
+  );
+}

--- a/web/components/settings/SettingsSection.tsx
+++ b/web/components/settings/SettingsSection.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+
+export default function SettingsSection({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="space-y-4">
+      <div>
+        <h1 className="text-2xl font-bold">{title}</h1>
+        <p className="text-sm text-muted-foreground">{description}</p>
+      </div>
+      <div>{children}</div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- show user workspace ID on dashboard settings page
- add small DisplayBox and SettingsSection components

## Testing
- `npm run lint`
- `cd web && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687b62674090832982671d439e08dbb9