### PR TITLE
feat: add documents popover to basket sidebar

### DIFF
--- a/web/components/basket/BasketSidebar.tsx
+++ b/web/components/basket/BasketSidebar.tsx
@@ -1,12 +1,11 @@
 "use client";
 import { useState } from "react";
 import { useRouter, useSearchParams, usePathname } from "next/navigation";
-import Link from "next/link";
 import { Button } from "@/components/ui/Button";
 import { Badge } from "@/components/ui/Badge";
 import { cn } from "@/lib/utils";
-import { createDocumentWithPrompt } from "@/lib/documents/createDocument";
 import SidebarToggleIcon from "@/components/icons/SidebarToggleIcon";
+import LeftNavDocuments from "@/components/basket/LeftNavDocuments";
 import type { Document } from "@/types";
 
 interface Props {
@@ -38,36 +37,9 @@ export default function BasketSidebar({
   const currentDocId = currentDocumentId || (docMatch ? docMatch[1] : params.get("docId"));
   
   const [collapsed, setCollapsed] = useState(false);
-  const [expandedDocs, setExpandedDocs] = useState<Set<string>>(new Set());
-  const [isCreatingDocument, setIsCreatingDocument] = useState(false);
-
-  const toggleDocExpansion = (docId: string) => {
-    const newExpanded = new Set(expandedDocs);
-    if (newExpanded.has(docId)) {
-      newExpanded.delete(docId);
-    } else {
-      newExpanded.add(docId);
-    }
-    setExpandedDocs(newExpanded);
-  };
 
   const handleNavigation = (path: string) => {
     router.push(path);
-  };
-
-  const handleCreateDocument = async () => {
-    if (isCreatingDocument) return;
-    
-    setIsCreatingDocument(true);
-    try {
-      const newDocument = await createDocumentWithPrompt(basketId);
-      router.refresh();
-    } catch (error) {
-      console.error('Failed to create document:', error);
-      alert('Failed to create document. Please try again.');
-    } finally {
-      setIsCreatingDocument(false);
-    }
   };
 
   if (collapsed) {
@@ -157,43 +129,12 @@ export default function BasketSidebar({
 
       {/* Documents Section */}
       <div className="flex-1 overflow-y-auto">
-        <div className="p-4">
-          <div className="flex items-center justify-between mb-3">
-            <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">
-              Documents
-            </h3>
-            <Button
-              variant="ghost"
-              size="sm"
-              className="text-xs h-6 px-2 text-muted-foreground hover:text-foreground"
-              onClick={handleCreateDocument}
-              disabled={isCreatingDocument}
-            >
-              {isCreatingDocument ? "..." : "+"}
-            </Button>
-          </div>
-          
-          <nav className="space-y-1">
-            {documents.length === 0 ? (
-              <div className="text-xs text-muted-foreground text-center py-4">
-                No documents yet
-              </div>
-            ) : (
-              documents.map((doc) => (
-                <DocumentNavItem
-                  key={doc.id}
-                  document={doc}
-                  basketId={basketId}
-                  expanded={expandedDocs.has(doc.id)}
-                  active={currentDocId === doc.id}
-                  currentTab={currentTab}
-                  onToggleExpand={() => toggleDocExpansion(doc.id)}
-                  onNavigate={handleNavigation}
-                />
-              ))
-            )}
-          </nav>
-        </div>
+        <LeftNavDocuments
+          basketId={basketId}
+          documents={documents}
+          currentDocId={currentDocId as string | undefined}
+          currentTab={currentTab}
+        />
       </div>
     </aside>
   );
@@ -226,85 +167,5 @@ function NavItem({ icon, label, active, onClick, badge }: NavItemProps) {
         </Badge>
       )}
     </button>
-  );
-}
-
-interface DocumentNavItemProps {
-  document: Document;
-  basketId: string;
-  expanded: boolean;
-  active: boolean;
-  currentTab: string;
-  onToggleExpand: () => void;
-  onNavigate: (path: string) => void;
-}
-
-function DocumentNavItem({
-  document,
-  basketId,
-  expanded,
-  active,
-  currentTab,
-  onToggleExpand,
-  onNavigate,
-}: DocumentNavItemProps) {
-  const docActive = active && !currentTab.includes("insights") && !currentTab.includes("history");
-  const docInsightsActive = active && currentTab.includes("insights");
-  const docHistoryActive = active && currentTab.includes("history");
-
-  return (
-    <div className="space-y-1">
-      {/* Main document item */}
-      <div className="flex items-center">
-        <button
-          onClick={onToggleExpand}
-          className="p-1 hover:bg-muted rounded text-muted-foreground hover:text-foreground mr-1"
-        >
-          {expanded ? "⌄" : "›"}
-        </button>
-        <button
-          onClick={() => onNavigate(`/baskets/${basketId}/work/documents/${document.id}`)}
-          className={cn(
-            "flex-1 flex items-center gap-2 px-2 py-1.5 text-sm rounded-md transition-colors text-left",
-            docActive
-              ? "bg-primary text-primary-foreground"
-              : "hover:bg-muted text-muted-foreground hover:text-foreground"
-          )}
-        >
-          <span className="text-base">📄</span>
-          <span className="flex-1 truncate">{document.title || `Document ${document.id.slice(0, 8)}`}</span>
-        </button>
-      </div>
-
-      {/* Expanded document sub-items */}
-      {expanded && (
-        <div className="ml-6 space-y-1">
-          <button
-            onClick={() => onNavigate(`/baskets/${basketId}/work/documents/${document.id}`)}
-            className={cn(
-              "w-full flex items-center gap-2 px-2 py-1 text-sm rounded-md transition-colors text-left",
-              docInsightsActive
-                ? "bg-primary text-primary-foreground"
-                : "hover:bg-muted text-muted-foreground hover:text-foreground"
-            )}
-          >
-            <span className="text-sm">🧠</span>
-            <span className="flex-1">Insights</span>
-          </button>
-          <button
-            onClick={() => onNavigate(`/baskets/${basketId}/work/timeline`)}
-            className={cn(
-              "w-full flex items-center gap-2 px-2 py-1 text-sm rounded-md transition-colors text-left",
-              docHistoryActive
-                ? "bg-primary text-primary-foreground"
-                : "hover:bg-muted text-muted-foreground hover:text-foreground"
-            )}
-          >
-            <span className="text-sm">📜</span>
-            <span className="flex-1">History</span>
-          </button>
-        </div>
-      )}
-    </div>
   );
 }

--- a/web/components/basket/LeftNavDocuments.tsx
+++ b/web/components/basket/LeftNavDocuments.tsx
@@ -1,0 +1,273 @@
+"use client";
+
+import { useState, useRef, KeyboardEvent } from "react";
+import { useRouter } from "next/navigation";
+import { Plus, FileText, FilePlus2, Upload } from "lucide-react";
+
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+import { useCreateActions } from "@/hooks/useCreateActions";
+
+import type { Document } from "@/types";
+
+interface Props {
+  basketId: string;
+  documents: Document[];
+  currentDocId?: string;
+  currentTab: string;
+}
+
+export default function LeftNavDocuments({
+  basketId,
+  documents = [],
+  currentDocId,
+  currentTab,
+}: Props) {
+  const router = useRouter();
+  const [expandedDocs, setExpandedDocs] = useState<Set<string>>(new Set());
+  const [open, setOpen] = useState(false);
+
+  const { quickDump, newBlankDocument, uploadFiles, handleSelectedFiles } =
+    useCreateActions();
+  const triggerRef = useRef<HTMLButtonElement>(null);
+
+  const toggleDocExpansion = (docId: string) => {
+    setExpandedDocs((prev) => {
+      const next = new Set(prev);
+      if (next.has(docId)) {
+        next.delete(docId);
+      } else {
+        next.add(docId);
+      }
+      return next;
+    });
+  };
+
+  return (
+    <div className="p-4">
+      <div className="flex items-center justify-between mb-3">
+        <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">
+          Documents
+        </h3>
+        <Popover
+          open={open}
+          onOpenChange={(v) => {
+            setOpen(v);
+            if (!v) triggerRef.current?.focus();
+          }}
+        >
+          <PopoverTrigger asChild>
+            <button
+              ref={triggerRef}
+              aria-label="Add to this basket"
+              aria-haspopup="menu"
+              aria-expanded={open}
+              data-testid="documents-add-trigger"
+              title="Add to this basket"
+              className="inline-flex h-7 w-7 items-center justify-center rounded-md hover:bg-muted focus:outline-none focus:ring-2 focus:ring-ring"
+            >
+              <Plus className="h-4 w-4" />
+            </button>
+          </PopoverTrigger>
+          <PopoverContent
+            role="menu"
+            className="w-72 p-0"
+            align="end"
+            sideOffset={4}
+          >
+            <div className="py-1">
+              <MenuItem
+                icon={FileText}
+                title="Quick dump"
+                desc="Paste, write, or drop files."
+                autoFocus
+                onSelect={() => {
+                  setOpen(false);
+                  quickDump();
+                }}
+                testId="documents-quick-dump"
+              />
+              <MenuItem
+                icon={FilePlus2}
+                title="New document"
+                desc="Start from a blank page."
+                onSelect={async () => {
+                  setOpen(false);
+                  await newBlankDocument();
+                }}
+                testId="documents-new-document"
+              />
+              <MenuItem
+                icon={Upload}
+                title="Upload files"
+                desc="Files become raw dumps."
+                onSelect={() => {
+                  setOpen(false);
+                  uploadFiles();
+                }}
+                testId="documents-upload-files"
+              />
+            </div>
+          </PopoverContent>
+        </Popover>
+        <input
+          id="leftnav-upload-hidden"
+          type="file"
+          multiple
+          className="hidden"
+          onChange={(e) =>
+            e.currentTarget.files && handleSelectedFiles(e.currentTarget.files)
+          }
+        />
+      </div>
+
+      <nav className="space-y-1">
+        {documents.length === 0 ? (
+          <div className="text-xs text-muted-foreground text-center py-4">
+            No documents yet
+          </div>
+        ) : (
+          documents.map((doc) => (
+            <DocumentNavItem
+              key={doc.id}
+              document={doc}
+              basketId={basketId}
+              expanded={expandedDocs.has(doc.id)}
+              active={currentDocId === doc.id}
+              currentTab={currentTab}
+              onToggleExpand={() => toggleDocExpansion(doc.id)}
+              onNavigate={(path) => router.push(path)}
+            />
+          ))
+        )}
+      </nav>
+    </div>
+  );
+}
+
+function MenuItem({
+  icon: Icon,
+  title,
+  desc,
+  onSelect,
+  autoFocus,
+  testId,
+}: {
+  icon: any;
+  title: string;
+  desc: string;
+  onSelect: () => void;
+  autoFocus?: boolean;
+  testId: string;
+}) {
+  const ref = useRef<HTMLButtonElement>(null);
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLButtonElement>) => {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      (ref.current?.nextElementSibling as HTMLElement | null)?.focus();
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      (ref.current?.previousElementSibling as HTMLElement | null)?.focus();
+    }
+  };
+
+  return (
+    <button
+      ref={ref}
+      role="menuitem"
+      data-testid={testId}
+      className="w-full px-3 py-2 text-left hover:bg-muted focus:bg-muted focus:outline-none"
+      onClick={onSelect}
+      autoFocus={autoFocus}
+      onKeyDown={handleKeyDown}
+    >
+      <div className="flex gap-3">
+        <Icon className="h-4 w-4 mt-1 shrink-0" />
+        <div>
+          <div className="text-sm font-medium">{title}</div>
+          <div className="text-xs text-muted-foreground">{desc}</div>
+        </div>
+      </div>
+    </button>
+  );
+}
+
+interface DocumentNavItemProps {
+  document: Document;
+  basketId: string;
+  expanded: boolean;
+  active: boolean;
+  currentTab: string;
+  onToggleExpand: () => void;
+  onNavigate: (path: string) => void;
+}
+
+function DocumentNavItem({
+  document,
+  basketId,
+  expanded,
+  active,
+  currentTab,
+  onToggleExpand,
+  onNavigate,
+}: DocumentNavItemProps) {
+  const docActive = active && !currentTab.includes("insights") && !currentTab.includes("history");
+  const docInsightsActive = active && currentTab.includes("insights");
+  const docHistoryActive = active && currentTab.includes("history");
+
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center">
+        <button
+          onClick={onToggleExpand}
+          className="p-1 hover:bg-muted rounded text-muted-foreground hover:text-foreground mr-1"
+        >
+          {expanded ? "⌄" : "›"}
+        </button>
+        <button
+          onClick={() => onNavigate(`/baskets/${basketId}/work/documents/${document.id}`)}
+          className={cn(
+            "flex-1 flex items-center gap-2 px-2 py-1.5 text-sm rounded-md transition-colors text-left",
+            docActive
+              ? "bg-primary text-primary-foreground"
+              : "hover:bg-muted text-muted-foreground hover:text-foreground"
+          )}
+        >
+          <span className="text-base">📄</span>
+          <span className="flex-1 truncate">{document.title || `Document ${document.id.slice(0, 8)}`}</span>
+        </button>
+      </div>
+
+      {expanded && (
+        <div className="ml-6 space-y-1">
+          <button
+            onClick={() => onNavigate(`/baskets/${basketId}/work/documents/${document.id}`)}
+            className={cn(
+              "w-full flex items-center gap-2 px-2 py-1 text-sm rounded-md transition-colors text-left",
+              docInsightsActive
+                ? "bg-primary text-primary-foreground"
+                : "hover:bg-muted text-muted-foreground hover:text-foreground"
+            )}
+          >
+            <span className="text-sm">🧠</span>
+            <span className="flex-1">Insights</span>
+          </button>
+          <button
+            onClick={() => onNavigate(`/baskets/${basketId}/work/timeline`)}
+            className={cn(
+              "w-full flex items-center gap-2 px-2 py-1 text-sm rounded-md transition-colors text-left",
+              docHistoryActive
+                ? "bg-primary text-primary-foreground"
+                : "hover:bg-muted text-muted-foreground hover:text-foreground"
+            )}
+          >
+            <span className="text-sm">📜</span>
+            <span className="flex-1">History</span>
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/web/components/ui/popover.tsx
+++ b/web/components/ui/popover.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import * as React from "react";
+import * as PopoverPrimitive from "@radix-ui/react-popover";
+
+import { cn } from "@/lib/utils";
+
+const Popover = PopoverPrimitive.Root;
+
+const PopoverTrigger = PopoverPrimitive.Trigger;
+
+const PopoverContent = React.forwardRef<
+  React.ElementRef<typeof PopoverPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
+>(({ className, align = "center", sideOffset = 4, ...props }, ref) => (
+  <PopoverPrimitive.Portal>
+    <PopoverPrimitive.Content
+      ref={ref}
+      align={align}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 rounded-md border bg-popover text-popover-foreground shadow-md outline-none",
+        className
+      )}
+      {...props}
+    />
+  </PopoverPrimitive.Portal>
+));
+PopoverContent.displayName = PopoverPrimitive.Content.displayName;
+
+export { Popover, PopoverTrigger, PopoverContent };
+

--- a/web/hooks/useCreateActions.ts
+++ b/web/hooks/useCreateActions.ts
@@ -1,0 +1,73 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useBasket } from "@/contexts/BasketContext";
+import { useAuth } from "@/lib/useAuth";
+import { createDocumentWithPrompt } from "@/lib/documents/createDocument";
+import { postDump } from "@/lib/baskets/dumpApi";
+import { useToast } from "@/components/ui/Toast";
+
+/**
+ * Encapsulates creation actions for the basket sidebar popover.
+ * Provides handlers for quick dumps, blank documents and file uploads.
+ */
+export function useCreateActions() {
+  const router = useRouter();
+  const { basket } = useBasket();
+  const { user } = useAuth();
+  const { showSuccess, showWarning } = useToast();
+
+  const basketId = basket?.id;
+
+  return {
+    quickDump: () => {
+      if (!basketId) return;
+      const el = document.getElementById(
+        "thinking-partner-input"
+      ) as HTMLTextAreaElement | null;
+      if (el) {
+        el.focus();
+        el.scrollIntoView({ block: "center", behavior: "smooth" });
+      }
+      console.debug("quickDump invoked", { basketId });
+      showSuccess("Quick dump ready");
+    },
+
+    newBlankDocument: async () => {
+      if (!basketId) return;
+      try {
+        const doc = await createDocumentWithPrompt(basketId);
+        router.push(`/baskets/${basketId}/work/documents/${doc.id}`);
+      } catch (e) {
+        console.warn("newBlankDocument failed", e);
+        showWarning("Couldn't create document");
+      }
+    },
+
+    uploadFiles: () => {
+      const input = document.getElementById(
+        "leftnav-upload-hidden"
+      ) as HTMLInputElement | null;
+      if (input) {
+        input.value = "";
+        input.click();
+      }
+    },
+
+    handleSelectedFiles: async (files: FileList) => {
+      if (!basketId || !user?.id || !files.length) return;
+      try {
+        await postDump({
+          basketId,
+          userId: user.id,
+          images: Array.from(files),
+        });
+        showSuccess(`Captured ${files.length} file(s) as raw dumps`);
+      } catch (e) {
+        console.warn("uploadFiles failed", e);
+        showWarning("Upload failed");
+      }
+    },
+  };
+}
+

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@hookform/resolvers": "^5.0.1",
         "@radix-ui/react-dialog": "^1.1.14",
+        "@radix-ui/react-popover": "^1.1.14",
         "@radix-ui/react-radio-group": "^1.0.6",
         "@radix-ui/react-select": "^2.2.5",
         "@radix-ui/react-slot": "^1.2.2",
@@ -1030,6 +1031,43 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.14.tgz",
+      "integrity": "sha512-ODz16+1iIbGUfFEfKx2HTPKizg2MN39uIOV8MXeHnmdd3i/N9Wt7vU46wbHsqA0xoaQyXVcs0KIlBdOA2Y95bw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.10",
+        "@radix-ui/react-focus-guards": "1.1.2",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.7",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/web/package.json
+++ b/web/package.json
@@ -13,6 +13,7 @@
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-radio-group": "^1.0.6",
     "@radix-ui/react-select": "^2.2.5",
+    "@radix-ui/react-popover": "^1.1.14",
     "@radix-ui/react-slot": "^1.2.2",
     "@radix-ui/react-tabs": "^1.1.12",
     "@supabase/auth-helpers-nextjs": "0.9.0",


### PR DESCRIPTION
## Summary
- wire quick dump, new document, and file upload actions behind documents [+]
- expose hidden file input and popover menu with a11y roles and data-testids
- implement `useCreateActions` hook using existing `createDocumentWithPrompt` and `postDump` helpers

## Testing
- `npm run build:check` *(fails: supabaseKey is required)*

------
https://chatgpt.com/codex/tasks/task_e_68996b40a5ac8329ab4cc7850e1bb4cb