### PR TITLE
feat: align create flow with backend contracts

### DIFF
--- a/web/app/api/baskets/[id]/work/route.ts
+++ b/web/app/api/baskets/[id]/work/route.ts
@@ -2,6 +2,9 @@
 // This is the critical missing link between the two systems
 
 import { NextRequest, NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
+import { z } from 'zod';
 
 interface RouteContext {
   params: Promise<{ id: string }>;
@@ -13,27 +16,54 @@ export async function POST(
 ) {
   try {
     const { id: basketId } = await context.params;
+    const reqId = request.headers.get('X-Req-Id') || `ui-${Date.now()}`;
     const body = await request.json();
-    
-    // Backend Manager Agent URL
-    const backendUrl = process.env.NEXT_PUBLIC_API_BASE_URL || 'https://rightnow-api.onrender.com';
+
+    // Basic shape validation to avoid proxying junk
+    const BodySchema = z.object({
+      request_id: z.string(),
+      basket_id: z.string().uuid(),
+      intent: z.string().optional(),
+      sources: z.array(z.object({ type: z.string(), id: z.string().optional() })).optional(),
+    });
+    const parsed = BodySchema.parse(body);
+
+    const supabase = createRouteHandlerClient({ cookies });
+    const {
+      data: { session },
+    } = await supabase.auth.getSession();
+
+    if (!session?.access_token) {
+      console.error('baskets/work unauthorized', { reqId });
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const workspaceId =
+      (session.user?.app_metadata as any)?.workspace_id ||
+      (session.user?.user_metadata as any)?.workspace_id ||
+      null;
+
+    const backendUrl = process.env.API_BASE ?? 'https://api.yarnnn.com';
     const endpoint = `${backendUrl}/api/baskets/${basketId}/work`;
-    
+
     console.log('🌉 API Bridge: Proxying to backend:', endpoint);
-    
-    // Proxy request to backend Manager Agent
+
     const response = await fetch(endpoint, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
+        Authorization: `Bearer ${session.access_token}`,
+        ...(workspaceId ? { 'X-Workspace-Id': String(workspaceId) } : {}),
+        'X-Req-Id': reqId,
       },
-      body: JSON.stringify(body),
+      body: JSON.stringify(parsed),
     });
 
     if (!response.ok) {
-      console.error('❌ Backend Manager Agent failed:', response.status, response.statusText);
+      const text = await response.text();
+      console.error('❌ Backend Manager Agent failed:', response.status, text.slice(0, 500));
       return NextResponse.json(
-        { error: `Manager Agent failed: ${response.statusText}` },
+        { error: text || `Manager Agent failed (${response.status})` },
         { status: response.status }
       );
     }
@@ -42,7 +72,6 @@ export async function POST(
     console.log('✅ Manager Agent response:', { deltaId: result.delta_id, changes: result.changes?.length });
 
     return NextResponse.json(result);
-
   } catch (error) {
     console.error('❌ API Bridge error:', error);
     const errorMessage = error instanceof Error ? error.message : 'Unknown error';

--- a/web/app/api/dumps/new/route.ts
+++ b/web/app/api/dumps/new/route.ts
@@ -4,22 +4,16 @@ import { cookies } from "next/headers";
 import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
 import { z } from "zod";
 
-const Source = z.discriminatedUnion("type", [
-  z.object({ type: z.literal("text"), content: z.string().min(1) }),
-  z.object({ type: z.literal("url"), url: z.string().url() }),
-  z.object({
-    type: z.literal("file"),
-    storage_path: z.string().min(1),
-    mime: z.string().optional(),
-    size: z.number().optional(),
-    title: z.string().optional(),
-  }),
-]);
-
+/**
+ * Backend contract alignment: POST /api/dumps/new expects a DumpPayload
+ * containing a basket id, the consolidated text dump, and optional public
+ * file URLs. The previous UI contract forwarded `sources[]` directly; we now
+ * validate and forward the backend shape instead.
+ */
 const BodySchema = z.object({
-  basket_id: z.string().uuid().nullable().optional(),
-  intent: z.string().optional(),
-  sources: z.array(Source).min(1),
+  basket_id: z.string().uuid().nullable(),
+  text_dump: z.string(),
+  file_urls: z.array(z.string().url()).optional(),
 });
 
 export async function POST(req: Request) {


### PR DESCRIPTION
## Summary
- accept nullable basket IDs in `/api/dumps/new` proxy and forward consolidated text and file URLs
- capture backend-assigned basket IDs and raw dump IDs when creating dumps, then trigger follow-up work requests
- proxy basket work requests to the backend with Supabase authentication

## Testing
- `npm test`
- `npm run lint`
- `npm run build:check`

------
https://chatgpt.com/codex/tasks/task_e_689d49d944188329ba3416ce7181ca49