### PR TITLE
refactor(server): replace API fetches with direct supabase queries

### DIFF
--- a/web/app/baskets/[id]/docs/[did]/work/page.tsx
+++ b/web/app/baskets/[id]/docs/[did]/work/page.tsx
@@ -2,11 +2,11 @@ import DocumentWorkbenchLayout from "@/components/document/DocumentWorkbenchLayo
 import ContextBlocksPanel from "@/components/document/ContextBlocksPanel";
 import { createServerSupabaseClient } from "@/lib/supabaseServerClient";
 import { ensureWorkspaceServer } from "@/lib/workspaces/ensureWorkspaceServer";
-import { getBasket } from "@/lib/api/baskets";
-import { getDocuments } from "@/lib/api/documents";
-import { getLatestDump } from "@/lib/api/dumps";
-import { getBlocks } from "@/lib/api/blocks";
-import { getContextItems } from "@/lib/api/contextItems";
+import { getBasketServer } from "@/lib/server/baskets";
+import { getDocumentsServer } from "@/lib/server/documents";
+import { getLatestDumpServer } from "@/lib/server/dumps";
+import { getBlocksServer } from "@/lib/server/blocks";
+import { getContextItemsServer } from "@/lib/server/contextItems";
 import type { Block } from "@/types";
 import { redirect } from "next/navigation";
 
@@ -33,7 +33,7 @@ export default async function DocWorkPage({ params }: PageProps) {
   const workspaceId = workspace?.id;
   console.debug("[DocLoader] Workspace ID:", workspaceId);
 
-  const basket = await getBasket(id);
+  const basket = await getBasketServer(id, workspaceId ?? "");
 
   console.debug("[DocLoader] Fetched basket:", basket);
 
@@ -44,17 +44,17 @@ export default async function DocWorkPage({ params }: PageProps) {
     redirect("/404");
   }
 
-  const documents = await getDocuments(id);
+  const documents = await getDocumentsServer(id);
 
-  const dump = await getLatestDump(id);
+  const dump = await getLatestDumpServer(id);
 
-  const blocks = await getBlocks(id);
+  const blocks = await getBlocksServer(id);
   const blocksWithState: BlockRow[] = (blocks || []).map((b) => ({
     ...b,
     state: "idle",
   }));
 
-  const docGuidelines = await getContextItems(did);
+  const docGuidelines = await getContextItemsServer(did);
 
   const snapshot = {
     basket,

--- a/web/app/baskets/[id]/work/page.tsx
+++ b/web/app/baskets/[id]/work/page.tsx
@@ -1,9 +1,9 @@
 import BasketWorkLayout from "@/components/basket/BasketWorkLayout";
 import { createServerSupabaseClient } from "@/lib/supabaseServerClient";
 import { ensureWorkspaceServer } from "@/lib/workspaces/ensureWorkspaceServer";
-import { getBasket } from "@/lib/api/baskets";
-import { getDocuments } from "@/lib/api/documents";
-import { getBlocks } from "@/lib/api/blocks";
+import { getBasketServer } from "@/lib/server/baskets";
+import { getDocumentsServer } from "@/lib/server/documents";
+import { getBlocksServer } from "@/lib/server/blocks";
 import { redirect } from "next/navigation";
 
 export default async function BasketWorkPage({
@@ -37,7 +37,7 @@ export default async function BasketWorkPage({
   }
 
   let error = null;
-  const basket = await getBasket(id);
+  const basket = await getBasketServer(id, workspaceId);
 
   if (!basket) {
     console.warn("❌ Basket not found — skipping redirect for debug.", {
@@ -55,12 +55,12 @@ export default async function BasketWorkPage({
 
   console.log("✅ Basket loaded:", basket);
 
-  const docs = await getDocuments(id);
+  const docs = await getDocumentsServer(id);
   const firstDoc = docs ? docs[0] : null;
 
   let rawDumpBody = "";
 
-  const blocks = await getBlocks(id);
+  const blocks = await getBlocksServer(id);
   const anyBlock = blocks && blocks.length > 0 ? blocks[0] : null;
 
   const isEmpty = !anyBlock && !firstDoc;

--- a/web/lib/api/baskets.ts
+++ b/web/lib/api/baskets.ts
@@ -1,3 +1,6 @@
+// ❗ CSR-only helper
+// This file is for client-side API calls via fetch('/api/...')
+// Do NOT use inside server components – use lib/server/* instead.
 import type { Basket } from "@/types";
 
 export async function getBasket(id: string): Promise<Basket | null> {

--- a/web/lib/api/blocks.ts
+++ b/web/lib/api/blocks.ts
@@ -1,3 +1,6 @@
+// ❗ CSR-only helper
+// This file is for client-side API calls via fetch('/api/...')
+// Do NOT use inside server components – use lib/server/* instead.
 import type { Block } from "@/types";
 
 export async function getBlocks(basketId: string): Promise<Block[]> {

--- a/web/lib/api/contextItems.ts
+++ b/web/lib/api/contextItems.ts
@@ -1,3 +1,6 @@
+// ❗ CSR-only helper
+// This file is for client-side API calls via fetch('/api/...')
+// Do NOT use inside server components – use lib/server/* instead.
 import type { ContextItem } from "@/types";
 
 export async function getContextItems(docId: string): Promise<ContextItem[]> {

--- a/web/lib/api/documents.ts
+++ b/web/lib/api/documents.ts
@@ -1,3 +1,6 @@
+// ❗ CSR-only helper
+// This file is for client-side API calls via fetch('/api/...')
+// Do NOT use inside server components – use lib/server/* instead.
 import type { Document } from "@/types";
 
 export async function getDocuments(basketId: string): Promise<Document[]> {

--- a/web/lib/api/dumps.ts
+++ b/web/lib/api/dumps.ts
@@ -1,3 +1,6 @@
+// ❗ CSR-only helper
+// This file is for client-side API calls via fetch('/api/...')
+// Do NOT use inside server components – use lib/server/* instead.
 import type { Dump } from "@/types";
 
 export async function getLatestDump(basketId: string): Promise<Dump | null> {

--- a/web/lib/server/baskets.ts
+++ b/web/lib/server/baskets.ts
@@ -1,0 +1,18 @@
+import { createServerSupabaseClient } from "@/lib/supabaseServerClient";
+import type { Basket } from "@/types";
+
+export async function getBasketServer(id: string, workspaceId: string): Promise<Basket | null> {
+  const supabase = createServerSupabaseClient();
+  const { data, error } = await supabase
+    .from("baskets")
+    .select("id,name,state,created_at")
+    .eq("id", id)
+    .eq("workspace_id", workspaceId)
+    .single();
+  if (error) {
+    console.error("[getBasketServer]", error.message);
+    return null;
+  }
+  if (!data) return null;
+  return { ...data, status: (data as any).state } as Basket;
+}

--- a/web/lib/server/blocks.ts
+++ b/web/lib/server/blocks.ts
@@ -1,0 +1,21 @@
+import { createServerSupabaseClient } from "@/lib/supabaseServerClient";
+import type { Block } from "@/types";
+
+export async function getBlocksServer(basketId: string): Promise<Block[]> {
+  const supabase = createServerSupabaseClient();
+  const { data, error } = await supabase
+    .from("blocks")
+    .select("id,document_id,semantic_type: type,content")
+    .eq("basket_id", basketId)
+    .order("created_at");
+  if (error) {
+    console.error("[getBlocksServer]", error.message);
+    return [];
+  }
+  return (data ?? []).map((b: any) => ({
+    id: b.id,
+    document_id: b.document_id || undefined,
+    type: b.semantic_type,
+    content: b.content || "",
+  })) as Block[];
+}

--- a/web/lib/server/contextItems.ts
+++ b/web/lib/server/contextItems.ts
@@ -1,0 +1,16 @@
+import { createServerSupabaseClient } from "@/lib/supabaseServerClient";
+import type { ContextItem } from "@/types";
+
+export async function getContextItemsServer(docId?: string): Promise<ContextItem[]> {
+  const supabase = createServerSupabaseClient();
+  let query = supabase.from("context_items").select("id,document_id,title,summary");
+  if (docId) {
+    query = query.eq("document_id", docId);
+  }
+  const { data, error } = await query.order("created_at");
+  if (error) {
+    console.error("[getContextItemsServer]", error.message);
+    return [];
+  }
+  return data ?? [];
+}

--- a/web/lib/server/documents.ts
+++ b/web/lib/server/documents.ts
@@ -1,0 +1,16 @@
+import { createServerSupabaseClient } from "@/lib/supabaseServerClient";
+import type { Document } from "@/types";
+
+export async function getDocumentsServer(basketId: string): Promise<Document[]> {
+  const supabase = createServerSupabaseClient();
+  const { data, error } = await supabase
+    .from("documents")
+    .select("id,title,basket_id")
+    .eq("basket_id", basketId)
+    .order("created_at");
+  if (error) {
+    console.error("[getDocumentsServer]", error.message);
+    return [];
+  }
+  return data ?? [];
+}

--- a/web/lib/server/dumps.ts
+++ b/web/lib/server/dumps.ts
@@ -1,0 +1,18 @@
+import { createServerSupabaseClient } from "@/lib/supabaseServerClient";
+import type { Dump } from "@/types";
+
+export async function getLatestDumpServer(basketId: string): Promise<Dump | null> {
+  const supabase = createServerSupabaseClient();
+  const { data, error } = await supabase
+    .from("dumps")
+    .select("id,basket_id,body_md,created_at")
+    .eq("basket_id", basketId)
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .single();
+  if (error) {
+    console.error("[getLatestDumpServer]", error.message);
+    return null;
+  }
+  return data ?? null;
+}


### PR DESCRIPTION
## Summary
- add `lib/server` helpers that use `createServerSupabaseClient`
- swap `/api/` fetchers in basket work pages for the new server helpers
- mark existing `lib/api` helpers as CSR-only

## Testing
- `npm test`
- `npm run build:check`


------
https://chatgpt.com/codex/tasks/task_e_687e2ee1cca88329933a212772d3c076