### PR TITLE
feat: verify Supabase JWTs via JWKS

### DIFF
--- a/api/src/app/agent_server.py
+++ b/api/src/app/agent_server.py
@@ -1,18 +1,20 @@
-# api/src/app/agent_server.py — deterministic handoffs via SDK `handoff()` with robust error handling
+# RightNow Agent Server entrypoint with robust error handling
+# ruff: noqa: E402
 
 from __future__ import annotations
 
+import logging
 import os
 import sys
-import logging
+from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from contextlib import asynccontextmanager
 
-# Extend sys.path: ensure 'api/src' is added before 'api/src/app' so sibling packages resolve correctly
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), "..")))
-sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+# Extend sys.path so sibling packages resolve correctly
+base_dir = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(os.path.abspath(os.path.join(base_dir, "..")))
+sys.path.append(base_dir)
 
 try:
     from dotenv import load_dotenv
@@ -21,42 +23,48 @@ except ImportError:
     pass
 
 # Route imports
+from middleware.auth import AuthMiddleware
+
 from .agent_entrypoints import router as agent_router, run_agent, run_agent_direct
+from .deps import close_db
+from .routes.agent_memory import router as agent_memory_router
 from .routes.agent_run import router as agent_run_router
 from .routes.agents import router as agents_router
+from .routes.basket_from_template import router as template_router
 from .routes.basket_new import router as basket_new_router
 from .routes.basket_snapshot import router as snapshot_router
 from .routes.baskets import router as basket_router
+from .routes.block_lifecycle import router as block_lifecycle_router
 from .routes.blocks import router as blocks_router
-from .routes.basket_from_template import router as template_router
 from .routes.change_queue import router as change_queue_router
 from .routes.commits import router as commits_router
+from .routes.context_blocks_create import router as context_blocks_create_router
+from .routes.context_intelligence import router as context_intelligence_router
+from .routes.context_items import router as context_items_router
 from .routes.debug import router as debug_router
 from .routes.dump_new import router as dump_new_router
 from .routes.inputs import router as inputs_router
-from .routes.phase1_routes import router as phase1_router
-from .routes.context_blocks_create import router as context_blocks_create_router  # new block creation modal router
-from .routes.context_items import router as context_items_router
-from .routes.block_lifecycle import router as block_lifecycle_router
-from .routes.agent_memory import router as agent_memory_router
-from .routes.context_intelligence import router as context_intelligence_router
 from .routes.narrative_intelligence import router as narrative_intelligence_router
 from .routes.narrative_jobs import router as narrative_jobs_router
-from .deps import close_db
+from .routes.phase1_routes import router as phase1_router
+
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     # Startup
     logger = logging.getLogger("uvicorn.error")
     logger.info("Starting RightNow Agent Server")
-    
+
     yield
-    
+
     # Shutdown
     logger.info("Shutting down RightNow Agent Server")
     await close_db()
 
 app = FastAPI(title="RightNow Agent Server", lifespan=lifespan)
+
+# Require JWT auth on API routes
+app.add_middleware(AuthMiddleware, exempt_paths={"/", "/health/db"})
 
 # Include routers
 routers = (
@@ -72,7 +80,7 @@ routers = (
     agent_run_router,
     agents_router,
     phase1_router,
-    context_blocks_create_router,  # new block creation modal router
+    context_blocks_create_router,
     context_items_router,
     block_lifecycle_router,
     agent_memory_router,
@@ -115,7 +123,7 @@ async def health_db():
     except Exception as e:
         logger.error(f"Database health check failed: {e}")
         return {
-            "status": "unhealthy", 
+            "status": "unhealthy",
             "database_connected": False,
             "error": str(e)
         }

--- a/api/src/app/utils/jwt.py
+++ b/api/src/app/utils/jwt.py
@@ -2,40 +2,14 @@
 
 from __future__ import annotations
 
-import logging
-from typing import Annotated
-
-import jwt
-from fastapi import Header, HTTPException
-
-logger = logging.getLogger("uvicorn.error")
+from fastapi import HTTPException, Request
 
 
-def verify_jwt(
-    sb_access_token: Annotated[str | None, Header(alias="sb-access-token")] = None,
-    authorization: Annotated[str | None, Header()] = None,
-) -> dict[str, str]:
-    """Return the caller's user ID extracted from a Supabase JWT."""
+def verify_jwt(request: Request) -> dict[str, str]:
+    """Return the caller's user ID, set by :class:`AuthMiddleware`."""
 
-    token = sb_access_token
-    if not token and authorization:
-        if authorization.lower().startswith("bearer "):
-            token = authorization.split(" ", 1)[1]
-        else:
-            token = authorization
-
-    if not token:
-        logger.debug("verify_jwt missing token")
-        raise HTTPException(status_code=401, detail="Missing authentication token")
-
-    try:
-        payload = jwt.decode(token, options={"verify_signature": False})
-        user_id = payload.get("sub")
-        if not user_id:
-            raise KeyError
-    except Exception as exc:  # noqa: BLE001
-        logger.warning("verify_jwt invalid token: %s", exc)
-        raise HTTPException(status_code=401, detail="Invalid authentication token") from exc
-
+    user_id = getattr(request.state, "user_id", None)
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Invalid authentication token")
     return {"user_id": str(user_id)}
 

--- a/api/src/auth/__init__.py
+++ b/api/src/auth/__init__.py
@@ -1,0 +1,4 @@
+"""Authentication utilities and helpers."""
+
+__all__ = ["jwt_verifier"]
+

--- a/api/src/auth/jwt_verifier.py
+++ b/api/src/auth/jwt_verifier.py
@@ -1,0 +1,75 @@
+"""Supabase JWT verification using JWKS with caching."""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+
+import jwt
+import requests
+from jwt import InvalidTokenError
+
+# JWKS caching
+_JWKS_CACHE: dict[str, dict] = {}
+_JWKS_LAST_FETCH: float = 0
+_JWKS_TTL = 60 * 5  # 5 minutes
+
+
+def _jwks_url() -> str:
+    base_url = os.getenv("SUPABASE_URL")
+    if not base_url:
+        raise RuntimeError("SUPABASE_URL not configured")
+    return f"{base_url.rstrip('/')}/auth/v1/keys"
+
+
+def _expected_issuer() -> str:
+    base_url = os.getenv("SUPABASE_URL")
+    return os.getenv("SUPABASE_JWT_ISS", f"{base_url.rstrip('/')}/auth/v1")
+
+
+def _expected_audience() -> str:
+    return os.getenv("SUPABASE_JWT_AUD", "authenticated")
+
+
+def _fetch_jwks(force: bool = False) -> dict[str, dict]:
+    """Fetch JWKS and cache results."""
+    global _JWKS_CACHE, _JWKS_LAST_FETCH
+    now = time.time()
+    if force or now - _JWKS_LAST_FETCH > _JWKS_TTL or not _JWKS_CACHE:
+        resp = requests.get(_jwks_url(), timeout=5)
+        resp.raise_for_status()
+        data = resp.json()
+        _JWKS_CACHE = {jwk["kid"]: jwk for jwk in data.get("keys", [])}
+        _JWKS_LAST_FETCH = now
+    return _JWKS_CACHE
+
+
+def _get_key(kid: str):
+    jwks = _fetch_jwks()
+    if kid not in jwks:
+        jwks = _fetch_jwks(force=True)
+    jwk = jwks.get(kid)
+    if not jwk:
+        raise InvalidTokenError("Unknown key id")
+    return jwt.algorithms.RSAAlgorithm.from_jwk(json.dumps(jwk))
+
+
+def verify_jwt(token: str) -> dict:
+    """Verify a Supabase JWT and return its payload."""
+    header = jwt.get_unverified_header(token)
+    kid = header.get("kid")
+    if not kid:
+        raise InvalidTokenError("Missing kid")
+    key = _get_key(kid)
+    return jwt.decode(
+        token,
+        key,
+        algorithms=["RS256"],
+        issuer=_expected_issuer(),
+        audience=_expected_audience(),
+    )
+
+
+__all__ = ["verify_jwt"]
+

--- a/api/src/middleware/__init__.py
+++ b/api/src/middleware/__init__.py
@@ -1,0 +1,4 @@
+"""Custom FastAPI middleware packages."""
+
+__all__ = ["auth"]
+

--- a/api/src/middleware/auth.py
+++ b/api/src/middleware/auth.py
@@ -1,0 +1,59 @@
+"""FastAPI middleware to enforce JWT authentication."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from auth.jwt_verifier import verify_jwt
+from fastapi import Request
+from fastapi.responses import JSONResponse
+from starlette.middleware.base import BaseHTTPMiddleware
+
+
+class AuthMiddleware(BaseHTTPMiddleware):
+    """Validate Supabase JWTs on protected routes."""
+
+    def __init__(self, app, exempt_paths: Iterable[str] | None = None) -> None:
+        super().__init__(app)
+        self.exempt_paths = set(exempt_paths or [])
+
+    async def dispatch(self, request: Request, call_next):  # type: ignore[override]
+        if any(request.url.path.startswith(p) for p in self.exempt_paths):
+            return await call_next(request)
+
+        token = request.headers.get("sb-access-token")
+        if not token:
+            auth = request.headers.get("Authorization")
+            if auth and auth.lower().startswith("bearer "):
+                token = auth.split(" ", 1)[1]
+
+        if not token:
+            return JSONResponse(
+                status_code=401,
+                content={
+                    "error": {
+                        "code": "UNAUTHORIZED",
+                        "message": "Missing authentication token",
+                    }
+                },
+            )
+
+        try:
+            payload = verify_jwt(token)
+        except Exception:  # noqa: BLE001
+            return JSONResponse(
+                status_code=401,
+                content={
+                    "error": {
+                        "code": "UNAUTHORIZED",
+                        "message": "Invalid authentication token",
+                    }
+                },
+            )
+
+        request.state.user_id = payload.get("sub")
+        return await call_next(request)
+
+
+__all__ = ["AuthMiddleware"]
+

--- a/api/tests/test_jwt_verifier.py
+++ b/api/tests/test_jwt_verifier.py
@@ -1,0 +1,96 @@
+"""Tests for JWKS-backed JWT verification."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import time
+
+import jwt
+import pytest
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+
+@pytest.fixture()
+def jwks_env(monkeypatch):
+    """Provide a mock JWKS endpoint and return signing key and module."""
+
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    public_key = private_key.public_key()
+    public_jwk = json.loads(jwt.algorithms.RSAAlgorithm.to_jwk(public_key))
+    public_jwk["kid"] = "test-kid"
+
+    jwks = {"keys": [public_jwk]}
+
+    monkeypatch.setenv("SUPABASE_URL", "https://example.supabase.co")
+
+    import auth.jwt_verifier as jv
+
+    def mock_get(url, timeout=5):  # noqa: D401
+        class Resp:
+            status_code = 200
+
+            def json(self):
+                return jwks
+
+            def raise_for_status(self):
+                pass
+
+        return Resp()
+
+    monkeypatch.setattr(jv.requests, "get", mock_get)
+    importlib.reload(jv)
+
+    # reset cache
+    jv._JWKS_CACHE.clear()
+    jv._JWKS_LAST_FETCH = 0
+
+    return private_key, jv
+
+
+def _create_token(key, **claims):
+    payload = {
+        "sub": "user123",
+        "iss": "https://example.supabase.co/auth/v1",
+        "aud": "authenticated",
+        "exp": int(time.time()) + 60,
+    }
+    payload.update(claims)
+    return jwt.encode(payload, key, algorithm="RS256", headers={"kid": "test-kid"})
+
+
+def test_valid_token(jwks_env):
+    key, jv = jwks_env
+    token = _create_token(key)
+    payload = jv.verify_jwt(token)
+    assert payload["sub"] == "user123"
+
+
+def test_expired_token(jwks_env):
+    key, jv = jwks_env
+    token = _create_token(key, exp=int(time.time()) - 10)
+    with pytest.raises(jwt.ExpiredSignatureError):
+        jv.verify_jwt(token)
+
+
+def test_wrong_issuer(jwks_env):
+    key, jv = jwks_env
+    token = _create_token(key, iss="https://other.example.com")
+    with pytest.raises(jwt.InvalidIssuerError):
+        jv.verify_jwt(token)
+
+
+def test_wrong_audience(jwks_env):
+    key, jv = jwks_env
+    token = _create_token(key, aud="other")
+    with pytest.raises(jwt.InvalidAudienceError):
+        jv.verify_jwt(token)
+
+
+def test_forged_token_rejected(jwks_env):
+    _, jv = jwks_env
+    other_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    token = _create_token(other_key)
+    with pytest.raises(jwt.InvalidTokenError):
+        jv.verify_jwt(token)
+

--- a/docs/YARNNN_AUTH_WORKFLOW.md
+++ b/docs/YARNNN_AUTH_WORKFLOW.md
@@ -1,4 +1,4 @@
-📜 /docs/AUTH_WORKFLOW.md — Canonical Authentication & Workspace Flow (v1)
+📜 docs/YARNNN_AUTH_WORKFLOW.md — Canonical Authentication & Workspace Flow (v1)
 This document is the source of truth. All code MUST conform to it.
 Terms: “MUST/SHALL/SHOULD” follow RFC-2119 semantics.
 ## 0) Scope & Guarantees


### PR DESCRIPTION
## Summary
- fix auth workflow doc header
- add JWKS-based JWT verifier with caching
- enforce auth via middleware and expose user id
- cover valid and invalid tokens in tests

## Testing
- `uv run pre-commit run --files docs/YARNNN_AUTH_WORKFLOW.md api/src/app/agent_server.py api/src/app/utils/auth_helpers.py api/src/app/utils/jwt.py api/src/auth/jwt_verifier.py api/src/auth/__init__.py api/src/middleware/auth.py api/src/middleware/__init__.py api/tests/test_jwt_verifier.py`
- `PYTHONPATH=src:api/src uv run pytest api/tests/test_jwt_verifier.py`

------
https://chatgpt.com/codex/tasks/task_e_689ff0bfaaa483299d8aa9e55224af88