### PR TITLE
Refactor basket creation flow

### DIFF
--- a/api/src/app/baskets/schemas.py
+++ b/api/src/app/baskets/schemas.py
@@ -2,6 +2,14 @@ from pydantic import BaseModel, Field
 from typing import List, Optional
 
 class BasketCreateRequest(BaseModel):
-    text_dump: str = Field(default="")  # Allow empty canvas
+    """Payload for `/api/baskets/new`."""
+
+    # Optional metadata for the basket itself
+    name: Optional[str] = "Untitled Basket"
+    status: Optional[str] = "active"
+    tags: Optional[List[str]] = Field(default_factory=list)
+
+    # Legacy creation fields for bootstrapping from text/file uploads
+    text_dump: Optional[str] = None
     file_urls: List[str] = Field(default_factory=list)
     template_slug: Optional[str] = None  # ✅ Now valid

--- a/api/src/app/routes/basket_new.py
+++ b/api/src/app/routes/basket_new.py
@@ -45,44 +45,80 @@ async def create_basket(
         )
         return JSONResponse({"id": basket_id}, status_code=201)
 
+    basket_id: str | None = None
 
+    if payload.text_dump:
+        # Legacy flow: create basket + raw dump via stored procedure
+        try:
+            rpc_resp = (
+                supabase.rpc(
+                    "create_basket_with_dump",
+                    {
+                        "user_id": user["user_id"],
+                        "workspace_id": workspace_id,
+                        "dump_body": payload.text_dump,
+                        "file_urls": payload.file_urls,
+                    },
+                ).execute()
+            )
+            if getattr(rpc_resp, "status_code", 200) >= 400 or getattr(rpc_resp, "error", None):
+                detail = getattr(rpc_resp, "error", rpc_resp)
+                raise HTTPException(status_code=500, detail=str(detail))
+            basket_id = rpc_resp.data[0]["basket_id"]
+            log.info("created basket %s via RPC", basket_id)
+        except Exception as err:  # pragma: no cover - network
+            log.exception("create_basket rpc failed")
+            raise HTTPException(status_code=500, detail="internal error") from err
 
-    # Atomic creation via stored procedure
-    try:
-        rpc_resp = (
-            supabase.rpc(
-                "create_basket_with_dump",
+        # Update metadata after RPC creation
+        try:
+            supabase.table("baskets").update(
                 {
-                    "user_id": user["user_id"],
-                    "workspace_id": workspace_id,
-                    "dump_body": payload.text_dump,
+                    "name": payload.name,
+                    "status": payload.status,
+                    "tags": payload.tags,
+                }
+            ).eq("id", basket_id).execute()
+        except Exception:  # pragma: no cover - network
+            log.exception("post-RPC basket update failed")
+
+        # Emit compose request event
+        try:
+            await emit(
+                "basket.compose_request",
+                {
+                    "basket_id": basket_id,
+                    "details": payload.text_dump,
                     "file_urls": payload.file_urls,
                 },
-            ).execute()
-        )
-        if getattr(rpc_resp, "status_code", 200) >= 400 or getattr(rpc_resp, "error", None):
-            detail = getattr(rpc_resp, "error", rpc_resp)
-            raise HTTPException(status_code=500, detail=str(detail))
-        basket_id = rpc_resp.data[0]["basket_id"]
-        log.info("created basket %s", basket_id)
-    except Exception as err:
-        log.exception("create_basket rpc failed")
-        raise HTTPException(status_code=500, detail="internal error") from err
-
-    # Publish event
-    try:
-        await emit(
-            "basket.compose_request",
-            {
-                "basket_id": basket_id,
-                "details": payload.text_dump,
-                "file_urls": payload.file_urls,
-            },
-        )
-    except Exception as e:  # noqa: BLE001
-        log.error(
-            "[EVENT BUS] Failed to emit 'basket.compose_request': %s", e,
-        )
-        # TODO: Queue failed events for retry when network is restored
+            )
+        except Exception as e:  # noqa: BLE001
+            log.error(
+                "[EVENT BUS] Failed to emit 'basket.compose_request': %s", e,
+            )
+    else:
+        # Simplest flow: just insert a basket row
+        try:
+            resp = (
+                supabase.table("baskets")
+                .insert(
+                    {
+                        "workspace_id": workspace_id,
+                        "user_id": user["user_id"],
+                        "name": payload.name,
+                        "status": payload.status,
+                        "tags": payload.tags,
+                    }
+                )
+                .execute()
+            )
+            if getattr(resp, "status_code", 200) >= 400 or getattr(resp, "error", None):
+                detail = getattr(resp, "error", resp)
+                raise HTTPException(status_code=500, detail=str(detail))
+            basket_id = resp.data[0]["id"]
+            log.info("created empty basket %s", basket_id)
+        except Exception as err:  # pragma: no cover - network
+            log.exception("simple basket insert failed")
+            raise HTTPException(status_code=500, detail="internal error") from err
 
     return JSONResponse({"id": basket_id}, status_code=201)

--- a/web/app/baskets/[id]/docs/[did]/work/page.tsx
+++ b/web/app/baskets/[id]/docs/[did]/work/page.tsx
@@ -44,7 +44,7 @@ export default async function DocWorkPage({ params }: PageProps) {
     redirect("/404");
   }
 
-  const documents = await getDocumentsServer(id);
+  const documents = await getDocumentsServer(workspaceId ?? "");
 
   const dump = await getLatestDumpServer(id);
 

--- a/web/app/baskets/[id]/work/page.tsx
+++ b/web/app/baskets/[id]/work/page.tsx
@@ -40,22 +40,13 @@ export default async function BasketWorkPage({
   const basket = await getBasketServer(id, workspaceId);
 
   if (!basket) {
-    console.warn("❌ Basket not found — skipping redirect for debug.", {
-      basketId: id,
-      workspaceId,
-    });
-    return (
-      <div className="p-8 text-red-500">
-        <h1 className="text-xl font-bold">🧪 DEBUG MODE</h1>
-        <p>Basket not found: <code>{id}</code></p>
-        <p>Workspace: <code>{workspaceId}</code></p>
-      </div>
-    );
+    console.warn("❌ Basket not found", { basketId: id, workspaceId });
+    redirect("/404");
   }
 
   console.log("✅ Basket loaded:", basket);
 
-  const docs = await getDocumentsServer(id);
+  const docs = await getDocumentsServer(workspaceId);
   const firstDoc = docs ? docs[0] : null;
 
   let rawDumpBody = "";

--- a/web/app/baskets/new/page.tsx
+++ b/web/app/baskets/new/page.tsx
@@ -12,10 +12,7 @@ function InstantBasketRedirector() {
     const router = useRouter();
     useEffect(() => {
         const go = async () => {
-            const { id } = await createBasketNew({
-                text_dump: null,
-                file_urls: [],
-            });
+            const { id } = await createBasketNew({});
             router.replace(`/baskets/${id}/work`);
         };
         go();

--- a/web/app/components/shell/Sidebar.tsx
+++ b/web/app/components/shell/Sidebar.tsx
@@ -66,7 +66,7 @@ export default function Sidebar({ className }: SidebarProps) {
   };
 
   const handleNewBasket = async () => {
-    const { id } = await createBasketNew({ text_dump: null });
+    const { id } = await createBasketNew({});
     router.push(`/baskets/${id}/work`);
   };
 

--- a/web/hooks/useCreateBasket.ts
+++ b/web/hooks/useCreateBasket.ts
@@ -56,37 +56,22 @@ export function useCreateBasket() {
   const setGuidelines = (v: string) =>
     setState((s) => ({ ...s, guidelines: v }));
 
-  const canSubmit =
-    !submitting &&
-    state.basketName.trim().length > 0 &&
-    state.coreBlock.length >= 100 &&
-    state.coreBlock.length <= 500 &&
-    state.dumps.length > 0 &&
-    state.dumps.every((d) => d.trim().length > 0);
+  const canSubmit = !submitting && state.basketName.trim().length > 0;
 
   const submit = async () => {
     if (!canSubmit) return;
     setSubmitting(true);
     try {
       const payload = {
-        template_id: "universal",
-        basket_name: state.basketName,
-        core_block: {
-          text: state.coreBlock,
-          scope: "basket",
-          status: "locked",
-        },
-        raw_dumps: state.dumps.map((d) => ({ body_md: d })),
-        guidelines: state.guidelines.trim() || null,
+        name: state.basketName || "Untitled Basket",
+        status: "active",
+        tags: [],
       };
-      const res = await fetchWithToken(
-        apiUrl("/baskets/new"),
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(payload),
-        },
-      );
+      const res = await fetchWithToken(apiUrl("/baskets/new"), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
       if (!res.ok) throw new Error("create failed");
       const { basket_id } = await res.json();
       router.push(`/baskets/${basket_id}/work`);

--- a/web/lib/baskets/createBasketNew.ts
+++ b/web/lib/baskets/createBasketNew.ts
@@ -5,16 +5,14 @@ import { apiUrl } from "@/lib/api";
 
 /** Body accepted by /api/baskets/new (v1 mode) */
 export interface NewBasketArgs {
-  /** Free-form markdown or plaintext that seeds the basket */
-  text_dump: string | null;
-  /** Optional previously-uploaded file URLs (≤ 5) */
-  file_urls?: string[];
+  name?: string;
+  status?: string;
+  tags?: string[];
 }
 
 export async function createBasketNew(
-  args: NewBasketArgs,
+  args: NewBasketArgs = {},
 ): Promise<{ id: string }> {
-  console.debug("[createBasketNew] text_dump:", args.text_dump);
 
   // 🔐 Get Supabase JWT
   const supabase = createClient();
@@ -29,15 +27,11 @@ export async function createBasketNew(
   const uid = user?.id;
   if (uid) headers["X-User-Id"] = uid;
 
-  // ✅ Omit empty fields to avoid API validation errors
-  const payload: Record<string, any> = {};
-  const text = args.text_dump ?? "";
-  if (text.trim().length > 0) {
-    payload.text_dump = text;
-  }
-  if (args.file_urls && args.file_urls.length > 0) {
-    payload.file_urls = args.file_urls;
-  }
+  const payload: Record<string, any> = {
+    name: args.name ?? "Untitled Basket",
+    status: args.status ?? "active",
+    tags: args.tags ?? [],
+  };
   const body = JSON.stringify(payload);
 
   console.log("[createBasketNew] Payload:", JSON.parse(body));


### PR DESCRIPTION
## Summary
- support name, status & tags in `BasketCreateRequest`
- insert empty baskets when no dump is provided
- update basket metadata after RPC call
- simplify `createBasketNew` payload
- streamline `useCreateBasket` logic
- redirect on missing basket and fix doc fetch

## Testing
- `npm test`
- `pytest` *(fails: ModuleNotFoundError: No module named 'jwt')*

------
https://chatgpt.com/codex/tasks/task_e_687ef81cb9b08329ab23163fe04ce0f4