### PR TITLE
Harden authenticated fetch + rewire basket work calls (polling-compatible)

### DIFF
--- a/shared/contracts/basket.ts
+++ b/shared/contracts/basket.ts
@@ -10,6 +10,14 @@ export interface BasketChangeRequest {
   sources?: Source[];
   agent_hints?: string[];
   user_context?: Record<string, unknown>;
+  /**
+   * Work request type handled by Manager Agent
+   * e.g. "raw_dump_process" or "block_update"
+   */
+  type?: string;
+  rawDumpId?: string;
+  blockId?: string;
+  payload?: unknown;
 }
 
 export type EntityChange =

--- a/web/hooks/useBasketOperations.ts
+++ b/web/hooks/useBasketOperations.ts
@@ -10,22 +10,22 @@ import { BasketChangeRequest, BasketDelta } from '@shared/contracts/basket'
 interface UseBasketOperationsReturn {
   isLoading: boolean
   error: string | null
-  processWork: (basketId: string, request: BasketChangeRequest) => Promise<BasketDelta | null>
-  getDeltas: (basketId: string) => Promise<BasketDelta[] | null>
-  applyDelta: (basketId: string, deltaId: string) => Promise<boolean>
+  processWork: (request: BasketChangeRequest) => Promise<BasketDelta | null>
+  getDeltas: () => Promise<BasketDelta[] | null>
+  applyDelta: (deltaId: string) => Promise<boolean>
   clearError: () => void
 }
 
-export function useBasketOperations(): UseBasketOperationsReturn {
+export function useBasketOperations(basketId: string): UseBasketOperationsReturn {
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
   const clearError = () => setError(null)
 
-  const processWork = async (basketId: string, request: BasketChangeRequest): Promise<BasketDelta | null> => {
+  const processWork = async (request: BasketChangeRequest): Promise<BasketDelta | null> => {
     setIsLoading(true)
     setError(null)
-    
+
     try {
       const delta = await basketApi.processWork(basketId, request)
       return delta
@@ -38,10 +38,10 @@ export function useBasketOperations(): UseBasketOperationsReturn {
     }
   }
 
-  const getDeltas = async (basketId: string): Promise<BasketDelta[] | null> => {
+  const getDeltas = async (): Promise<BasketDelta[] | null> => {
     setIsLoading(true)
     setError(null)
-    
+
     try {
       const deltas = await basketApi.getDeltas(basketId)
       return deltas
@@ -54,10 +54,10 @@ export function useBasketOperations(): UseBasketOperationsReturn {
     }
   }
 
-  const applyDelta = async (basketId: string, deltaId: string): Promise<boolean> => {
+  const applyDelta = async (deltaId: string): Promise<boolean> => {
     setIsLoading(true)
     setError(null)
-    
+
     try {
       await basketApi.applyDelta(basketId, deltaId)
       return true

--- a/web/lib/api/client.ts
+++ b/web/lib/api/client.ts
@@ -4,6 +4,7 @@
  */
 
 import { BasketChangeRequest, BasketDelta } from '@shared/contracts/basket'
+import { fetchWithToken } from '@/lib/fetchWithToken'
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || 'https://rightnow-api.onrender.com'
 
@@ -28,7 +29,12 @@ export class ApiClient {
       ...options,
     }
 
-    const response = await fetch(url, config)
+    let response = await fetchWithToken(url, config)
+
+    // Single retry on 401 to handle token race conditions
+    if (response.status === 401) {
+      response = await fetchWithToken(url, config)
+    }
 
     if (!response.ok) {
       throw new Error(`API Error: ${response.status} ${response.statusText}`)

--- a/web/lib/substrate/SubstrateService.ts
+++ b/web/lib/substrate/SubstrateService.ts
@@ -3,7 +3,6 @@
 
 import { createSupabaseClient } from '@/lib/supabase/client';
 import { authHelper } from '@/lib/supabase/auth-helper';
-import { apiClient } from '@/lib/api/client';
 
 export interface RawDump {
   id: string;
@@ -127,56 +126,6 @@ export class SubstrateService {
     }
   }
 
-  // MANAGER AGENT: Single consolidated substrate processing
-  async processRawDump(rawDumpId: string): Promise<{
-    blocks: Block[];
-    contextItems: ContextItem[];
-    narrative: any[];
-    relationships: any[];
-  }> {
-    try {
-      // Get basket_id for the raw dump
-      const { data: rawDump, error: fetchError } = await this.supabase
-        .from('raw_dumps')
-        .select('basket_id')
-        .eq('id', rawDumpId)
-        .single();
-
-      if (fetchError || !rawDump) {
-        throw new Error(`Failed to fetch raw dump: ${fetchError?.message}`);
-      }
-
-      console.log('🎯 Calling Manager Agent for complete substrate processing...');
-
-      // CALL MANAGER AGENT - Single endpoint handles everything
-      const result = await apiClient.request('/api/substrate/process', {
-        method: 'POST',
-        body: JSON.stringify({
-          rawDumpId,
-          basketId: rawDump.basket_id
-        })
-      });
-
-      if (!result || (result as any)?.error) {
-        throw new Error((result as any)?.error || 'Manager Agent failed');
-      }
-      
-      if (!(result as any).success) {
-        throw new Error((result as any).error || 'Manager Agent processing failed');
-      }
-
-      console.log('✅ Manager Agent completed:', (result as any).summary);
-      
-      return (result as any).substrate;
-      
-    } catch (error) {
-      console.error('❌ Manager Agent processing failed:', error);
-      throw new Error(`Failed to process raw dump: ${error instanceof Error ? error.message : 'Unknown error'}`);
-    }
-  }
-
-  // Note: All substrate processing now handled by Manager Agent at /api/substrate/process
-  // This eliminates mocks and provides real agent orchestration
 
   async approveBlock(id: string): Promise<Block> {
     const { data, error } = await this.supabase


### PR DESCRIPTION
## Summary
- inject Supabase JWT and 401 retry logic into ApiClient
- bind basket operations via useBasketOperations(basketId) and route raw dump processing through ApiClient
- remove legacy /api/substrate/process references

## Testing
- `npm run build:check`


------
https://chatgpt.com/codex/tasks/task_e_689955725ffc83298d5bc0ed70a50710