### PR TITLE
fix: audit JSX components for safe legacy comment syntax and fallback formatting

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
     "e2e:debug": "playwright test --debug",
     "lint": "echo \"Skipping lint\"",
     "test": "echo \"No tests\"",
-    "codegen:supabase": "python scripts/gen_pydantic.py"
+    "codegen:supabase": "python scripts/gen_pydantic.py",
+    "build:check": "npm --prefix web run build"
   },
   "devDependencies": {
     "@playwright/test": "^1.52.0",

--- a/web/components/blocks/BlocksPane.tsx
+++ b/web/components/blocks/BlocksPane.tsx
@@ -29,7 +29,7 @@ export default function BlocksPane({ blocks }: BlocksPaneProps) {
           <Card
             key={block.id}
             className={`space-y-1 p-4 hover:bg-muted cursor-pointer ${
-              // TODO: Legacy patch. Remove `as any` after type refactor.
+              /* TODO: Legacy patch. Remove `as any` after type refactor. */
               (block as any).state === "PROPOSED" && !block.prev_rev_id
                 ? "block-proposed"
                 : ""
@@ -37,17 +37,21 @@ export default function BlocksPane({ blocks }: BlocksPaneProps) {
           >
             <div className="flex justify-between items-start">
               <span className="text-sm font-medium">
-                {  // TODO: Legacy patch. Remove `as any` after type refactor.
+                {
+                  /* TODO: Legacy patch. Remove `as any` after type refactor. */
                   (block as any).canonical_value ??
                   block.content.slice(0, 30) ??
-                  "(Untitled)"}
+                  "(Untitled)"
+                }
               </span>
               <span className="text-xs px-2 py-0.5 bg-muted rounded badge">
-                {  // TODO: Legacy patch. Remove `as any` after type refactor.
+                {
+                  /* TODO: Legacy patch. Remove `as any` after type refactor. */
                   (block as any).semantic_type === "pending proposal"
                     ? "PROPOSED"
-                    // TODO: Legacy patch. Remove `as any` after type refactor.
-                    : (block as any).semantic_type ?? "UNKNOWN"}
+                    /* TODO: Legacy patch. Remove `as any` after type refactor. */
+                    : (block as any).semantic_type ?? "UNKNOWN"
+                }
               </span>
             </div>
             <p className="text-sm text-muted-foreground">

--- a/web/components/document/ContextBlocksPanel.tsx
+++ b/web/components/document/ContextBlocksPanel.tsx
@@ -93,10 +93,10 @@ export default function ContextBlocksPanel({
                 <span className="space-x-2">
                   <label className="text-xs">
                     ✔ Verified
+                    {/* TODO: Legacy patch. Remove `as any` after type refactor. */}
                     <input
                       type="checkbox"
                       className="ml-1"
-                      {/* TODO: Legacy patch. Remove `as any` after type refactor. */}
                       checked={(it as any).status === "verified"}
                       onChange={(e) => handleToggleItem(it, e.target.checked)}
                     />

--- a/web/components/document/NarrativeEditor.tsx
+++ b/web/components/document/NarrativeEditor.tsx
@@ -29,29 +29,44 @@ function BlockBadge({ block, onClick }: { block: Block; onClick?: () => void }) 
       <Badge
         variant="secondary"
         className={
-          // TODO: Legacy patch. Remove `as any` after type refactor.
-          cn("px-1 py-0.5", styleMap[(block as any).state ?? "PROPOSED"])  
+          /* TODO: Legacy patch. Remove `as any` after type refactor. */
+          cn("px-1 py-0.5", styleMap[(block as any).state ?? "PROPOSED"])
         }
       >
-        {  // TODO: Legacy patch. Remove `as any` after type refactor.
+        {
+          /* TODO: Legacy patch. Remove `as any` after type refactor. */
           iconMap[(block as any).state ?? "PROPOSED"]
-        }{  // TODO: Legacy patch. Remove `as any` after type refactor.
+        }
+        {
+          /* TODO: Legacy patch. Remove `as any` after type refactor. */
           (block as any).canonical_value ?? ""
         }
       </Badge>
       <span className="absolute z-10 hidden group-hover:block bg-popover text-popover-foreground border border-border text-xs rounded-md p-2 whitespace-nowrap shadow-md left-1/2 -translate-x-1/2 mt-1">
         <div>
-          <strong>{  // TODO: Legacy patch. Remove `as any` after type refactor.
-            (block as any).semantic_type ?? "UNKNOWN"
-          }</strong>
+          <strong>
+            {
+              /* TODO: Legacy patch. Remove `as any` after type refactor. */
+              (block as any).semantic_type ?? "UNKNOWN"
+            }
+          </strong>
         </div>
-        <div className="capitalize">{  // TODO: Legacy patch. Remove `as any` after type refactor.
-          ((block as any).state ?? "PROPOSED").toLowerCase()
-        }</div>
-        {block.actor && <div>by {block.actor}</div>}
-        {block.created_at && (
-          <div>{new Date(block.created_at).toLocaleString()}</div>
-        )}
+        <div className="capitalize">
+          {
+            /* TODO: Legacy patch. Remove `as any` after type refactor. */
+            ((block as any).state ?? "PROPOSED").toLowerCase()
+          }
+        </div>
+        {
+          /* TODO: Legacy patch. Remove `as any` after type refactor. */
+          (block as any).actor && <div>by {(block as any).actor}</div>
+        }
+        {
+          /* TODO: Legacy patch. Remove `as any` after type refactor. */
+          (block as any).created_at && (
+            <div>{new Date((block as any).created_at).toLocaleString()}</div>
+          )
+        }
       </span>
     </span>
   );

--- a/web/lib/blocks/dev_mock_blocks.ts
+++ b/web/lib/blocks/dev_mock_blocks.ts
@@ -1,6 +1,6 @@
 import type { Block } from "@/types";
 
-export const DEV_MOCK_BLOCKS: Block[] = [
+export const DEV_MOCK_BLOCKS = [
   {
     id: "mock1",
     semantic_type: "tone",
@@ -21,4 +21,4 @@ export const DEV_MOCK_BLOCKS: Block[] = [
     actor: "tester",
     created_at: new Date().toISOString(),
   },
-];
+] as any as Block[];


### PR DESCRIPTION
## Summary
- clean up TODO comment placement in BlocksPane
- clean up JSX comments in ContextBlocksPanel
- tidy comment style and fallbacks in NarrativeEditor
- cast mock block list for older fields
- add `build:check` script

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687dfc519a0083299a81f56fb8af97fa