### PR TITLE
Add workspace bootstrap API route

### DIFF
--- a/web/app/api/workspaces/bootstrap/route.ts
+++ b/web/app/api/workspaces/bootstrap/route.ts
@@ -1,0 +1,69 @@
+import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { cookies } from "next/headers";
+import { NextResponse } from "next/server";
+import type { Database } from "@/lib/dbTypes";
+
+export async function POST() {
+  const cookieStore = cookies();
+  const supabase = createRouteHandlerClient<Database>({ cookies: () => cookieStore });
+
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError || !user) {
+    return NextResponse.json({ status: "error", message: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const { data: membership, error: membershipError } = await supabase
+      .from("workspace_memberships")
+      .select("workspace_id")
+      .eq("user_id", user.id)
+      .maybeSingle();
+
+    if (membershipError) {
+      console.error("❌ Error checking workspace membership:", membershipError);
+      return NextResponse.json(
+        { status: "error", message: membershipError.message },
+        { status: 500 },
+      );
+    }
+
+    if (membership?.workspace_id) {
+      return NextResponse.json({ status: "exists", workspace_id: membership.workspace_id });
+    }
+
+    const { data: workspace, error: wsError } = await supabase
+      .from("workspaces")
+      .insert({ owner_id: user.id, name: `${user.email}'s Workspace` })
+      .select("id")
+      .single();
+
+    if (wsError || !workspace) {
+      console.error("❌ Error creating workspace:", wsError);
+      return NextResponse.json(
+        { status: "error", message: wsError?.message ?? "Workspace creation failed" },
+        { status: 500 },
+      );
+    }
+
+    const { error: memberInsertError } = await supabase
+      .from("workspace_memberships")
+      .insert({ user_id: user.id, workspace_id: workspace.id, role: "owner" });
+
+    if (memberInsertError) {
+      console.error("❌ Error creating workspace membership:", memberInsertError);
+      return NextResponse.json(
+        { status: "error", message: memberInsertError.message },
+        { status: 500 },
+      );
+    }
+
+    return NextResponse.json({ status: "created", workspace_id: workspace.id });
+  } catch (err) {
+    console.error("❌ Unexpected error during workspace bootstrap:", err);
+    return NextResponse.json({ status: "error", message: "Unexpected error" }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary
- add new route at `/api/workspaces/bootstrap` to create a personal workspace when needed

## Testing
- `npm test`
- `make tests` *(fails: 21 failed, 32 passed)*

------
https://chatgpt.com/codex/tasks/task_e_687c85aefc008329af32a027f5317b2a