### PR TITLE
feat: add basket ingest endpoint

### DIFF
--- a/shared/contracts/baskets.ts
+++ b/shared/contracts/baskets.ts
@@ -1,9 +1,13 @@
-export type CreateBasketReq = {
-  workspace_id: string;
-  name?: string;
-  idempotency_key: string; // UUID
-};
+import { z } from 'zod';
 
-export type CreateBasketRes = { 
-  basket_id: string; 
-};
+export const CreateBasketReqSchema = z.object({
+  workspace_id: z.string().uuid(),
+  name: z.string().optional(),
+  idempotency_key: z.string().uuid(),
+});
+export type CreateBasketReq = z.infer<typeof CreateBasketReqSchema>;
+
+export const CreateBasketResSchema = z.object({
+  basket_id: z.string().uuid(),
+});
+export type CreateBasketRes = z.infer<typeof CreateBasketResSchema>;

--- a/shared/contracts/dumps.ts
+++ b/shared/contracts/dumps.ts
@@ -1,11 +1,15 @@
-export type CreateDumpReq = {
-  basket_id: string;
-  dump_request_id: string; // UUID
-  text_dump?: string;
-  file_url?: string;
-  meta?: Record<string, unknown>;
-};
+import { z } from 'zod';
 
-export type CreateDumpRes = { 
-  dump_id: string; 
-};
+export const CreateDumpReqSchema = z.object({
+  basket_id: z.string().uuid(),
+  dump_request_id: z.string().uuid(),
+  text_dump: z.string().optional(),
+  file_url: z.string().url().optional(),
+  meta: z.record(z.any()).optional(),
+});
+export type CreateDumpReq = z.infer<typeof CreateDumpReqSchema>;
+
+export const CreateDumpResSchema = z.object({
+  dump_id: z.string().uuid(),
+});
+export type CreateDumpRes = z.infer<typeof CreateDumpResSchema>;

--- a/shared/contracts/ingest.ts
+++ b/shared/contracts/ingest.ts
@@ -1,17 +1,26 @@
-import type { CreateBasketReq, CreateBasketRes } from "./baskets";
+import { z } from 'zod';
 
-export type IngestItem = {
-  dump_request_id: string; // UUID
-  text_dump?: string;
-  file_url?: string;
-  meta?: Record<string, unknown>;
-};
+export const IngestDumpSchema = z.object({
+  dump_request_id: z.string().uuid(),
+  text_dump: z.string().optional(),
+  file_urls: z.array(z.string()).optional(),
+});
+export type IngestDump = z.infer<typeof IngestDumpSchema>;
 
-export type IngestReq = CreateBasketReq & { 
-  items: IngestItem[]; 
-};
+export const IngestReqSchema = z.object({
+  idempotency_key: z.string().uuid(),
+  basket: z.object({ name: z.string().optional() }).optional(),
+  dumps: z.array(IngestDumpSchema),
+});
+export type IngestReq = z.infer<typeof IngestReqSchema>;
 
-export type IngestRes = { 
-  basket_id: string; 
-  dump_ids: string[]; 
-};
+export const IngestResSchema = z.object({
+  workspace_id: z.string().uuid(),
+  basket: z.object({ id: z.string().uuid(), created: z.boolean() }),
+  dumps: z.array(z.object({
+    id: z.string().uuid(),
+    dump_request_id: z.string().uuid(),
+    created: z.boolean(),
+  })),
+});
+export type IngestRes = z.infer<typeof IngestResSchema>;

--- a/supabase/migrations/20250816_ingest_basket_and_dumps.sql
+++ b/supabase/migrations/20250816_ingest_basket_and_dumps.sql
@@ -1,0 +1,66 @@
+-- Unique indexes for idempotency
+CREATE UNIQUE INDEX IF NOT EXISTS ux_baskets_ws_idempo
+ON public.baskets (workspace_id, idempotency_key)
+WHERE idempotency_key IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_raw_dumps_ws_dumpreq
+ON public.raw_dumps (workspace_id, dump_request_id)
+WHERE dump_request_id IS NOT NULL;
+
+-- Function to atomically ingest basket and dumps
+CREATE OR REPLACE FUNCTION public.ingest_basket_and_dumps(
+  p_workspace_id uuid,
+  p_idempotency_key text,
+  p_basket_name text,
+  p_dumps jsonb
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_basket_id uuid;
+  v_basket_created boolean := false;
+  v_dump jsonb;
+  v_dump_id uuid;
+  v_dump_created boolean;
+  v_out jsonb := jsonb_build_object();
+  v_dump_results jsonb := '[]'::jsonb;
+BEGIN
+  -- basket (create or replay)
+  INSERT INTO public.baskets (workspace_id, idempotency_key, name)
+  VALUES (p_workspace_id, p_idempotency_key, p_basket_name)
+  ON CONFLICT (workspace_id, idempotency_key) DO UPDATE
+    SET name = COALESCE(EXCLUDED.name, public.baskets.name)
+  RETURNING id, (xmax = 0) INTO v_basket_id, v_basket_created;
+
+  -- dumps
+  FOR v_dump IN SELECT * FROM jsonb_array_elements(p_dumps)
+  LOOP
+    INSERT INTO public.raw_dumps (workspace_id, dump_request_id, text_dump, file_urls)
+    VALUES (
+      p_workspace_id,
+      (v_dump->>'dump_request_id'),
+      (v_dump->>'text_dump'),
+      COALESCE((v_dump->'file_urls')::text[], '{}')
+    )
+    ON CONFLICT (workspace_id, dump_request_id) DO UPDATE
+      SET text_dump = COALESCE(EXCLUDED.text_dump, public.raw_dumps.text_dump)
+    RETURNING id, (xmax = 0) INTO v_dump_id, v_dump_created;
+
+    v_dump_results := v_dump_results || jsonb_build_object(
+      'id', v_dump_id,
+      'dump_request_id', v_dump->>'dump_request_id',
+      'created', v_dump_created
+    );
+  END LOOP;
+
+  v_out := jsonb_build_object(
+    'workspace_id', p_workspace_id,
+    'basket', jsonb_build_object('id', v_basket_id, 'created', v_basket_created),
+    'dumps', v_dump_results
+  );
+  RETURN v_out;
+END $$;
+
+-- Allow authenticated users to invoke
+GRANT EXECUTE ON FUNCTION public.ingest_basket_and_dumps(uuid, text, text, jsonb) TO authenticated;

--- a/tests/baskets-ingest.spec.ts
+++ b/tests/baskets-ingest.spec.ts
@@ -1,0 +1,41 @@
+import { test, expect } from '@playwright/test';
+import { randomUUID } from 'crypto';
+import { getTestJwt } from './utils/auth';
+
+test.describe('Basket ingest API', () => {
+  test('creates basket and dumps atomically with idempotency', async ({ request }) => {
+    const jwt = await getTestJwt();
+    const idempotencyKey = randomUUID();
+    const dumpReq1 = randomUUID();
+    const dumpReq2 = randomUUID();
+
+    const payload = {
+      idempotency_key: idempotencyKey,
+      basket: { name: 'Combined Ingest' },
+      dumps: [
+        { dump_request_id: dumpReq1, text_dump: 'First dump' },
+        { dump_request_id: dumpReq2, text_dump: 'Second dump' },
+      ],
+    };
+
+    const res1 = await request.post('/api/baskets/ingest', {
+      headers: { Authorization: `Bearer ${jwt}` },
+      data: payload,
+    });
+    expect(res1.ok()).toBeTruthy();
+    const data1 = await res1.json();
+    expect(data1.basket.created).toBe(true);
+    expect(data1.dumps).toHaveLength(2);
+
+    const res2 = await request.post('/api/baskets/ingest', {
+      headers: { Authorization: `Bearer ${jwt}` },
+      data: payload,
+    });
+    expect(res2.ok()).toBeTruthy();
+    const data2 = await res2.json();
+    expect(data2.basket.created).toBe(false);
+    for (const d of data2.dumps) {
+      expect(d.created).toBe(false);
+    }
+  });
+});

--- a/tests/utils/auth.ts
+++ b/tests/utils/auth.ts
@@ -1,0 +1,13 @@
+import fs from 'fs';
+import path from 'path';
+
+export async function getTestJwt(): Promise<string> {
+  const statePath = path.resolve(__dirname, '..', '..', 'storageState.json');
+  const raw = await fs.promises.readFile(statePath, 'utf-8');
+  const state = JSON.parse(raw);
+  const cookie = state.cookies.find((c: any) => c.name.endsWith('auth-token'));
+  if (!cookie) throw new Error('auth cookie missing');
+  const value = decodeURIComponent(cookie.value);
+  const [access] = JSON.parse(value);
+  return access;
+}

--- a/web/app/api/baskets/ingest/route.ts
+++ b/web/app/api/baskets/ingest/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { IngestReqSchema } from '@shared/contracts/ingest';
+import { getAuthenticatedUser, ensureWorkspaceForUser } from '@/lib/server/auth';
+import { ingestBasketAndDumps } from '@/lib/server/ingest';
+
+export async function POST(req: NextRequest) {
+  try {
+    const { userId } = await getAuthenticatedUser(req);
+    const workspaceId = await ensureWorkspaceForUser(userId);
+    const body = IngestReqSchema.parse(await req.json());
+    const res = await ingestBasketAndDumps({ workspaceId, userId, ...body });
+    console.log(
+      JSON.stringify({
+        route: '/api/baskets/ingest',
+        user_id: userId,
+        workspace_id: workspaceId,
+        basket: res.basket.created ? 'created' : 'replayed',
+        dumps: res.dumps.map((d) => ({
+          dump_request_id: d.dump_request_id,
+          action: d.created ? 'created' : 'replayed',
+        })),
+      }),
+    );
+    return NextResponse.json(res, { status: 200 });
+  } catch (err) {
+    if (err instanceof z.ZodError) {
+      return NextResponse.json({ error: err.message }, { status: 422 });
+    }
+    if (err instanceof Error && err.message === 'Unauthorized') {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    console.error('ingest route error', err);
+    return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
+  }
+}

--- a/web/lib/server/auth.ts
+++ b/web/lib/server/auth.ts
@@ -1,0 +1,53 @@
+import { NextRequest } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import type { Database } from '@/lib/dbTypes';
+import { createServiceRoleClient } from '@/lib/supabase/serviceRole';
+
+export async function getAuthenticatedUser(req: NextRequest) {
+  const auth = req.headers.get('authorization');
+  if (!auth || !auth.startsWith('Bearer ')) {
+    throw new Error('Unauthorized');
+  }
+  const token = auth.slice(7);
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  if (!url || !anon) {
+    throw new Error('Missing Supabase env vars');
+  }
+  const supabase = createClient<Database>(url, anon, {
+    global: { headers: { Authorization: `Bearer ${token}` } },
+    auth: { persistSession: false },
+  });
+  const { data: { user }, error } = await supabase.auth.getUser();
+  if (error || !user) {
+    throw new Error('Unauthorized');
+  }
+  return { userId: user.id };
+}
+
+export async function ensureWorkspaceForUser(userId: string) {
+  const supabase = createServiceRoleClient();
+  const { data: membership } = await supabase
+    .from('workspace_memberships')
+    .select('workspace_id')
+    .eq('user_id', userId)
+    .limit(1)
+    .single();
+  if (membership?.workspace_id) return membership.workspace_id;
+
+  const { data: workspace, error: workspaceErr } = await supabase
+    .from('workspaces')
+    .insert({ owner_id: userId, name: 'Default Workspace' })
+    .select('id')
+    .single();
+  if (workspaceErr || !workspace) {
+    throw new Error('Failed to create workspace');
+  }
+  const { error: membershipErr } = await supabase
+    .from('workspace_memberships')
+    .insert({ user_id: userId, workspace_id: workspace.id, role: 'owner' });
+  if (membershipErr) {
+    throw new Error('Failed to create membership');
+  }
+  return workspace.id;
+}

--- a/web/lib/server/ingest.ts
+++ b/web/lib/server/ingest.ts
@@ -1,0 +1,25 @@
+import { createServiceRoleClient } from '@/lib/supabase/serviceRole';
+import type { IngestRes } from '@shared/contracts/ingest';
+
+interface IngestArgs {
+  workspaceId: string;
+  userId: string;
+  idempotency_key: string;
+  basket?: { name?: string };
+  dumps: Array<{ dump_request_id: string; text_dump?: string; file_urls?: string[] }>;
+}
+
+export async function ingestBasketAndDumps(args: IngestArgs): Promise<IngestRes> {
+  const supabase = createServiceRoleClient();
+  const payload = {
+    p_workspace_id: args.workspaceId,
+    p_idempotency_key: args.idempotency_key,
+    p_basket_name: args.basket?.name ?? null,
+    p_dumps: JSON.stringify(args.dumps),
+  };
+  const { data, error } = await supabase.rpc('ingest_basket_and_dumps', payload);
+  if (error) {
+    throw new Error(error.message);
+  }
+  return data as IngestRes;
+}


### PR DESCRIPTION
## Summary
- add SQL function for transactional basket/dump ingest with idempotency
- expose `/api/baskets/ingest` route validating payload and logging replayed/created dumps
- cover combined ingest and idempotency via Playwright test

## Testing
- `npm run lint`
- `npm run e2e:test tests/baskets-ingest.spec.ts` *(fails: Process from config.webServer was not able to start. Exit code: 127)*
- `npm run build:check` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689fe92bb0308329aa4dd95ce1b75cbe