### PR TITLE
refactor: reuse supabase client

### DIFF
--- a/web/lib/hooks/useBasketEventsWebSocket.ts
+++ b/web/lib/hooks/useBasketEventsWebSocket.ts
@@ -1,12 +1,11 @@
 import { useEffect, useState } from 'react';
-import { createSupabaseClient } from '@/lib/supabase/client';
+import { supabase } from '@/lib/supabase/client';
 
 export function useBasketEventsWebSocket(basketId: string) {
   const [lastEvent, setLastEvent] = useState<{ type: string; payload: any } | null>(null);
   const [status, setStatus] = useState<'connecting' | 'connected' | 'error'>('connecting');
 
   useEffect(() => {
-    const supabase = createSupabaseClient();
     const channel = supabase
       .channel(`basket-${basketId}`)
       .on('postgres_changes', { event: 'INSERT', schema: 'public', table: 'basket_events', filter: `payload->>basket_id=eq.${basketId}` }, (payload) => {

--- a/web/lib/hooks/useBasketPolling.ts
+++ b/web/lib/hooks/useBasketPolling.ts
@@ -11,13 +11,12 @@
  */
 
 import { useState, useEffect, useRef } from 'react';
-import { createSupabaseClient } from '@/lib/supabase/client';
+import { supabase } from '@/lib/supabase/client';
 
 export function useBasketPolling(basketId: string) {
   const [lastEvent, setLastEvent] = useState<{ type: string; payload: any } | null>(null);
   const [status, setStatus] = useState<'connecting' | 'connected' | 'error'>('connecting');
   const lastEventIdRef = useRef<string | null>(null);
-  const supabase = createSupabaseClient();
 
   useEffect(() => {
     if (!basketId) {


### PR DESCRIPTION
## Summary
- reuse singleton Supabase client inside basket polling and websocket hooks

## Testing
- `npm test`
- `npm run lint`
- `npm run build:check` *(fails: Type error in web/components/create/CaptureTray.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_689c1115027c832993b5fe0bc48b0169