### PR TITLE
refactor: replace workspace onboarding with basket

### DIFF
--- a/web/app/api/intelligence/process-content/route.ts
+++ b/web/app/api/intelligence/process-content/route.ts
@@ -48,7 +48,7 @@ interface SuggestedDocument {
   relevance: number;
 }
 
-interface WorkspaceStructure {
+interface BasketStructure {
   suggested_name: string;
   description: string;
   organization_strategy: string;
@@ -94,8 +94,8 @@ export async function POST(request: NextRequest) {
     // Process content through universal intelligence engine
     const intelligence = await processUniversalContent(inputs, workspace_context);
     
-    // Generate workspace structure suggestions
-    const suggested_structure = await suggestWorkspaceStructure(intelligence, processing_intent);
+    // Generate basket structure suggestions
+    const suggested_structure = await suggestBasketStructure(intelligence, processing_intent);
     
     // Generate processing summary
     const processing_summary = generateProcessingSummary(inputs, intelligence);
@@ -336,7 +336,7 @@ function identifyPatterns(
   if (semantics.themes.length > 3) {
     patterns.push({
       pattern_type: 'theme_rich',
-      description: `Multiple themes indicate cross-functional project scope`,
+      description: `Multiple themes indicate cross-functional basket scope`,
       confidence: 0.7
     });
   }
@@ -368,12 +368,12 @@ function calculateConfidenceScore(
   return Math.min(score, 0.95); // Cap at 95%
 }
 
-async function suggestWorkspaceStructure(
+async function suggestBasketStructure(
   intelligence: IntelligenceResult,
   processing_intent: string
 ): Promise<{
   documents: SuggestedDocument[];
-  organization: WorkspaceStructure;
+  organization: BasketStructure;
 }> {
   const primaryThemes = intelligence.themes.slice(0, 3);
   
@@ -412,12 +412,12 @@ async function suggestWorkspaceStructure(
     });
   }
   
-  // Generate workspace organization
-  const organization: WorkspaceStructure = {
-    suggested_name: generateWorkspaceName(intelligence.themes),
-    description: `Intelligent workspace focused on ${primaryThemes.join(', ').replace(/-/g, ' ')}`,
-    organization_strategy: intelligence.confidence_score > 0.7 
-      ? 'theme-based' 
+  // Generate basket organization
+  const organization: BasketStructure = {
+    suggested_name: generateBasketName(intelligence.themes),
+    description: `Basket focused on ${primaryThemes.join(', ').replace(/-/g, ' ')}`,
+    organization_strategy: intelligence.confidence_score > 0.7
+      ? 'theme-based'
       : 'exploratory'
   };
   
@@ -427,14 +427,14 @@ async function suggestWorkspaceStructure(
   };
 }
 
-function generateWorkspaceName(themes: string[]): string {
-  if (themes.length === 0) return 'New Project Workspace';
-  
+function generateBasketName(themes: string[]): string {
+  if (themes.length === 0) return 'New Basket';
+
   const primaryTheme = themes[0].split('-')
     .map(word => word.charAt(0).toUpperCase() + word.slice(1))
     .join(' ');
-  
-  return `${primaryTheme} Project`;
+
+  return `${primaryTheme} Basket`;
 }
 
 function generateProcessingSummary(

--- a/web/app/baskets/[id]/work/layout.tsx
+++ b/web/app/baskets/[id]/work/layout.tsx
@@ -76,6 +76,6 @@ export async function generateMetadata({ params }: { params: Promise<{ id: strin
   
   return {
     title: `${basketData?.name || 'Basket'} - Yarnnn`,
-    description: 'Strategic intelligence workspace'
+    description: 'Strategic intelligence project'
   };
 }

--- a/web/app/baskets/page.tsx
+++ b/web/app/baskets/page.tsx
@@ -68,7 +68,7 @@ export default function BasketsPage() {
         description="Lightweight containers for your tasks, context, and thoughts"
         actions={
           <div className="flex flex-wrap gap-2">
-            <Button onClick={() => router.push('/onboarding')}>✨ Create Workspace</Button>
+            <Button onClick={() => router.push('/onboarding')}>✨ Create Project</Button>
             <Select value={sort} onValueChange={(v) => setSort(v)}>
               <SelectTrigger className="w-[150px]">
                 <SelectValue placeholder="Sort by" />

--- a/web/app/onboarding/OnboardingContent.tsx
+++ b/web/app/onboarding/OnboardingContent.tsx
@@ -2,7 +2,7 @@
 
 import { useSearchParams } from "next/navigation";
 import { AppRouterInstance } from "next/dist/shared/lib/app-router-context.shared-runtime";
-import UniversalProjectCreator from "@/components/onboarding/UniversalWorkspaceCreator";
+import InitialBasketSetup from "@/components/onboarding/InitialBasketSetup";
 
 interface OnboardingContentProps {
   router: AppRouterInstance;
@@ -23,21 +23,21 @@ export default function OnboardingContent({ router }: OnboardingContentProps) {
           <span>Universal Intelligence Engine</span>
         </div>
         <h1 className="text-4xl font-bold mb-4">
-          {basketId ? 'Enhance Your Project' : 'Create Your Intelligent Project'}
+          {basketId ? 'Enhance Your Basket' : 'Create Your Basket'}
         </h1>
         <p className="text-xl text-muted-foreground max-w-2xl mx-auto leading-relaxed">
-          {basketId 
-            ? 'Add more content to build stronger intelligence for your existing project'
-            : 'Add any content—files, text, ideas—and watch our AI build a complete project with documents, insights, and intelligent organization.'
+          {basketId
+            ? 'Add more content to build stronger intelligence for your existing basket'
+            : 'Add any content—files, text, ideas—and watch our AI build a complete basket with documents, insights, and intelligent organization.'
           }
         </p>
       </div>
 
-      {/* Universal Project Creator */}
-      <UniversalProjectCreator 
+      {/* Initial Basket Setup */}
+      <InitialBasketSetup
         existingBasketId={basketId}
         mode={mode}
-        onProjectCreated={(finalBasketId) => {
+        onBasketCreated={(finalBasketId) => {
           // Analytics or tracking could go here
           router.push(`/baskets/${finalBasketId}/work`);
         }}

--- a/web/app/onboarding/layout.tsx
+++ b/web/app/onboarding/layout.tsx
@@ -16,7 +16,7 @@ export default function OnboardingLayout({ children }: Props) {
                 🧠 RightNow
               </div>
               <div className="text-sm text-muted-foreground">
-                Workspace Creation
+                Project Creation
               </div>
             </div>
             <div className="text-sm text-muted-foreground">

--- a/web/app/onboarding/page.tsx
+++ b/web/app/onboarding/page.tsx
@@ -4,7 +4,6 @@ import { useAuth } from "@/lib/useAuth";
 import { redirect } from "next/navigation";
 import { useRouter } from "next/navigation";
 import { Suspense } from "react";
-import UniversalWorkspaceCreator from "@/components/onboarding/UniversalWorkspaceCreator";
 import OnboardingContent from "./OnboardingContent";
 
 export default function OnboardingPage() {
@@ -71,7 +70,7 @@ export default function OnboardingPage() {
                 <div className="text-3xl mb-3">🔗</div>
                 <h4 className="font-medium mb-2">Contextual Connections</h4>
                 <p className="text-sm text-muted-foreground">
-                  Links related ideas and suggests next steps for your project
+                  Links related ideas and suggests next steps for your basket
                 </p>
               </div>
             </div>

--- a/web/components/onboarding/BasketCreationTrigger.tsx
+++ b/web/components/onboarding/BasketCreationTrigger.tsx
@@ -5,29 +5,29 @@ import { Button } from '@/components/ui/Button';
 import { Card, CardContent } from '@/components/ui/Card';
 import { Badge } from '@/components/ui/Badge';
 import { cn } from '@/lib/utils';
-import { ProcessingResponse, WorkspaceCreationResult } from '@/lib/intelligence/useUniversalIntelligence';
+import { ProcessingResponse, BasketInitializationResult } from '@/lib/intelligence/useUniversalIntelligence';
 
-interface ProjectCreationTriggerProps {
+interface BasketCreationTriggerProps {
   processingResult: ProcessingResponse | null;
-  onCreateProject: (modifications?: {
-    project_name?: string;
+  onCreateBasket: (modifications?: {
+    basket_name?: string;
     selected_documents?: string[];
     additional_context?: string;
-  }) => Promise<WorkspaceCreationResult | null>;
+  }) => Promise<BasketInitializationResult | null>;
   isCreating: boolean;
-  creationResult: WorkspaceCreationResult | null;
+  creationResult: BasketInitializationResult | null;
   disabled?: boolean;
   className?: string;
 }
 
-export default function ProjectCreationTrigger({
+export default function BasketCreationTrigger({
   processingResult,
-  onCreateProject,
+  onCreateBasket,
   isCreating,
   creationResult,
   disabled = false,
   className
-}: ProjectCreationTriggerProps) {
+}: BasketCreationTriggerProps) {
   const [showCustomization, setShowCustomization] = useState(false);
   const [customName, setCustomName] = useState('');
   const [selectedDocs, setSelectedDocs] = useState<string[]>([]);
@@ -41,14 +41,14 @@ export default function ProjectCreationTrigger({
     }
   });
 
-  const handleCreateProject = async () => {
+  const handleCreateBasket = async () => {
     const modifications = showCustomization ? {
-      project_name: customName || undefined,
+      basket_name: customName || undefined,
       selected_documents: selectedDocs.length > 0 ? selectedDocs : undefined,
       additional_context: additionalContext || undefined
     } : undefined;
 
-    await onCreateProject(modifications);
+    await onCreateBasket(modifications);
   };
 
   const toggleDocSelection = (docTitle: string) => {
@@ -66,10 +66,10 @@ export default function ProjectCreationTrigger({
         <CardContent className="text-center py-8">
           <div className="text-5xl mb-4">🎉</div>
           <h3 className="text-xl font-bold mb-2 text-green-800">
-            Project Created Successfully!
+            Basket Created Successfully!
           </h3>
           <p className="text-sm text-green-700 mb-4">
-            Your intelligent project "{creationResult.basket.name}" is ready with AI-powered insights
+            Your basket "{creationResult.basket.name}" is ready with AI-powered insights
           </p>
           
           <div className="flex flex-wrap justify-center gap-2 mb-6">
@@ -99,7 +99,7 @@ export default function ProjectCreationTrigger({
 
           <div className="flex items-center justify-center gap-2 text-sm text-green-600">
             <div className="animate-spin rounded-full h-4 w-4 border-2 border-green-600 border-t-transparent"></div>
-            <span>Taking you to your project...</span>
+            <span>Taking you to your basket...</span>
           </div>
         </CardContent>
       </Card>
@@ -112,9 +112,9 @@ export default function ProjectCreationTrigger({
       <Card className={cn("border-primary bg-primary/5", className)}>
         <CardContent className="text-center py-8">
           <div className="animate-spin rounded-full h-12 w-12 border-3 border-primary border-t-transparent mx-auto mb-4"></div>
-          <h3 className="text-lg font-semibold mb-2">Creating Your Intelligent Project</h3>
+          <h3 className="text-lg font-semibold mb-2">Creating Your Basket</h3>
           <p className="text-sm text-muted-foreground max-w-md mx-auto mb-4">
-            Setting up your project with documents, AI analysis, and intelligent insights. 
+            Setting up your basket with documents, AI analysis, and intelligent insights.
             This will just take a moment...
           </p>
           <div className="flex flex-wrap justify-center gap-2">
@@ -134,7 +134,7 @@ export default function ProjectCreationTrigger({
         <CardContent className="text-center py-6">
           <span className="text-2xl mb-2 block opacity-40">✨</span>
           <p className="text-sm text-muted-foreground">
-            Add content above to create your project
+            Add content above to create your basket
           </p>
         </CardContent>
       </Card>
@@ -153,24 +153,24 @@ export default function ProjectCreationTrigger({
         {/* Main Creation Button */}
         <div className="text-center">
           <Button
-            onClick={handleCreateProject}
+            onClick={handleCreateBasket}
             disabled={disabled || !isReady}
             size="lg"
             className="w-full mb-3"
           >
             <span className="mr-2">✨</span>
-            Create My Project
+            Create My Basket
           </Button>
           
           {!isReady && (
             <p className="text-xs text-muted-foreground">
-              Add more content to improve project creation
+              Add more content to improve basket creation
             </p>
           )}
           
           {isReady && (
             <p className="text-xs text-muted-foreground">
-              Ready to create project with {processingResult.suggested_structure.documents.length} documents
+              Ready to create basket with {processingResult.suggested_structure.documents.length} documents
             </p>
           )}
         </div>
@@ -193,10 +193,10 @@ export default function ProjectCreationTrigger({
         {/* Customization Panel */}
         {showCustomization && (
           <div className="border-t pt-4 space-y-4">
-            {/* Workspace Name */}
+            {/* Basket Name */}
             <div>
               <label className="text-xs font-medium text-muted-foreground mb-1 block">
-                Project Name
+                Basket Name
               </label>
               <input
                 type="text"
@@ -243,7 +243,7 @@ export default function ProjectCreationTrigger({
               <textarea
                 value={additionalContext}
                 onChange={(e) => setAdditionalContext(e.target.value)}
-                placeholder="Any additional information to help customize your project..."
+                placeholder="Any additional information to help customize your basket..."
                 className="w-full p-2 border border-input rounded-lg text-sm bg-background resize-none h-20 focus:outline-none focus:ring-2 focus:ring-ring"
               />
             </div>

--- a/web/components/onboarding/InitialBasketSetup.tsx
+++ b/web/components/onboarding/InitialBasketSetup.tsx
@@ -4,32 +4,32 @@ import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import UniversalContentInput from './UniversalContentInput';
 import LiveIntelligencePreview from './LiveIntelligencePreview';
-import ProjectCreationTrigger from './WorkspaceCreationTrigger';
+import BasketCreationTrigger from './BasketCreationTrigger';
 import { useEnhancedUniversalIntelligence, EnhancedContentInput } from '@/lib/intelligence/useEnhancedUniversalIntelligence';
-import { WorkspaceCreationResult } from '@/lib/intelligence/useUniversalIntelligence';
+import { BasketInitializationResult } from '@/lib/intelligence/useUniversalIntelligence';
 import { cn } from '@/lib/utils';
 
-interface UniversalProjectCreatorProps {
-  onProjectCreated?: (basketId: string) => void;
+interface InitialBasketSetupProps {
+  onBasketCreated?: (basketId: string) => void;
   className?: string;
   existingBasketId?: string | null;
   mode?: string | null;
 }
 
-export default function UniversalProjectCreator({
-  onProjectCreated,
+export default function InitialBasketSetup({
+  onBasketCreated,
   className,
   existingBasketId,
   mode
-}: UniversalProjectCreatorProps) {
+}: InitialBasketSetupProps) {
   const router = useRouter();
   const [inputs, setInputs] = useState<EnhancedContentInput[]>([]);
-  const [isCreatingProject, setIsCreatingProject] = useState(false);
-  const [creationResult, setCreationResult] = useState<WorkspaceCreationResult | null>(null);
-  
+  const [isCreatingBasket, setIsCreatingBasket] = useState(false);
+  const [creationResult, setCreationResult] = useState<BasketInitializationResult | null>(null);
+
   const {
     processContent,
-    createWorkspace,
+    createInitialBasket,
     isProcessing,
     processingResult,
     error,
@@ -50,45 +50,45 @@ export default function UniversalProjectCreator({
     return () => clearTimeout(timeoutId);
   }, [inputs, processContent]);
 
-  const handleCreateProject = async (modifications?: any) => {
+  const handleCreateBasket = async (modifications?: any) => {
     if (!processingResult) return null;
 
-    setIsCreatingProject(true);
-    
+    setIsCreatingBasket(true);
+
     try {
-      const result = await createWorkspace(
+      const result = await createInitialBasket(
         processingResult.intelligence,
         processingResult.suggested_structure,
         modifications
       );
-      
+
       if (result) {
         setCreationResult(result);
-        
+
         // Redirect after showing success
         setTimeout(() => {
           const basketId = result.basket.id;
-          if (onProjectCreated) {
-            onProjectCreated(basketId);
+          if (onBasketCreated) {
+            onBasketCreated(basketId);
           } else {
             router.push(`/baskets/${basketId}/work`);
           }
         }, 3000);
       }
-      
+
       return result;
     } catch (err) {
-      console.error('Project creation failed:', err);
+      console.error('Basket creation failed:', err);
       return null;
     } finally {
-      setIsCreatingProject(false);
+      setIsCreatingBasket(false);
     }
   };
 
   const handleReset = () => {
     setInputs([]);
     setCreationResult(null);
-    setIsCreatingProject(false);
+    setIsCreatingBasket(false);
     reset();
   };
 
@@ -117,15 +117,15 @@ export default function UniversalProjectCreator({
           <div className="text-center mb-6">
             <h2 className="text-2xl font-bold mb-2">Add Your Content</h2>
             <p className="text-muted-foreground">
-              Share your ideas, documents, or requirements. Our AI will analyze them 
-              and create an intelligent project tailored to your needs.
+              Share your ideas, documents, or requirements. Our AI will analyze them
+              and create a basket tailored to your needs.
             </p>
           </div>
           
           <UniversalContentInput
             inputs={inputs}
             onInputsChange={setInputs}
-            disabled={isCreatingProject}
+            disabled={isCreatingBasket}
           />
         </div>
       )}
@@ -139,11 +139,11 @@ export default function UniversalProjectCreator({
         />
       )}
 
-      {/* Project Creation */}
-      <ProjectCreationTrigger
+      {/* Basket Creation */}
+      <BasketCreationTrigger
         processingResult={processingResult}
-        onCreateProject={handleCreateProject}
-        isCreating={isCreatingProject}
+        onCreateBasket={handleCreateBasket}
+        isCreating={isCreatingBasket}
         creationResult={creationResult}
         disabled={isProcessing || !!error}
       />
@@ -152,7 +152,7 @@ export default function UniversalProjectCreator({
       {!creationResult && (
         <div className="text-center">
           <p className="text-sm text-muted-foreground">
-            💡 Tip: Add multiple sources (files, text, URLs) for richer workspace intelligence
+            💡 Tip: Add multiple sources (files, text, URLs) for richer basket intelligence
           </p>
         </div>
       )}
@@ -164,7 +164,7 @@ export default function UniversalProjectCreator({
             onClick={handleReset}
             className="text-sm text-muted-foreground hover:text-foreground underline"
           >
-            Create another workspace
+            Create another basket
           </button>
         </div>
       )}

--- a/web/components/onboarding/LiveIntelligencePreview.tsx
+++ b/web/components/onboarding/LiveIntelligencePreview.tsx
@@ -125,9 +125,9 @@ export default function LiveIntelligencePreview({
           </div>
         )}
 
-        {/* Suggested Workspace */}
+        {/* Suggested Basket */}
         <div>
-          <h4 className="text-xs font-medium text-green-800 mb-2">Suggested Workspace</h4>
+          <h4 className="text-xs font-medium text-green-800 mb-2">Suggested Basket</h4>
           <div className="p-3 bg-white/60 rounded-lg border border-green-200">
             <div className="flex items-center gap-2 mb-2">
               <span className="text-sm">🗂️</span>
@@ -192,7 +192,7 @@ export default function LiveIntelligencePreview({
         {/* Next Steps Hint */}
         <div className="text-center pt-2 border-t border-green-200">
           <p className="text-xs text-green-600">
-            ✨ Ready to create your intelligent workspace
+            ✨ Ready to create your basket
           </p>
         </div>
       </CardContent>

--- a/web/components/onboarding/UniversalContentInput.tsx
+++ b/web/components/onboarding/UniversalContentInput.tsx
@@ -290,7 +290,7 @@ export default function UniversalContentInput({
             value={textContent}
             onChange={(e) => setTextContent(e.target.value)}
             disabled={disabled}
-            placeholder="Paste your content here... (project notes, business requirements, ideas, etc.)"
+            placeholder="Paste your content here... (basket notes, business requirements, ideas, etc.)"
             className="w-full min-h-[100px] p-3 border border-input rounded-lg text-sm bg-background resize-none focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50"
           />
           <div className="flex items-center justify-between">

--- a/web/components/onboarding/UniversalCreateButton.tsx
+++ b/web/components/onboarding/UniversalCreateButton.tsx
@@ -21,7 +21,7 @@ export default function UniversalCreateButton({
 }: Props) {
   const router = useRouter();
 
-  const handleCreateProject = () => {
+  const handleCreateBasket = () => {
     router.push("/onboarding");
   };
 
@@ -33,9 +33,9 @@ export default function UniversalCreateButton({
           <>
             <div className="text-xl mb-2">✨</div>
             <div>
-              <div className="font-semibold">Create Intelligent Project</div>
+              <div className="font-semibold">Create Basket</div>
               <div className="text-sm opacity-90">
-                I'll help you set up a complete project with AI insights
+                I'll help you set up a complete basket with AI insights
               </div>
             </div>
           </>
@@ -45,7 +45,7 @@ export default function UniversalCreateButton({
         return (
           <>
             <span className="mr-2">✨</span>
-            Create Project
+            Create Basket
           </>
         );
       
@@ -53,9 +53,9 @@ export default function UniversalCreateButton({
         return (
           <>
             <div className="text-2xl mb-3">🚀</div>
-            <div className="font-semibold mb-1">Create Your First Project</div>
+            <div className="font-semibold mb-1">Create Your First Basket</div>
             <div className="text-sm text-muted-foreground">
-              I'll guide you through creating an intelligent project in just a few minutes
+              I'll guide you through creating your basket in just a few minutes
             </div>
           </>
         );
@@ -64,7 +64,7 @@ export default function UniversalCreateButton({
         return children || (
           <>
             <span className="mr-2">✨</span>
-            Create Project
+            Create Basket
           </>
         );
     }
@@ -97,7 +97,7 @@ export default function UniversalCreateButton({
     <Button
       variant={variant}
       size={size}
-      onClick={handleCreateProject}
+      onClick={handleCreateBasket}
       className={getButtonClassName()}
     >
       {getButtonContent()}
@@ -155,7 +155,7 @@ export function NewBasketButton({
       {children || (
         <>
           <span className="mr-2">✨</span>
-          Create Workspace
+          Create Basket
         </>
       )}
     </UniversalCreateButton>

--- a/web/lib/intelligence/useUniversalIntelligence.ts
+++ b/web/lib/intelligence/useUniversalIntelligence.ts
@@ -33,7 +33,7 @@ export interface SuggestedDocument {
   relevance: number;
 }
 
-export interface WorkspaceStructure {
+export interface BasketStructure {
   suggested_name: string;
   description: string;
   organization_strategy: string;
@@ -43,14 +43,14 @@ export interface ProcessingResponse {
   intelligence: IntelligenceResult;
   suggested_structure: {
     documents: SuggestedDocument[];
-    organization: WorkspaceStructure;
+    organization: BasketStructure;
   };
   processing_summary: string;
   processed_at: string;
   processing_intent: string;
 }
 
-export interface WorkspaceCreationResult {
+export interface BasketInitializationResult {
   basket: {
     id: string;
     name: string;
@@ -120,25 +120,25 @@ export function useUniversalIntelligence() {
     }
   };
 
-  const createWorkspace = async (
+  const createInitialBasket = async (
     intelligence: IntelligenceResult,
     suggested_structure: {
       documents: SuggestedDocument[];
-      organization: WorkspaceStructure;
+      organization: BasketStructure;
     },
     user_modifications?: {
-      workspace_name?: string;
+      basket_name?: string;
       selected_documents?: string[];
       additional_context?: string;
     }
-  ): Promise<WorkspaceCreationResult | null> => {
+  ): Promise<BasketInitializationResult | null> => {
     if (!user) return null;
 
     setIsProcessing(true);
     setError(null);
 
     try {
-      const response = await fetchWithToken('/api/intelligence/create-workspace', {
+      const response = await fetchWithToken('/api/intelligence/initialize', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -152,16 +152,16 @@ export function useUniversalIntelligence() {
 
       if (!response.ok) {
         const errorData = await response.json();
-        throw new Error(errorData.error || 'Failed to create workspace');
+        throw new Error(errorData.error || 'Failed to initialize basket');
       }
 
       const { result } = await response.json();
-      return result as WorkspaceCreationResult;
+      return result as BasketInitializationResult;
 
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : 'Unknown error occurred';
       setError(errorMessage);
-      console.error('Workspace creation error:', err);
+      console.error('Basket initialization error:', err);
       return null;
     } finally {
       setIsProcessing(false);
@@ -176,7 +176,7 @@ export function useUniversalIntelligence() {
 
   return {
     processContent,
-    createWorkspace,
+    createInitialBasket,
     reset,
     isProcessing,
     processingResult,
@@ -186,7 +186,7 @@ export function useUniversalIntelligence() {
     themes: processingResult?.intelligence.themes || [],
     confidence: processingResult?.intelligence.confidence_score || 0,
     suggestedDocuments: processingResult?.suggested_structure.documents || [],
-    workspaceName: processingResult?.suggested_structure.organization.suggested_name || '',
+    basketName: processingResult?.suggested_structure.organization.suggested_name || '',
   };
 }
 


### PR DESCRIPTION
## Summary
- move initialization endpoint to `/api/intelligence/initialize` and adjust hooks to consume it
- rename onboarding components and copy to focus on basket creation
- update live preview and triggers to show "Suggested Basket" and basket-focused success messaging

## Testing
- `npm test`
- `npm run build:check`


------
https://chatgpt.com/codex/tasks/task_e_68945c244cc8832984d6cae516937b17