### PR TITLE
Normalize ingest RPC response

### DIFF
--- a/docs/YARNNN_INGESTION_FLOW.md
+++ b/docs/YARNNN_INGESTION_FLOW.md
@@ -30,9 +30,8 @@ type IngestReq = {
 
 // IngestRes
 type IngestRes = {
-  workspace_id: string;
-  basket: { id: string; created: boolean };       // created=false => replayed
-  dumps: Array<{ id: string; dump_request_id: string; created: boolean }>;
+  basket_id: string;
+  dumps: Array<{ dump_id: string }>;
 };
 
 ## 4) Idempotency Rules (authoritative)
@@ -46,7 +45,7 @@ Idempotency keys MUST be stable, client-generated, and collision-resistant (e.g.
 The ingest operation MUST be atomic. Either:
 Use a single SQL function that wraps the process in a transaction, or
 Use a server-side transaction with equivalent guarantees.
-On success, the response MUST include created|replayed booleans for basket and each dump.
+The response returns only IDs. Created vs replayed status SHOULD be captured in logs, not in the payload.
 ## 6) Logging
 Server MUST log request_id, user_id, workspace_id, idempotency_key, and outcome per entity:
 basket.created|replayed
@@ -66,5 +65,4 @@ Elevated actions are not part of ingest; standard member privileges suffice.
 ## 9) Testability
 The combined flow MUST have an integration test that:
 Calls /api/baskets/ingest with {idempotency_key, dumps[]} and a valid user session.
-Replays the same request and observes: basket.created=false, each replayed dump created=false.
-Confirms all rows carry the same workspace_id.
+Replays the same request and observes identical basket_id and dump_ids.

--- a/docs/YARNNN_INTERFACE_SPEC_v0.1.0.md
+++ b/docs/YARNNN_INTERFACE_SPEC_v0.1.0.md
@@ -55,8 +55,7 @@ export type IngestReq = {
   dumps: IngestItem[];
 };
 export type IngestRes = {
-  workspace_id: string;
-  basket: { id: string; created: boolean };
+  basket_id: string;
   dumps: CreateDumpRes[];
 };
 ```
@@ -161,7 +160,7 @@ POST /api/baskets/ingest
     { "dump_request_id": "22222222-2222-2222-2222-222222222222", "text_dump": "first notes" }
   ]
 }
-→ 200 { "workspace_id": "d4f9f2e7-7c3b-4e13-a0ba-2d9b3c2f3a01", "basket": {"id": "ba75c8a0-...", "created": true}, "dumps": [{"id": "rd_x", "dump_request_id": "111...", "created": true}, {"id": "rd_y", "dump_request_id": "222...", "created": true}] }
+→ 200 { "basket_id": "ba75c8a0-...", "dumps": [{"dump_id": "rd_x"}, {"dump_id": "rd_y"}] }
 
 ## 7) Database Changes (SQL)
 **IMPLEMENTED**: Migration `supabase/migrations/20250815_add_create_idempotency.sql` applied.

--- a/supabase/migrations/20250816_ingest_basket_and_dumps.sql
+++ b/supabase/migrations/20250816_ingest_basket_and_dumps.sql
@@ -48,15 +48,12 @@ BEGIN
     RETURNING id, (xmax = 0) INTO v_dump_id, v_dump_created;
 
     v_dump_results := v_dump_results || jsonb_build_object(
-      'id', v_dump_id,
-      'dump_request_id', v_dump->>'dump_request_id',
-      'created', v_dump_created
+      'dump_id', v_dump_id
     );
   END LOOP;
 
   v_out := jsonb_build_object(
-    'workspace_id', p_workspace_id,
-    'basket', jsonb_build_object('id', v_basket_id, 'created', v_basket_created),
+    'basket_id', v_basket_id,
     'dumps', v_dump_results
   );
   RETURN v_out;

--- a/tests/baskets-ingest.spec.ts
+++ b/tests/baskets-ingest.spec.ts
@@ -24,7 +24,7 @@ test.describe('Basket ingest API', () => {
     });
     expect(res1.ok()).toBeTruthy();
     const data1 = await res1.json();
-    expect(data1.basket.created).toBe(true);
+    expect(typeof data1.basket_id).toBe('string');
     expect(data1.dumps).toHaveLength(2);
 
     const res2 = await request.post('/api/baskets/ingest', {
@@ -33,9 +33,9 @@ test.describe('Basket ingest API', () => {
     });
     expect(res2.ok()).toBeTruthy();
     const data2 = await res2.json();
-    expect(data2.basket.created).toBe(false);
-    for (const d of data2.dumps) {
-      expect(d.created).toBe(false);
-    }
+    expect(data2.basket_id).toBe(data1.basket_id);
+    expect(data2.dumps.map((d: any) => d.dump_id)).toEqual(
+      data1.dumps.map((d: any) => d.dump_id)
+    );
   });
 });

--- a/web/app/api/baskets/ingest/route.ts
+++ b/web/app/api/baskets/ingest/route.ts
@@ -9,12 +9,12 @@ export async function POST(req: NextRequest) {
     const { userId } = await getAuthenticatedUser(req);
     const workspaceId = await ensureWorkspaceForUser(userId);
     const body = IngestReqSchema.parse(await req.json());
-    const res = await ingestBasketAndDumps({ 
-      workspaceId, 
-      userId, 
+    const { raw, data } = await ingestBasketAndDumps({
+      workspaceId,
+      userId,
       idempotency_key: body.idempotency_key,
       basket: body.basket,
-      dumps: body.dumps 
+      dumps: body.dumps
     });
     // Log request and response separately per canon - no field synthesis
     console.log(JSON.stringify({
@@ -30,9 +30,9 @@ export async function POST(req: NextRequest) {
     console.log(JSON.stringify({
       route: '/api/baskets/ingest',
       user_id: userId,
-      response: res
+      response: raw
     }));
-    return NextResponse.json(res, { status: 200 });
+    return NextResponse.json(data, { status: 200 });
   } catch (err) {
     if (err instanceof z.ZodError) {
       return NextResponse.json({ error: err.message }, { status: 422 });

--- a/web/lib/server/ingest.ts
+++ b/web/lib/server/ingest.ts
@@ -1,5 +1,6 @@
 import { createServiceRoleClient } from '@/lib/supabase/serviceRole';
 import type { IngestRes, IngestItem } from '@shared/contracts/ingest';
+import { IngestResSchema } from '@/lib/schemas/ingest';
 
 interface IngestArgs {
   workspaceId: string;
@@ -9,7 +10,9 @@ interface IngestArgs {
   dumps: IngestItem[];
 }
 
-export async function ingestBasketAndDumps(args: IngestArgs): Promise<IngestRes> {
+export async function ingestBasketAndDumps(
+  args: IngestArgs
+): Promise<{ raw: unknown; data: IngestRes }> {
   const supabase = createServiceRoleClient();
   const payload = {
     p_workspace_id: args.workspaceId,
@@ -21,5 +24,6 @@ export async function ingestBasketAndDumps(args: IngestArgs): Promise<IngestRes>
   if (error) {
     throw new Error(error.message);
   }
-  return data as IngestRes;
+  const parsed = IngestResSchema.parse(data);
+  return { raw: data, data: parsed };
 }


### PR DESCRIPTION
## Summary
- simplify `ingest_basket_and_dumps` output to only basket and dump IDs
- validate RPC result against `IngestResSchema` and return normalized payload
- align ingest API route, tests, and docs with new response shape

## Testing
- `npm test`
- `npm run e2e:test tests/baskets-ingest.spec.ts` *(fails: Process from config.webServer was not able to start. Exit code: 1)*

------
https://chatgpt.com/codex/tasks/task_e_68a00860645c832989d4a9c6b33dfa99