### PR TITLE
refactor: use user-scoped supabase clients

### DIFF
--- a/api/src/app/agent_server.py
+++ b/api/src/app/agent_server.py
@@ -141,7 +141,7 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-# Log missing Supabase key
+# Log missing Supabase anon key
 logger = logging.getLogger("uvicorn.error")
-if "SUPABASE_SERVICE_ROLE_KEY" not in os.environ:
-    logger.warning("SUPABASE_SERVICE_ROLE_KEY not set; Supabase operations may fail")
+if "SUPABASE_ANON_KEY" not in os.environ:
+    logger.warning("SUPABASE_ANON_KEY not set; Supabase operations may fail")

--- a/api/src/app/utils/auth_helpers.py
+++ b/api/src/app/utils/auth_helpers.py
@@ -29,7 +29,7 @@ async def get_user(request: Request):
     if not token:
         raise HTTPException(status_code=401, detail="Invalid or missing authentication token")
 
-    supabase = get_supabase()
+    supabase = get_supabase(token)
     try:
         user_response = supabase.auth.get_user(token)
     except Exception as exc:  # noqa: BLE001

--- a/api/src/app/utils/supabase_client.py
+++ b/api/src/app/utils/supabase_client.py
@@ -1,43 +1,25 @@
-"""Local Supabase client used by application routes and tasks."""
+"""Supabase client factory that builds a per-request client using user JWT."""
 
-import logging
+from __future__ import annotations
+
 import os
-
-import jwt
-
-from supabase import create_client
-
-logger = logging.getLogger(__name__)
+from supabase import create_client, Client
 
 SUPABASE_URL = os.getenv("SUPABASE_URL")
-SUPABASE_SERVICE_ROLE_KEY = os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+SUPABASE_ANON_KEY = os.getenv("SUPABASE_ANON_KEY")
 
-if not SUPABASE_URL or not SUPABASE_SERVICE_ROLE_KEY:
+if not SUPABASE_URL or not SUPABASE_ANON_KEY:
     raise RuntimeError("Supabase env vars missing")
 
 
-def _decode_key_role(key: str) -> str:
-    try:
-        decoded = jwt.decode(key, options={"verify_signature": False})
-    except Exception:  # noqa: BLE001
-        return "UNKNOWN"
-    return decoded.get("role", "UNKNOWN")
+def get_supabase(token: str) -> Client:
+    """Create a new Supabase client scoped to the provided JWT."""
+    client: Client = create_client(SUPABASE_URL, SUPABASE_ANON_KEY)
+    client.postgrest.auth(token)
+    return client
 
 
-supabase_client = create_client(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)
+supabase_client = create_client(SUPABASE_URL, SUPABASE_ANON_KEY)
 
 
-def get_supabase() -> "Client":
-    """Return the singleton service role client."""
-    return supabase_client
-
-
-SUPABASE_KEY_ROLE = _decode_key_role(SUPABASE_SERVICE_ROLE_KEY)
-logger.info("[SUPABASE DEBUG] Loaded Supabase key role: %s", SUPABASE_KEY_ROLE)
-if SUPABASE_KEY_ROLE != "service_role":
-    logger.error(
-        "[SUPABASE ERROR] Invalid key role loaded: %s. This may cause permission errors.",
-        SUPABASE_KEY_ROLE,
-    )
-
-__all__ = ["supabase_client", "get_supabase", "_decode_key_role", "SUPABASE_KEY_ROLE"]
+__all__ = ["get_supabase", "supabase_client"]

--- a/api/src/utils/supabase_client.py
+++ b/api/src/utils/supabase_client.py
@@ -1,11 +1,16 @@
-import os
+"""Supabase client wrapper for legacy modules using anon key."""
 
+from __future__ import annotations
+
+import os
 from supabase import create_client
 
 SUPABASE_URL = os.getenv("SUPABASE_URL")
-SUPABASE_SERVICE_ROLE_KEY = os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+SUPABASE_ANON_KEY = os.getenv("SUPABASE_ANON_KEY")
 
-if not SUPABASE_URL or not SUPABASE_SERVICE_ROLE_KEY:
+if not SUPABASE_URL or not SUPABASE_ANON_KEY:
     raise RuntimeError("Supabase env vars missing")
 
-supabase_client = create_client(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)
+supabase_client = create_client(SUPABASE_URL, SUPABASE_ANON_KEY)
+
+__all__ = ["supabase_client"]

--- a/web/app/api/baskets/ingest/route.ts
+++ b/web/app/api/baskets/ingest/route.ts
@@ -6,15 +6,16 @@ import { ingestBasketAndDumps } from '@/lib/server/ingest';
 
 export async function POST(req: NextRequest) {
   try {
-    const { userId } = await getAuthenticatedUser(req);
-    const workspaceId = await ensureWorkspaceForUser(userId);
+    const { userId, token } = await getAuthenticatedUser(req);
+    const workspaceId = await ensureWorkspaceForUser(userId, token);
     const body = IngestReqSchema.parse(await req.json());
     const { raw, data } = await ingestBasketAndDumps({
       workspaceId,
       userId,
       idempotency_key: body.idempotency_key,
       basket: body.basket,
-      dumps: body.dumps
+      dumps: body.dumps,
+      token,
     });
     // Log request and response separately per canon - no field synthesis
     console.log(JSON.stringify({

--- a/web/app/api/context-blocks/[id]/route.ts
+++ b/web/app/api/context-blocks/[id]/route.ts
@@ -1,11 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
-import { createServiceRoleClient } from "@/lib/supabase/serviceRole";
+import { getAuthenticatedUser } from "@/lib/server/auth";
+import { createUserClient } from "@/lib/supabase/user";
 export async function GET(
   req: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
   const { id } = await params;
-  const supabase = createServiceRoleClient();
+  const { token } = await getAuthenticatedUser(req);
+  const supabase = createUserClient(token);
   const { data, error } = await supabase
     .from("blocks")
     .select("*")
@@ -22,7 +24,8 @@ export async function DELETE(
   { params }: { params: Promise<{ id: string }> },
 ) {
   const { id } = await params;
-  const supabase = createServiceRoleClient();
+  const { token } = await getAuthenticatedUser(req);
+  const supabase = createUserClient(token);
   const { error } = await supabase
     .from("blocks")
     .delete()

--- a/web/app/api/context-blocks/create/route.ts
+++ b/web/app/api/context-blocks/create/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
-import { createServiceRoleClient } from "@/lib/supabase/serviceRole";
+import { getAuthenticatedUser } from "@/lib/server/auth";
+import { createUserClient } from "@/lib/supabase/user";
 
 export async function POST(req: NextRequest) {
   let payload: any;
@@ -9,7 +10,8 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "invalid JSON" }, { status: 400 });
   }
 
-  const supabase = createServiceRoleClient();
+  const { token } = await getAuthenticatedUser(req);
+  const supabase = createUserClient(token);
   const { data, error } = await supabase
     .from("blocks")
     .insert(payload)

--- a/web/app/api/context-blocks/update/route.ts
+++ b/web/app/api/context-blocks/update/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
-import { createServiceRoleClient } from "@/lib/supabase/serviceRole";
+import { getAuthenticatedUser } from "@/lib/server/auth";
+import { createUserClient } from "@/lib/supabase/user";
 
 export async function PUT(req: NextRequest) {
   let payload: any;
@@ -14,7 +15,8 @@ export async function PUT(req: NextRequest) {
     return NextResponse.json({ error: "id required" }, { status: 400 });
   }
 
-  const supabase = createServiceRoleClient();
+  const { token } = await getAuthenticatedUser(req);
+  const supabase = createUserClient(token);
   const { error } = await supabase
     .from("blocks")
     .update(updates)

--- a/web/app/api/substrate/persist/route.ts
+++ b/web/app/api/substrate/persist/route.ts
@@ -2,18 +2,16 @@
 // Handles saving substrate to database
 
 import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@supabase/supabase-js';
 import { SubstrateElement } from '@/lib/substrate/SubstrateTypes';
-
-const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE_KEY!
-);
+import { getAuthenticatedUser } from '@/lib/server/auth';
+import { createUserClient } from '@/lib/supabase/user';
 
 export async function POST(request: NextRequest) {
   try {
+    const { token } = await getAuthenticatedUser(request);
+    const supabase = createUserClient(token);
     const substrate: SubstrateElement = await request.json();
-    
+
     // Route to appropriate table based on substrate type
     let tableName: string;
     let data: any;
@@ -125,9 +123,9 @@ export async function POST(request: NextRequest) {
   } catch (error) {
     console.error('Persist API Error:', error);
     return NextResponse.json(
-      { 
-        success: false, 
-        error: error instanceof Error ? error.message : 'Internal server error' 
+      {
+        success: false,
+        error: error instanceof Error ? error.message : 'Internal server error'
       },
       { status: 500 }
     );

--- a/web/lib/server/auth.ts
+++ b/web/lib/server/auth.ts
@@ -1,7 +1,7 @@
 import { NextRequest } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import type { Database } from '@/lib/dbTypes';
-import { createServiceRoleClient } from '@/lib/supabase/serviceRole';
+import { createUserClient } from '@/lib/supabase/user';
 
 export async function getAuthenticatedUser(req: NextRequest) {
   const auth = req.headers.get('authorization');
@@ -22,11 +22,11 @@ export async function getAuthenticatedUser(req: NextRequest) {
   if (error || !user) {
     throw new Error('Unauthorized');
   }
-  return { userId: user.id };
+  return { userId: user.id, token };
 }
 
-export async function ensureWorkspaceForUser(userId: string) {
-  const supabase = createServiceRoleClient();
+export async function ensureWorkspaceForUser(userId: string, token: string) {
+  const supabase = createUserClient(token);
   const { data: membership } = await supabase
     .from('workspace_memberships')
     .select('workspace_id')

--- a/web/lib/server/ingest.ts
+++ b/web/lib/server/ingest.ts
@@ -1,4 +1,4 @@
-import { createServiceRoleClient } from '@/lib/supabase/serviceRole';
+import { createUserClient } from '@/lib/supabase/user';
 import type { IngestRes, IngestItem } from '@shared/contracts/ingest';
 import { IngestResSchema } from '@/lib/schemas/ingest';
 
@@ -8,12 +8,13 @@ interface IngestArgs {
   idempotency_key: string;
   basket?: { name?: string };
   dumps: IngestItem[];
+  token: string;
 }
 
 export async function ingestBasketAndDumps(
   args: IngestArgs
 ): Promise<{ raw: unknown; data: IngestRes }> {
-  const supabase = createServiceRoleClient();
+  const supabase = createUserClient(args.token);
   const payload = {
     p_workspace_id: args.workspaceId,
     p_idempotency_key: args.idempotency_key,

--- a/web/lib/supabase/user.ts
+++ b/web/lib/supabase/user.ts
@@ -1,0 +1,14 @@
+import { createClient } from '@supabase/supabase-js';
+import type { Database } from '../dbTypes';
+
+export function createUserClient(token: string) {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  if (!url || !anon) {
+    throw new Error('Missing Supabase env vars');
+  }
+  return createClient<Database>(url, anon, {
+    global: { headers: { Authorization: `Bearer ${token}` } },
+    auth: { persistSession: false },
+  });
+}


### PR DESCRIPTION
## Summary
- create user-scoped Supabase client helper for server routes
- forward JWT to Supabase in ingest and context-block APIs
- build per-request Supabase clients in Python utilities

## Testing
- `npm test`
- `pytest` *(fails: pyenv: version `3.11.9` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68a01ed66ec08329975d78a950eabb3f