### PR TITLE
Fix Supabase client initialization to avoid deploy error

### DIFF
--- a/api/src/app/agents/utils/supabase_helpers.py
+++ b/api/src/app/agents/utils/supabase_helpers.py
@@ -3,9 +3,9 @@ from uuid import uuid4
 
 from src.utils.db import json_safe
 
-from app.utils.supabase_client import get_supabase
+from app.utils.supabase_client import get_supabase, supabase_client
 
-supabase = get_supabase()
+supabase = supabase_client
 
 
 def get_collected_fields(user_id: str, task_id: str) -> dict:

--- a/api/src/app/routes/task_brief.py
+++ b/api/src/app/routes/task_brief.py
@@ -6,11 +6,12 @@ import logging
 from datetime import datetime
 from typing import Optional
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 from src.utils.db import json_safe
 
-from ..agents.utils.supabase_helpers import get_supabase
+from ..utils.jwt import verify_jwt
+from ..utils.supabase_client import supabase_client as supabase
 
 router = APIRouter(prefix="/task-brief", tags=["task-brief"])
 
@@ -34,9 +35,8 @@ class TaskBrief(BaseModel):
 
 
 @router.post("/", response_model=TaskBrief, status_code=201)
-async def create_task_brief(task_brief: TaskBrief):
+async def create_task_brief(task_brief: TaskBrief, user: dict = Depends(verify_jwt)):
     """Create a new TaskBrief entry in Supabase and return it."""
-    supabase = get_supabase()
     payload = task_brief.model_dump(
         mode="json", exclude_unset=True, exclude={"id", "created_at"}
     )
@@ -57,9 +57,8 @@ async def create_task_brief(task_brief: TaskBrief):
 
 
 @router.get("/{brief_id}", response_model=TaskBrief)
-async def get_task_brief(brief_id: str):
+async def get_task_brief(brief_id: str, user: dict = Depends(verify_jwt)):
     """Fetch a TaskBrief by ID."""
-    supabase = get_supabase()
     try:
         resp = (
             supabase.table("task_briefs")

--- a/scripts/backfill_inputs_to_artifacts.py
+++ b/scripts/backfill_inputs_to_artifacts.py
@@ -1,10 +1,9 @@
 """Backfill basket_inputs rows into dump_artifacts."""
 
-from app.agents.utils.supabase_helpers import get_supabase
+from app.utils.supabase_client import supabase_client as supabase
 
 
 def main() -> None:
-    supabase = get_supabase()
     resp = supabase.table("basket_inputs").select("*").execute()
     rows = resp.data or []
 


### PR DESCRIPTION
## Summary
- avoid missing-token crash by using shared `supabase_client` instead of calling `get_supabase()` without args
- require JWT verification for TaskBrief routes and use shared Supabase client
- streamline backfill script to reuse shared Supabase client

## Testing
- `ruff check api/src/app/agents/utils/supabase_helpers.py api/src/app/routes/task_brief.py scripts/backfill_inputs_to_artifacts.py` *(fails: pyenv: version `3.11.9` is not installed, ruff: command not found)*
- `pytest` *(fails: pyenv: version `3.11.9` is not installed, pytest: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0273be1ec8329b903958953d71262