### PR TITLE
Bootstrap workspace on basket creation

### DIFF
--- a/api/src/app/baskets/schemas.py
+++ b/api/src/app/baskets/schemas.py
@@ -35,6 +35,5 @@ class BasketWorkRequest(BaseModel):
 class CreateBasketReq(BaseModel):
     """DTO matching the CreateBasketReq contract."""
 
-    workspace_id: str
     idempotency_key: str
     name: Optional[str] = "Untitled Basket"

--- a/api/tests/api/test_basket_flow.py
+++ b/api/tests/api/test_basket_flow.py
@@ -63,7 +63,6 @@ def test_create_and_list(monkeypatch):
     monkeypatch.setattr("app.routes.basket_new.supabase", fake)
 
     payload = {
-        "workspace_id": "ws1",
         "idempotency_key": str(uuid.uuid4()),
     }
 
@@ -76,12 +75,13 @@ def test_create_and_list(monkeypatch):
     assert items.data[0]["id"] == bid
 
 
-def test_create_forbidden(monkeypatch):
-    store = {"workspace_memberships": [], "baskets": []}
+def test_auto_workspace(monkeypatch):
+    store = {"workspace_memberships": [], "baskets": [], "workspaces": []}
     fake = _supabase(store)
     monkeypatch.setattr("app.routes.basket_new.supabase", fake)
 
-    payload = {"workspace_id": "ws1", "idempotency_key": str(uuid.uuid4())}
+    payload = {"idempotency_key": str(uuid.uuid4())}
     resp = client.post("/api/baskets/new", json=payload)
-    assert resp.status_code == 403
+    assert resp.status_code == 201
+    assert store["workspaces"]
 

--- a/api/tests/api/test_new_snapshot_flow.py
+++ b/api/tests/api/test_new_snapshot_flow.py
@@ -92,7 +92,7 @@ def test_snapshot_after_flow(monkeypatch):
     monkeypatch.setattr("app.routes.dump_new.supabase", fake)
     monkeypatch.setattr("app.routes.basket_snapshot.supabase", fake)
 
-    b_payload = {"workspace_id": "ws1", "idempotency_key": str(uuid.uuid4())}
+    b_payload = {"idempotency_key": str(uuid.uuid4())}
     basket = client.post("/api/baskets/new", json=b_payload)
     bid = basket.json()["basket_id"]
 

--- a/docs/YARNNN_AUTH_WORKFLOW.md
+++ b/docs/YARNNN_AUTH_WORKFLOW.md
@@ -89,13 +89,13 @@ Create Basket
 POST /api/baskets/new
 Authorization: Bearer <jwt>
 
-Body: { "name": "My Basket" }
+Body: { "name": "My Basket", "idempotency_key": "<uuid>" }
 
 Behavior:
 - Verify JWT → userId
-- workspaceId = ensureWorkspaceForUser(userId)
-- Insert baskets(name, workspace_id)
-- Return { id, name, workspace_id }
+- workspace = ensureWorkspaceForUser(userId)
+- Insert baskets(name, workspace_id=workspace.id, idempotency_key)
+- Return { basket_id }
 Create Raw Dump
 POST /api/dumps/new
 Authorization: Bearer <jwt>

--- a/docs/YARNNN_CANON.md
+++ b/docs/YARNNN_CANON.md
@@ -21,7 +21,7 @@ Schema, API, and runtime implementations must conform to these references.
 - **YARNNN_INGESTION_FLOW.md**  
   Contracts and flow for atomic basket + dump ingestion.  
 
-- **YARNNN_INTERFACE_SPEC_v.1.0.md**  
+- **YARNNN_INTERFACE_SPEC_v0.1.0.md**
   API and DTO contracts for baskets, dumps, and ingestion flows.  
 
 - **YARNNN_MEMORY_MODEL.md**  

--- a/docs/YARNNN_MONOREPO_ARCHITECTURE.md
+++ b/docs/YARNNN_MONOREPO_ARCHITECTURE.md
@@ -30,7 +30,7 @@ These are peers in the substrate; agents operate across them.
 - **Baskets:** `/api/baskets/new`, `/api/baskets/ingest`  
 - **Dumps:** `/api/dumps/new`  
 - **Blocks:** `/api/blocks/*`  
-- **Documents:** `/api/document-composition`  
+- **Documents:** `/api/documents`
 - **Events:** WebSocket endpoints for real-time updates  
 
 ## Frontend

--- a/shared/contracts/baskets.ts
+++ b/shared/contracts/baskets.ts
@@ -1,7 +1,6 @@
 import { z } from 'zod';
 
 export const CreateBasketReqSchema = z.object({
-  workspace_id: z.string().uuid(),
   name: z.string().optional(),
   idempotency_key: z.string().uuid(),
 });

--- a/shared/contracts/ingest.ts
+++ b/shared/contracts/ingest.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import type { CreateBasketReq, CreateBasketRes } from "./baskets";
+import type { CreateBasketRes } from "./baskets";
 import type { CreateDumpRes } from "./dumps";
 
 // Ingest dump schema
@@ -16,7 +16,7 @@ export const IngestReqSchema = z.object({
   basket: z.object({ name: z.string().optional() }).optional(),
   dumps: z.array(IngestDumpSchema),
 });
-export type IngestReq = CreateBasketReq & { items: IngestDump[] };
+export type IngestReq = z.infer<typeof IngestReqSchema>;
 
 // Ingest response schema
 export const IngestResSchema = z.object({
@@ -30,6 +30,6 @@ export const IngestResSchema = z.object({
     })
   ),
 });
-export type IngestRes = CreateBasketRes & { dumps: CreateDumpRes[] };
+export type IngestRes = z.infer<typeof IngestResSchema>;
 
 export type { CreateDumpRes };

--- a/tests/idempotency-golden-path.spec.ts
+++ b/tests/idempotency-golden-path.spec.ts
@@ -120,7 +120,6 @@ test.describe('Idempotency Golden Path', () => {
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
         body: JSON.stringify({
-          workspace_id: '00000000-0000-0000-0000-000000000001',
           name: 'Test Basket',
           idempotency_key: 'invalid-uuid'
         })
@@ -151,8 +150,7 @@ test.describe('Idempotency Golden Path', () => {
     
     // Create a basket with known idempotency key
     const idempotencyKey = crypto.randomUUID();
-    const workspaceId = '00000000-0000-0000-0000-000000000001';
-    
+
     const firstRequest = await page.evaluate(async (data) => {
       return await fetch('/api/baskets/new', {
         method: 'POST',
@@ -160,7 +158,7 @@ test.describe('Idempotency Golden Path', () => {
         credentials: 'include',
         body: JSON.stringify(data)
       }).then(res => ({ status: res.status, body: res.json() }));
-    }, { workspace_id: workspaceId, name: 'Test Basket', idempotency_key: idempotencyKey });
+    }, { name: 'Test Basket', idempotency_key: idempotencyKey });
     
     expect(firstRequest.status).toBe(201); // Created
     
@@ -172,7 +170,7 @@ test.describe('Idempotency Golden Path', () => {
         credentials: 'include',
         body: JSON.stringify(data)
       }).then(res => ({ status: res.status, body: res.json() }));
-    }, { workspace_id: workspaceId, name: 'Test Basket', idempotency_key: idempotencyKey });
+    }, { name: 'Test Basket', idempotency_key: idempotencyKey });
     
     expect(replayRequest.status).toBe(200); // Replayed
     

--- a/web/components/create/useCreatePageMachine.ts
+++ b/web/components/create/useCreatePageMachine.ts
@@ -202,16 +202,12 @@ useEffect(() => {
         return;
       }
 
-      // Get workspace_id (use ensureWorkspaceServer pattern or default)
-      const workspace_id = "00000000-0000-0000-0000-000000000001"; // TODO: Get from user context
-      
       // Generate UUID idempotency keys per spec
       const idempotency_key = crypto.randomUUID();
-      
+
       // 1) Create basket with idempotency (spec v0.1.0 compliant)
-      logStep('before basket create', { workspace_id, idempotency_key });
+      logStep('before basket create', { idempotency_key });
       const basketReq: CreateBasketReq = {
-        workspace_id,
         name: intent.trim() || 'Untitled Basket',
         idempotency_key,
       };

--- a/web/hooks/useCreateBasket.ts
+++ b/web/hooks/useCreateBasket.ts
@@ -61,12 +61,7 @@ export function useCreateBasket() {
     if (!canSubmit) return;
     setSubmitting(true);
     try {
-      const workspaceId =
-        (typeof window !== "undefined" &&
-          localStorage.getItem("workspace_id")) ||
-        "00000000-0000-0000-0000-000000000001";
       const payload = {
-        workspace_id: workspaceId,
         name: state.basketName || "Untitled Basket",
         idempotency_key: crypto.randomUUID(),
       };

--- a/web/lib/api/contracts.ts
+++ b/web/lib/api/contracts.ts
@@ -8,7 +8,7 @@ const UUIDSchema = z.string().uuid();
 export const BasketSchema = z.object({
   id: UUIDSchema,
   name: z.string(),
-  status: z.enum(['ACTIVE', 'ARCHIVED', 'DELETED']),
+  status: z.enum(['INIT', 'ACTIVE', 'ARCHIVED', 'DEPRECATED']),
   workspace_id: UUIDSchema,
   raw_dump_id: UUIDSchema.nullable().optional(),
   origin_template: z.string().nullable().optional(),
@@ -139,7 +139,6 @@ export type ApiError = z.infer<typeof ApiErrorSchema>;
 
 // Request/Response helpers
 export const CreateBasketRequestSchema = z.object({
-  workspace_id: UUIDSchema,
   name: z.string().optional(),
   idempotency_key: UUIDSchema,
 });

--- a/web/lib/baskets/createBasketWithInput.ts
+++ b/web/lib/baskets/createBasketWithInput.ts
@@ -5,14 +5,12 @@ import { sanitizeFilename } from "@/lib/utils/sanitizeFilename";
 
 export interface CreateBasketArgs {
   userId: string;
-  workspaceId: string;
   text: string;
   files?: (File | string)[];
   name?: string;
 }
 export async function createBasketWithInput({
   userId,
-  workspaceId,
   text,
   files = [],
   name,
@@ -20,7 +18,6 @@ export async function createBasketWithInput({
   const supabase = createClient();
   // 1️⃣ Core basket creation via privileged API route
   const payload: Record<string, string> = {
-    workspace_id: workspaceId,
     idempotency_key: crypto.randomUUID(),
   };
   if (name) payload.name = name;


### PR DESCRIPTION
## Summary
- rename interface spec and document basket status and raw dump fields
- derive workspace server-side for basket creation and drop workspace_id from API contract
- fix document composition path and align basket status enum with schema

## Testing
- `npm test`
- `pytest` *(fails: pyenv: version `3.11.9` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_689ffed5df90832981936ebca7ba9c39