### PR TITLE
feat: use new basket creation contract

### DIFF
--- a/web/ARCHITECTURE_ACTUAL.md
+++ b/web/ARCHITECTURE_ACTUAL.md
@@ -129,7 +129,7 @@ export class ApiClient {
 }
 
 // Usage throughout app
-const result = await apiClient.request('/api/baskets', { method: 'POST', ... });
+const result = await apiClient.request('/api/baskets/new', { method: 'POST', ... });
 ```
 
 ### Authentication Flow:

--- a/web/hooks/useCreateBasket.ts
+++ b/web/hooks/useCreateBasket.ts
@@ -61,16 +61,23 @@ export function useCreateBasket() {
     if (!canSubmit) return;
     setSubmitting(true);
     try {
+      const workspaceId =
+        (typeof window !== "undefined" &&
+          localStorage.getItem("workspace_id")) ||
+        "00000000-0000-0000-0000-000000000001";
       const payload = {
+        workspace_id: workspaceId,
         name: state.basketName || "Untitled Basket",
-        status: "active",
-        tags: [],
+        idempotency_key: crypto.randomUUID(),
       };
-      const { id } = await apiClient.request<{id: string}>("/api/baskets", {
-        method: "POST",
-        body: JSON.stringify(payload),
-      });
-      router.push(`/baskets/${id}/work`);
+      const { basket_id } = await apiClient.request<{ basket_id: string }>(
+        "/api/baskets/new",
+        {
+          method: "POST",
+          body: JSON.stringify(payload),
+        },
+      );
+      router.push(`/baskets/${basket_id}/work`);
       setState(emptyState);
     } finally {
       setSubmitting(false);

--- a/web/lib/api/baskets.ts
+++ b/web/lib/api/baskets.ts
@@ -7,6 +7,7 @@ import {
   type Paginated,
   type CreateBasketRequest,
 } from './contracts';
+import type { CreateBasketRes } from '@shared/contracts/baskets';
 
 /**
  * Basket API functions with Zod validation
@@ -53,18 +54,20 @@ export async function listBaskets(options?: {
 }
 
 // Create new basket
-export async function createBasket(request: CreateBasketRequest): Promise<Basket> {
+export async function createBasket(
+  request: CreateBasketRequest,
+): Promise<CreateBasketRes> {
   // Validate request payload
   const validatedRequest = CreateBasketRequestSchema.parse(request);
-  
+
   const response = await apiClient({
-    url: '/api/baskets',
+    url: '/api/baskets/new',
     method: 'POST',
     body: validatedRequest,
     signal: timeoutSignal(15000),
   });
-  
-  return BasketSchema.parse(response);
+
+  return response as CreateBasketRes;
 }
 
 // Update basket

--- a/web/lib/api/contracts.ts
+++ b/web/lib/api/contracts.ts
@@ -139,9 +139,9 @@ export type ApiError = z.infer<typeof ApiErrorSchema>;
 
 // Request/Response helpers
 export const CreateBasketRequestSchema = z.object({
-  name: z.string(),
-  origin_template: z.string().optional(),
-  tags: z.array(z.string()).optional(),
+  workspace_id: UUIDSchema,
+  name: z.string().optional(),
+  idempotency_key: UUIDSchema,
 });
 
 export type CreateBasketRequest = z.infer<typeof CreateBasketRequestSchema>;

--- a/web/lib/baskets/submit.ts
+++ b/web/lib/baskets/submit.ts
@@ -67,15 +67,18 @@ export function buildContextBlocks(values: BasketValues): ContextBlock[] {
 
 import { apiClient } from "../api/client";
 
-export async function createBasket(values: BasketValues): Promise<{ id: string }> {
+export async function createBasket(values: BasketValues): Promise<{ basket_id: string }> {
+  const workspaceId =
+    (typeof window !== "undefined" &&
+      localStorage.getItem("workspace_id")) ||
+    "00000000-0000-0000-0000-000000000001";
   const payload = {
-    topic: values.topic,
-    intent: values.intent,
-    insight: values.insight,
-    reference_file_ids: values.reference_file_ids,
+    workspace_id: workspaceId,
+    name: values.topic || "Untitled Basket",
+    idempotency_key: crypto.randomUUID(),
   };
-  return apiClient.request<{ id: string }>("/api/baskets", {
+  return apiClient.request<{ basket_id: string }>("/api/baskets/new", {
     method: "POST",
-    body: JSON.stringify(payload)
+    body: JSON.stringify(payload),
   });
 }


### PR DESCRIPTION
## Summary
- switch basket creation to `/api/baskets/new` with `workspace_id`, optional `name`, and `idempotency_key`
- align `CreateBasketRequestSchema` and API wrappers to new contract
- update creation hooks and helpers to provide required fields

## Testing
- `npm test`
- `npm run lint`
- `npm run build:check`

------
https://chatgpt.com/codex/tasks/task_e_689fe933b8f88329bc354bcda2d4a9d8