### PR TITLE
Fix document fetch on basket work page

### DIFF
--- a/web/app/baskets/[id]/work/page.tsx
+++ b/web/app/baskets/[id]/work/page.tsx
@@ -64,6 +64,7 @@ export default async function BasketWorkPage({
       scope={[]} // ✅ Temporarily empty until tags are wired properly
       dumpBody={rawDumpBody}
       empty={isEmpty}
+      documents={docs}
     />
   );
 }

--- a/web/components/basket/BasketWorkLayout.tsx
+++ b/web/components/basket/BasketWorkLayout.tsx
@@ -4,6 +4,7 @@ import BasketSidebar from "@/components/basket/BasketSidebar";
 import BasketDashboard from "@/components/views/BasketDashboard";
 import { useSearchParams } from "next/navigation";
 import { ReactNode } from "react";
+import type { Document } from "@/types";
 
 interface Props {
   basketId: string;
@@ -12,6 +13,7 @@ interface Props {
   scope: string[];
   dumpBody?: string;
   empty?: boolean;
+  documents?: Document[];
 }
 
 export default function BasketWorkLayout({
@@ -21,6 +23,7 @@ export default function BasketWorkLayout({
   scope,
   dumpBody,
   empty = false,
+  documents,
 }: Props) {
   const searchParams = useSearchParams();
   const tab = searchParams.get("tab") || "dashboard";
@@ -34,6 +37,7 @@ export default function BasketWorkLayout({
           basketName={basketName}
           dumpBody={dumpBody}
           empty={empty}
+          documents={documents}
         />
       );
       break;
@@ -52,7 +56,7 @@ export default function BasketWorkLayout({
       <div className="md:flex w-full min-h-screen flex-1 overflow-y-auto">
         <aside className="hidden md:block w-[220px] shrink-0 border-r overflow-y-auto">
           <div className="flex flex-col h-full">
-            <DocumentList basketId={basketId} />
+            <DocumentList basketId={basketId} documents={documents} />
             <div className="p-4 border-t">
               <button className="w-full text-sm" disabled>
                 + Create Document

--- a/web/components/basket/DocumentList.tsx
+++ b/web/components/basket/DocumentList.tsx
@@ -16,7 +16,9 @@ export default function DocumentList({
   documentId,
   onSelect,
 }: Props) {
-  const { docs, isLoading, error } = useDocuments(basketId);
+  const { docs, isLoading, error } = documents
+    ? { docs: documents, isLoading: false, error: null }
+    : useDocuments(basketId);
   const router = useRouter();
 
   const items = documents ?? docs;
@@ -39,7 +41,7 @@ export default function DocumentList({
 
   if (items.length === 0) {
     return (
-      <div className="p-6 text-sm text-muted-foreground">No documents yet</div>
+      <div className="p-6 text-sm text-muted-foreground">No documents yet.</div>
     );
   }
 

--- a/web/components/views/BasketDashboard.tsx
+++ b/web/components/views/BasketDashboard.tsx
@@ -7,6 +7,7 @@ import BlockCreateModal from "@/components/blocks/BlockCreateModal";
 import { openDumpModal } from "@/components/DumpModal";
 import { createBlock } from "@/lib/supabase/blocks";
 import { useState } from "react";
+import type { Document } from "@/types";
 import { useRouter } from "next/navigation";
 
 interface Props {
@@ -14,6 +15,7 @@ interface Props {
   dumpBody?: string;
   empty?: boolean;
   basketName?: string;
+  documents?: Document[];
 }
 
 function EmptyPrompt({ basketId }: { basketId: string }) {
@@ -61,6 +63,7 @@ export default function BasketDashboard({
   dumpBody,
   empty = false,
   basketName,
+  documents,
 }: Props) {
   return (
     <div className="p-4 space-y-6">
@@ -72,7 +75,7 @@ export default function BasketDashboard({
       <section className="md:hidden">
         <h2 className="font-medium mb-2">Documents</h2>
         <Card className="p-4">
-          <DocumentList basketId={basketId} />
+          <DocumentList basketId={basketId} documents={documents} />
           <div className="pt-4">
             <Button size="sm" disabled className="w-full">
               + Create Document

--- a/web/lib/baskets/useDocuments.ts
+++ b/web/lib/baskets/useDocuments.ts
@@ -10,11 +10,15 @@ const fetcher = async (basketId: string) => {
   const supabase = createClient();
   const { data, error } = await supabase
     .from("documents")
-    .select("id, title, created_at, basket_id")
+    .select("id, title, created_at, updated_at, basket_id")
     .eq("basket_id", basketId)
     .order("created_at", { ascending: true });
   if (error) throw error;
-  return (data ?? []) as DocumentRow[];
+  if (!data) return [];
+  return data.map((doc) => ({
+    updated_at: doc.updated_at ?? doc.created_at,
+    ...doc,
+  })) as DocumentRow[];
 };
 
 export function useDocuments(basketId: string) {

--- a/web/lib/baskets/useDocuments.ts
+++ b/web/lib/baskets/useDocuments.ts
@@ -16,8 +16,8 @@ const fetcher = async (basketId: string) => {
   if (error) throw error;
   if (!data) return [];
   return data.map((doc) => ({
-    updated_at: doc.updated_at ?? doc.created_at,
     ...doc,
+    updated_at: doc.updated_at ?? doc.created_at,
   })) as DocumentRow[];
 };
 

--- a/web/lib/baskets/useDocuments.ts
+++ b/web/lib/baskets/useDocuments.ts
@@ -1,16 +1,25 @@
 import useSWR from "swr";
-import { apiGet } from "../api";
 import type { Document } from "@/types";
+import { createClient } from "@/lib/supabaseClient";
 
 export interface DocumentRow extends Document {
   updated_at: string;
 }
 
-const fetcher = (url: string) => apiGet<DocumentRow[]>(url);
+const fetcher = async (basketId: string) => {
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from("documents")
+    .select("id, title, created_at, basket_id")
+    .eq("basket_id", basketId)
+    .order("created_at", { ascending: true });
+  if (error) throw error;
+  return (data ?? []) as DocumentRow[];
+};
 
 export function useDocuments(basketId: string) {
   const { data, error, isLoading } = useSWR(
-    () => (basketId ? `/api/baskets/${basketId}/docs` : null),
+    () => (basketId ? basketId : null),
     fetcher,
     { refreshInterval: 10_000 },
   );


### PR DESCRIPTION
## Summary
- query documents with Supabase in `useDocuments`
- allow passing preloaded documents to `DocumentList` and `BasketDashboard`
- load documents server-side in basket work page and pass to layout

## Testing
- `npm run test`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_687f09d4e15883298f457f9a276a9eea