### PR TITLE
Apply design system to create onboarding flow

### DIFF
--- a/web/app/create/components/IntentField.tsx
+++ b/web/app/create/components/IntentField.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { Input } from '@/components/ui/Input';
+
 interface IntentFieldProps {
   value: string;
   onChange: (value: string) => void;
@@ -7,12 +9,12 @@ interface IntentFieldProps {
 
 export function IntentField({ value, onChange }: IntentFieldProps) {
   return (
-    <input
+    <Input
       type="text"
-      placeholder="What are you working on?"
+      placeholder="What are you working on right now?"
       value={value}
       onChange={(e) => onChange(e.target.value)}
-      className="w-full text-3xl font-light bg-transparent border-b border-gray-800 focus:border-white transition-colors pb-2 outline-none"
+      className="text-2xl font-light bg-transparent border-b border-gray-800 focus:border-white transition-colors pb-2"
       autoFocus
     />
   );

--- a/web/app/create/components/MemoryCapture.tsx
+++ b/web/app/create/components/MemoryCapture.tsx
@@ -1,117 +1,61 @@
 'use client';
 
-import { useState, useCallback } from 'react';
-import { Upload, Type, Link, Sparkles } from 'lucide-react';
-import { useDropzone } from 'react-dropzone';
+import { useState } from 'react';
+import { Sparkles } from 'lucide-react';
 import { SubstrateEvolution } from './SubstrateEvolution';
 import { IntentField } from './IntentField';
+import UnifiedIngest, { IngestItem } from './UnifiedIngest';
+import { Button } from '@/components/ui/Button';
+import { uploadFile } from '@/lib/uploadFile';
 
-export interface Input {
-  type: 'file' | 'text' | 'url';
+export interface SourceInput {
+  type: 'file' | 'text';
+  content?: string;
+  id?: string;
   name?: string;
-  content: string;
   size?: number;
 }
 
 interface Props {
-  onFormation: (intent: string, inputs: Input[]) => void;
+  onFormation: (intent: string, inputs: SourceInput[]) => void;
   basketId: string | null;
 }
 
 export function MemoryCapture({ onFormation, basketId }: Props) {
   const [intent, setIntent] = useState('');
-  const [inputs, setInputs] = useState<Input[]>([]);
+  const [items, setItems] = useState<IngestItem[]>([]);
   const [isForming, setIsForming] = useState(false);
 
-  const onDrop = useCallback((acceptedFiles: File[]) => {
-    acceptedFiles.forEach((file) => {
-      const reader = new FileReader();
-      reader.onload = () => {
-        setInputs((prev) => [
-          ...prev,
-          { type: 'file', name: file.name, content: reader.result as string, size: file.size },
-        ]);
-      };
-      reader.readAsText(file);
-    });
-  }, []);
-
-  const handlePaste = useCallback((e: React.ClipboardEvent<HTMLDivElement>) => {
-    const text = e.clipboardData.getData('text');
-    if (!text) return;
-    try {
-      const url = new URL(text);
-      setInputs((prev) => [...prev, { type: 'url', content: url.toString(), name: url.hostname }]);
-    } catch {
-      setInputs((prev) => [...prev, { type: 'text', content: text }]);
-    }
-  }, []);
-
-  const { getRootProps, getInputProps, isDragActive } = useDropzone({
-    onDrop,
-    noClick: false,
-    multiple: true,
-  });
-
-  const handleCreate = () => {
+  const handleCreate = async () => {
     setIsForming(true);
-    onFormation(intent, inputs);
+    const sources: SourceInput[] = await Promise.all(
+      items.map(async (item) => {
+        if (item.kind === 'file') {
+          const url = await uploadFile(item.file, `ingest/${item.file.name}`);
+          return { type: 'file', id: url, name: item.file.name, size: item.file.size };
+        }
+        if (item.kind === 'url') {
+          return { type: 'text', content: item.url, name: item.url };
+        }
+        return { type: 'text', content: item.text };
+      })
+    );
+    onFormation(intent, sources);
   };
 
   return (
-    <div className="relative w-full max-w-4xl mx-auto p-8">
-      <div className="mb-12">
-        <IntentField value={intent} onChange={setIntent} />
-      </div>
+    <div className="max-w-4xl mx-auto space-y-8 p-6">
+      <IntentField value={intent} onChange={setIntent} />
 
-      <div
-        {...getRootProps()}
-        onPaste={handlePaste}
-        className={`relative min-h-[400px] rounded-lg border-2 border-dashed ${
-          isDragActive ? 'border-white bg-white/5' : 'border-gray-800'
-        } ${isForming ? 'pointer-events-none' : 'cursor-pointer'} transition-all duration-300`}
-      >
-        <input {...getInputProps()} />
+      {!isForming && <UnifiedIngest onChange={setItems} />}
+      {isForming && basketId && <SubstrateEvolution basketId={basketId} />}
 
-        {!isForming && inputs.length === 0 && (
-          <div className="absolute inset-0 flex items-center justify-center">
-            <div className="text-center space-y-4">
-              <div className="flex justify-center gap-4 text-gray-600">
-                <Upload size={24} />
-                <Type size={24} />
-                <Link size={24} />
-              </div>
-              <p className="text-gray-500">Drop files, paste text, or add URLs</p>
-            </div>
-          </div>
-        )}
-
-        {!isForming && inputs.length > 0 && (
-          <div className="p-6 space-y-3">
-            {inputs.map((input, i) => (
-              <div key={i} className="flex items-center gap-3 text-sm text-gray-400">
-                {input.type === 'file' && <Upload size={16} />}
-                {input.type === 'text' && <Type size={16} />}
-                {input.type === 'url' && <Link size={16} />}
-                <span>{input.name || `${input.type} input`}</span>
-              </div>
-            ))}
-          </div>
-        )}
-
-        {isForming && basketId && <SubstrateEvolution basketId={basketId} />}
-      </div>
-
-      {!isForming && inputs.length > 0 && intent && (
-        <button
-          onClick={handleCreate}
-          className="mt-8 w-full py-4 bg-white text-black rounded-lg font-medium hover:bg-gray-100 transition-colors flex items-center justify-center gap-2"
-        >
+      {!isForming && items.length > 0 && intent && (
+        <Button size="lg" className="w-full flex items-center justify-center gap-2" onClick={handleCreate}>
           <Sparkles size={20} />
           Begin Formation
-        </button>
+        </Button>
       )}
     </div>
   );
 }
-

--- a/web/app/create/components/UnifiedIngest.tsx
+++ b/web/app/create/components/UnifiedIngest.tsx
@@ -1,0 +1,123 @@
+'use client';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import Image from 'next/image';
+import { useDropzone } from 'react-dropzone';
+import { Button } from '@/components/ui/Button';
+import { Input } from '@/components/ui/Input';
+import { Card } from '@/components/ui/Card';
+
+type IngestItem =
+  | { kind: 'file'; file: File; preview?: string }
+  | { kind: 'text'; text: string }
+  | { kind: 'url'; url: string };
+
+export interface UnifiedIngestProps {
+  onChange: (items: IngestItem[]) => void;
+}
+
+export default function UnifiedIngest({ onChange }: UnifiedIngestProps) {
+  const [items, setItems] = useState<IngestItem[]>([]);
+  const urlRef = useRef<HTMLInputElement>(null);
+
+  const push = (next: IngestItem[]) => {
+    setItems(prev => {
+      const merged = [...prev, ...next];
+      onChange(merged);
+      return merged;
+    });
+  };
+
+  const onDrop = useCallback((accepted: File[]) => {
+    push(
+      accepted.map(f => ({
+        kind: 'file',
+        file: f,
+        preview: f.type.startsWith('image/') ? URL.createObjectURL(f) : undefined,
+      }))
+    );
+  }, []);
+
+  const { getRootProps, getInputProps, isDragActive } = useDropzone({ onDrop, multiple: true });
+
+  useEffect(() => {
+    const onPaste = async (e: ClipboardEvent) => {
+      const blobs: File[] = [];
+      for (const item of e.clipboardData?.items ?? []) {
+        if (item.kind === 'file') {
+          const file = item.getAsFile();
+          if (file) blobs.push(file);
+        }
+      }
+      if (blobs.length) {
+        push(
+          blobs.map(f => ({ kind: 'file', file: f, preview: URL.createObjectURL(f) }))
+        );
+      } else {
+        const text = e.clipboardData?.getData('text')?.trim();
+        if (text) {
+          try {
+            const u = new URL(text);
+            push([{ kind: 'url', url: u.toString() }]);
+          } catch {
+            push([{ kind: 'text', text }]);
+          }
+        }
+      }
+    };
+    window.addEventListener('paste', onPaste);
+    return () => window.removeEventListener('paste', onPaste);
+  }, []);
+
+  const addUrl = () => {
+    const v = urlRef.current?.value?.trim();
+    if (!v) return;
+    try {
+      const u = new URL(v);
+      push([{ kind: 'url', url: u.toString() }]);
+      if (urlRef.current) urlRef.current.value = '';
+    } catch {}
+  };
+
+  return (
+    <Card className="p-4 space-y-4">
+      <div className="flex items-center gap-2">
+        <Input ref={urlRef} placeholder="Paste a link and press Add" />
+        <Button onClick={addUrl}>Add</Button>
+      </div>
+
+      <div
+        {...getRootProps()}
+        className={`rounded-md border-2 border-dashed p-8 text-center ${isDragActive ? 'opacity-100' : 'opacity-80'}`}
+      >
+        <input {...getInputProps()} />
+        <div>Drop files here, or paste text/screenshots anywhere</div>
+      </div>
+
+      {!!items.length && (
+        <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
+          {items.map((it, i) => (
+            <div key={i} className="rounded border p-2 text-sm">
+              {it.kind === 'file' && it.preview ? (
+                <Image
+                  src={it.preview}
+                  alt={it.file.name}
+                  width={300}
+                  height={200}
+                  className="rounded"
+                />
+              ) : (
+                <div className="truncate">
+                  {it.kind === 'file' && it.file.name}
+                  {it.kind === 'url' && it.url}
+                  {it.kind === 'text' && it.text.slice(0, 140)}
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </Card>
+  );
+}
+
+export type { IngestItem };

--- a/web/app/create/page.tsx
+++ b/web/app/create/page.tsx
@@ -2,14 +2,14 @@
 
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { MemoryCapture, Input } from './components/MemoryCapture';
+import { MemoryCapture, SourceInput } from './components/MemoryCapture';
 import { apiClient } from '@/lib/api/client';
 
 export default function CreatePage() {
   const router = useRouter();
   const [basketId, setBasketId] = useState<string | null>(null);
 
-  const handleMemoryFormation = async (intent: string, inputs: Input[]) => {
+  const handleMemoryFormation = async (intent: string, inputs: SourceInput[]) => {
     const basket = await apiClient.request<{ id: string }>('/api/baskets/new', {
       method: 'POST',
       body: JSON.stringify({ intent, status: 'forming' }),
@@ -38,7 +38,7 @@ export default function CreatePage() {
   };
 
   return (
-    <div className="min-h-screen bg-black text-white">
+    <div className="container py-8">
       <MemoryCapture onFormation={handleMemoryFormation} basketId={basketId} />
     </div>
   );

--- a/web/components/shell/ClientLayoutShell.tsx
+++ b/web/components/shell/ClientLayoutShell.tsx
@@ -12,6 +12,7 @@ const SHOW_SIDEBAR_ROUTES = [
   "/dashboard",
   "/blocks",
   "/context",
+  "/create",
 ];
 
 // These specific routes should NOT show global sidebar (they have custom layouts)


### PR DESCRIPTION
## Summary
- wrap /create in global shell by adding route to ClientLayoutShell
- swap raw inputs for design system components and introduce UnifiedIngest dropzone
- integrate file upload mapping and DS Button in MemoryCapture

## Testing
- `npm test`
- `npm --prefix web run lint` *(fails: no-unused-vars and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_689955631ea8832996e5a58d77779fe0