### PR TITLE
Refactor dump creation request and response

### DIFF
--- a/web/app/api/substrate/add-context/route.ts
+++ b/web/app/api/substrate/add-context/route.ts
@@ -87,7 +87,7 @@ export async function POST(request: NextRequest) {
       .filter(Boolean);
     
     // Create raw_dump using existing function
-    const rawDump = await createDump(basketId, consolidatedContent, fileUrls);
+    const dump = await createDump(basketId, consolidatedContent, fileUrls[0]);
     
     // Trigger immediate background intelligence generation for raw dumps
     try {
@@ -96,7 +96,7 @@ export async function POST(request: NextRequest) {
       triggerBackgroundIntelligenceGeneration({
         basketId,
         origin: 'raw_dump_added',
-        rawDumpId: rawDump.raw_dump_id
+        rawDumpId: dump.dump_id
       });
       
       console.log(`Background intelligence generation triggered for raw dump in basket ${basketId}`);
@@ -107,7 +107,7 @@ export async function POST(request: NextRequest) {
     // Build response
     const result: AddContextResult = {
       success: true,
-      rawDumpId: rawDump.raw_dump_id,
+      rawDumpId: dump.dump_id,
       processingResults: {
         contentProcessed: content.length,
         insights: processingResults?.results ? 'Generated' : 'None',

--- a/web/components/DumpModal.tsx
+++ b/web/components/DumpModal.tsx
@@ -44,7 +44,7 @@ export default function DumpModal({ basketId, initialOpen = false }: DumpModalPr
     }
     setLoading(true);
     try {
-      await createDump(basketId, text, []);
+      await createDump(basketId, text);
       toast.success("Dump saved ✓");
       setOpen(false);
       setText("");

--- a/web/lib/api/adapters/mock.ts
+++ b/web/lib/api/adapters/mock.ts
@@ -247,7 +247,7 @@ export class MockApiAdapter {
       // Create new dump
       const basketId = options.body?.basket_id || mockId('basket-default');
       return {
-        raw_dump_id: mockId(`dump-${basketId}-new`),
+        dump_id: mockId(`dump-${basketId}-new`),
         status: 'created',
         processing: 'triggered',
       };

--- a/web/lib/api/contracts.ts
+++ b/web/lib/api/contracts.ts
@@ -180,9 +180,10 @@ export const RawDumpSchema = z.object({
 export type RawDump = z.infer<typeof RawDumpSchema>;
 
 export const CreateDumpRequestSchema = z.object({
+  dump_request_id: UUIDSchema,
   basket_id: UUIDSchema,
   text_dump: z.string(),
-  file_urls: z.array(z.string()).optional(),
+  file_url: z.string().optional(),
 });
 
 export type CreateDumpRequest = z.infer<typeof CreateDumpRequestSchema>;

--- a/web/lib/api/dumps.ts
+++ b/web/lib/api/dumps.ts
@@ -11,23 +11,27 @@ import {
  */
 
 // Create new raw dump
-export async function createDump(request: CreateDumpRequest): Promise<{
-  raw_dump_id: string;
+export async function createDump(
+  request: Omit<CreateDumpRequest, 'dump_request_id'>,
+): Promise<{
+  dump_id: string;
   status: string;
   processing: string;
 }> {
+  const payload = { ...request, dump_request_id: crypto.randomUUID() };
+
   // Validate request payload
-  const validatedRequest = CreateDumpRequestSchema.parse(request);
-  
+  const validatedRequest = CreateDumpRequestSchema.parse(payload);
+
   const response = await apiClient({
     url: '/api/dumps/new',
     method: 'POST',
     body: validatedRequest,
     signal: timeoutSignal(20000), // Longer timeout for processing
   });
-  
+
   return response as {
-    raw_dump_id: string;
+    dump_id: string;
     status: string;
     processing: string;
   };

--- a/web/lib/dumps/createDump.ts
+++ b/web/lib/dumps/createDump.ts
@@ -2,15 +2,18 @@ import { apiClient } from "@/lib/api/client";
 
 export async function createDump(
   basketId: string,
-  body_md: string,
-  file_refs: string[] = [],
-): Promise<{ raw_dump_id: string }> {
-  return apiClient.request<{ raw_dump_id: string }>("/api/dumps/new", {
+  textDump: string,
+  fileUrl?: string,
+): Promise<{ dump_id: string }> {
+  const dumpRequestId = crypto.randomUUID();
+
+  return apiClient.request<{ dump_id: string }>("/api/dumps/new", {
     method: "POST",
     body: JSON.stringify({
       basket_id: basketId,
-      text_dump: body_md,  // Map body_md → text_dump for backend
-      file_urls: file_refs || []  // Map file_refs → file_urls for backend
-    })
+      dump_request_id: dumpRequestId,
+      text_dump: textDump, // Map body_md → text_dump for backend
+      ...(fileUrl ? { file_url: fileUrl } : {}),
+    }),
   });
 }

--- a/web/lib/substrate/SubstrateService.ts
+++ b/web/lib/substrate/SubstrateService.ts
@@ -90,13 +90,13 @@ export class SubstrateService {
       
       // Use API route instead of direct Supabase insert
       // This ensures events are fired and proper processing happens
-      const result = await createDump(basketId, content, []);
+      const result = await createDump(basketId, content);
       
       // Fetch the created dump to return full data
       const { data, error } = await this.supabase
         .from('raw_dumps')
         .select('*')
-        .eq('id', result.raw_dump_id)
+        .eq('id', result.dump_id)
         .single();
       
       if (error) throw new Error(`Failed to fetch created dump: ${error.message}`);


### PR DESCRIPTION
## Summary
- support new dump creation contract with `dump_request_id` and optional `file_url`
- generate request ids and expect `dump_id` in API responses
- update dump callers and mock adapter for new response shape

## Testing
- `npm test`
- `npm run lint` *(fails: 'NodeJS' is not defined, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689fe9338e4c8329894d086c67042820