### PR TITLE
Remove layout workspace creation

### DIFF
--- a/web/app/dashboard/home/page.tsx
+++ b/web/app/dashboard/home/page.tsx
@@ -1,8 +1,8 @@
-"use client";
-
+import { getOrCreateWorkspace } from "@/lib/workspaces";
 import AuthGuard from "@/components/AuthGuard";
 
-export default function HomePage() {
+export default async function HomePage() {
+  await getOrCreateWorkspace();
   return (
     <AuthGuard>
       <div className="p-6">

--- a/web/app/dashboard/layout.tsx
+++ b/web/app/dashboard/layout.tsx
@@ -5,15 +5,12 @@ import { cookies } from "next/headers";
 import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
 import { Database } from "@/lib/dbTypes";
 import ClientLayoutWrapper from "@/components/layouts/ClientLayoutWrapper";
-import { getOrCreateWorkspace } from "@/lib/workspaces";
 
 export default async function DashboardLayout({ children }: { children: ReactNode }) {
   const supabase = createServerComponentClient<Database>({ cookies });
   const {
     data: { session },
   } = await supabase.auth.getSession();
-
-  await getOrCreateWorkspace();
 
   return (
     <ClientLayoutWrapper initialSession={session}>

--- a/web/app/dashboard/settings/page.tsx
+++ b/web/app/dashboard/settings/page.tsx
@@ -4,6 +4,7 @@ import { redirect } from "next/navigation";
 import type { Database } from "@/lib/dbTypes";
 import SettingsSection from "@/components/settings/SettingsSection";
 import DisplayBox from "@/components/settings/DisplayBox";
+import { getOrCreateWorkspace } from "@/lib/workspaces";
 
 export default async function SettingsPage() {
   const supabase = createServerComponentClient<Database>({ cookies });
@@ -14,6 +15,9 @@ export default async function SettingsPage() {
   if (!user) {
     redirect("/login?redirect=/dashboard/settings");
   }
+
+  const workspace = await getOrCreateWorkspace();
+  const workspaceId = workspace?.id ?? null;
 
   const displayName =
     (user.user_metadata?.full_name as string) ||
@@ -29,6 +33,16 @@ export default async function SettingsPage() {
         <DisplayBox label="UID" value={user.id} />
         <DisplayBox label="Display Name" value={displayName} />
         <DisplayBox label="Email" value={user.email ?? ""} />
+        {workspaceId ? (
+          <DisplayBox label="Workspace ID" value={workspaceId} />
+        ) : (
+          <div className="rounded-md bg-red-50 p-4 text-red-800 border border-red-200">
+            <strong>⚠️ No workspace found.</strong>
+            <p className="mt-1 text-sm">
+              Something went wrong with workspace setup. Please refresh the page or contact support.
+            </p>
+          </div>
+        )}
       </SettingsSection>
     </div>
   );


### PR DESCRIPTION
## Summary
- create workspace when visiting specific dashboard pages
- drop workspace creation from dashboard layout

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687b70d8f6988329add21d586fa31442