### PR TITLE
Wrap basket name in CreateBasket request

### DIFF
--- a/api/src/app/baskets/schemas.py
+++ b/api/src/app/baskets/schemas.py
@@ -32,8 +32,12 @@ class BasketWorkRequest(BaseModel):
     policy: WorkPolicy = WorkPolicy()
     options: WorkOptions = WorkOptions()
 
+class BasketInput(BaseModel):
+    name: Optional[str] = None
+
+
 class CreateBasketReq(BaseModel):
     """DTO matching the CreateBasketReq contract."""
 
     idempotency_key: str
-    name: Optional[str] = "Untitled Basket"
+    basket: BasketInput

--- a/api/src/app/routes/basket_new.py
+++ b/api/src/app/routes/basket_new.py
@@ -60,7 +60,7 @@ async def create_basket(
             {
                 "workspace_id": workspace_id,
                 "user_id": user["user_id"],
-                "name": payload.name or "Untitled Basket",
+                "name": payload.basket.name or "Untitled Basket",
                 "idempotency_key": payload.idempotency_key,
                 "status": "INIT",
             }

--- a/api/tests/api/test_basket_flow.py
+++ b/api/tests/api/test_basket_flow.py
@@ -64,6 +64,7 @@ def test_create_and_list(monkeypatch):
 
     payload = {
         "idempotency_key": str(uuid.uuid4()),
+        "basket": {},
     }
 
     resp = client.post("/api/baskets/new", json=payload)
@@ -80,7 +81,7 @@ def test_auto_workspace(monkeypatch):
     fake = _supabase(store)
     monkeypatch.setattr("app.routes.basket_new.supabase", fake)
 
-    payload = {"idempotency_key": str(uuid.uuid4())}
+    payload = {"idempotency_key": str(uuid.uuid4()), "basket": {}}
     resp = client.post("/api/baskets/new", json=payload)
     assert resp.status_code == 201
     assert store["workspaces"]

--- a/api/tests/api/test_basket_new.py
+++ b/api/tests/api/test_basket_new.py
@@ -81,8 +81,8 @@ def test_basket_new_replay(monkeypatch):
     monkeypatch.setattr("app.routes.basket_new.supabase", fake)
 
     payload = {
-        "name": "Test",
         "idempotency_key": str(uuid.uuid4()),
+        "basket": {"name": "Test"},
     }
 
     r1 = client.post("/api/baskets/new", json=payload)
@@ -92,7 +92,10 @@ def test_basket_new_replay(monkeypatch):
     r2 = client.post("/api/baskets/new", json=payload)
     assert r2.status_code == 200
     assert r2.json()["basket_id"] == bid
-    payload2 = {"name": "Test", "idempotency_key": payload["idempotency_key"]}
+    payload2 = {
+        "idempotency_key": payload["idempotency_key"],
+        "basket": {"name": "Test"},
+    }
     r2 = client.post("/api/baskets/new", json=payload2)
     assert r2.status_code == 200
     assert r2.json()["basket_id"] == bid
@@ -103,7 +106,7 @@ def test_basket_new_creates_workspace(monkeypatch):
     fake = _supabase(store)
     monkeypatch.setattr("app.routes.basket_new.supabase", fake)
 
-    payload = {"idempotency_key": str(uuid.uuid4())}
+    payload = {"idempotency_key": str(uuid.uuid4()), "basket": {}}
     resp = client.post("/api/baskets/new", json=payload)
     assert resp.status_code == 201
     assert store["workspaces"]

--- a/api/tests/api/test_new_snapshot_flow.py
+++ b/api/tests/api/test_new_snapshot_flow.py
@@ -92,7 +92,7 @@ def test_snapshot_after_flow(monkeypatch):
     monkeypatch.setattr("app.routes.dump_new.supabase", fake)
     monkeypatch.setattr("app.routes.basket_snapshot.supabase", fake)
 
-    b_payload = {"idempotency_key": str(uuid.uuid4())}
+    b_payload = {"idempotency_key": str(uuid.uuid4()), "basket": {}}
     basket = client.post("/api/baskets/new", json=b_payload)
     bid = basket.json()["basket_id"]
 

--- a/docs/YARNNN_AUTH_WORKFLOW.md
+++ b/docs/YARNNN_AUTH_WORKFLOW.md
@@ -89,7 +89,7 @@ Create Basket
 POST /api/baskets/new
 Authorization: Bearer <jwt>
 
-Body: { "name": "My Basket", "idempotency_key": "<uuid>" }
+Body: { "idempotency_key": "<uuid>", "basket": { "name": "My Basket" } }
 
 Behavior:
 - Verify JWT → userId

--- a/docs/YARNNN_INTERFACE_SPEC_v0.1.0.md
+++ b/docs/YARNNN_INTERFACE_SPEC_v0.1.0.md
@@ -27,8 +27,8 @@ RLS: All inserts must satisfy workspace membership policies; server derives user
 ```typescript
 // shared/contracts/baskets.ts
 export type CreateBasketReq = {
-  name?: string;
   idempotency_key: string; // UUID
+  basket: { name?: string };
 };
 export type CreateBasketRes = { basket_id: string };
 // shared/contracts/dumps.ts
@@ -122,8 +122,8 @@ Content-Type: application/json
 Authorization: Bearer <jwt>
 
 {
-  "name": "Brand Sprint",
-  "idempotency_key": "6f2d4c4e-1b4a-4c4e-9b32-2b9a1e0e8f91"
+  "idempotency_key": "6f2d4c4e-1b4a-4c4e-9b32-2b9a1e0e8f91",
+  "basket": { "name": "Brand Sprint" }
 }
 
 200 OK
@@ -194,7 +194,7 @@ async function createBasketAndIngest(items: Array<{ text_dump?: string; file_url
   inFlight.current = true;
   try {
     const idem = crypto.randomUUID();
-    const { basket_id } = await api.createBasket({ name, idempotency_key: idem });
+    const { basket_id } = await api.createBasket({ idempotency_key: idem, basket: { name } });
 
     await Promise.all(items.map(it =>
       api.createDump({

--- a/shared/contracts/baskets.ts
+++ b/shared/contracts/baskets.ts
@@ -2,9 +2,10 @@
 // Canon contracts: pure TypeScript types (no Zod).
 
 export type CreateBasketReq = {
-  // workspace is resolved server-side; client must NOT send it
-  name?: string;
   idempotency_key: string; // UUID
+  basket: {
+    name?: string;
+  };
 };
 
 export type CreateBasketRes = {

--- a/tests/dump_hotkey.spec.ts
+++ b/tests/dump_hotkey.spec.ts
@@ -1,11 +1,15 @@
 import { test, expect } from '@playwright/test';
+import { randomUUID } from 'crypto';
 
 // Helper to call API directly
 async function createBasket() {
   const res = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/baskets/new`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ text_dump: 'init' }),
+    body: JSON.stringify({
+      idempotency_key: randomUUID(),
+      basket: { name: 'init' },
+    }),
   });
   const data = await res.json();
   return data.basket_id as string;

--- a/tests/idempotency-golden-path.spec.ts
+++ b/tests/idempotency-golden-path.spec.ts
@@ -120,8 +120,8 @@ test.describe('Idempotency Golden Path', () => {
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
         body: JSON.stringify({
-          name: 'Test Basket',
-          idempotency_key: 'invalid-uuid'
+          idempotency_key: 'invalid-uuid',
+          basket: { name: 'Test Basket' }
         })
       }).then(res => ({ status: res.status, body: res.json() }));
     });
@@ -158,7 +158,7 @@ test.describe('Idempotency Golden Path', () => {
         credentials: 'include',
         body: JSON.stringify(data)
       }).then(res => ({ status: res.status, body: res.json() }));
-    }, { name: 'Test Basket', idempotency_key: idempotencyKey });
+    }, { idempotency_key: idempotencyKey, basket: { name: 'Test Basket' } });
     
     expect(firstRequest.status).toBe(201); // Created
     
@@ -170,7 +170,7 @@ test.describe('Idempotency Golden Path', () => {
         credentials: 'include',
         body: JSON.stringify(data)
       }).then(res => ({ status: res.status, body: res.json() }));
-    }, { name: 'Test Basket', idempotency_key: idempotencyKey });
+    }, { idempotency_key: idempotencyKey, basket: { name: 'Test Basket' } });
     
     expect(replayRequest.status).toBe(200); // Replayed
     

--- a/web/app/api/baskets/new/route.ts
+++ b/web/app/api/baskets/new/route.ts
@@ -11,7 +11,7 @@ const API_BASE =
   process.env.NEXT_PUBLIC_API_BASE_URL ?? "https://api.yarnnn.com";
 
 export async function POST(req: NextRequest) {
-  // 1) Parse & validate request (canon: { idempotency_key, name? })
+  // 1) Parse & validate request (canon: { idempotency_key, basket: { name? } })
   let json: unknown;
   try {
     json = await req.json();

--- a/web/components/create/useCreatePageMachine.ts
+++ b/web/components/create/useCreatePageMachine.ts
@@ -224,8 +224,8 @@ useEffect(() => {
       // 1) Create basket with idempotency (spec v0.1.0 compliant)
       logStep('before basket create', { idempotency_key });
       const basketReq: CreateBasketReq = {
-        name: intent.trim() || 'Untitled Basket',
         idempotency_key,
+        basket: { name: intent.trim() || 'Untitled Basket' },
       };
       
       const basketRes = await fetch('/api/baskets/new', {

--- a/web/hooks/useCreateBasket.ts
+++ b/web/hooks/useCreateBasket.ts
@@ -62,8 +62,8 @@ export function useCreateBasket() {
     setSubmitting(true);
     try {
       const payload = {
-        name: state.basketName || "Untitled Basket",
         idempotency_key: crypto.randomUUID(),
+        basket: { name: state.basketName || "Untitled Basket" },
       };
       const { basket_id } = await apiClient.request<{ basket_id: string }>(
         "/api/baskets/new",

--- a/web/lib/api/contracts.ts
+++ b/web/lib/api/contracts.ts
@@ -139,8 +139,10 @@ export type ApiError = z.infer<typeof ApiErrorSchema>;
 
 // Request/Response helpers
 export const CreateBasketRequestSchema = z.object({
-  name: z.string().optional(),
   idempotency_key: UUIDSchema,
+  basket: z.object({
+    name: z.string().optional(),
+  }),
 });
 
 export type CreateBasketRequest = z.infer<typeof CreateBasketRequestSchema>;

--- a/web/lib/baskets/createBasketWithInput.ts
+++ b/web/lib/baskets/createBasketWithInput.ts
@@ -17,10 +17,11 @@ export async function createBasketWithInput({
 }: CreateBasketArgs) {
   const supabase = createClient();
   // 1️⃣ Core basket creation via privileged API route
-  const payload: Record<string, string> = {
+  const payload: { idempotency_key: string; basket: { name?: string } } = {
     idempotency_key: crypto.randomUUID(),
+    basket: {},
   };
-  if (name) payload.name = name;
+  if (name) payload.basket.name = name;
   console.log("[createBasketWithInput] Payload:", payload);
   const resp = await fetchWithToken("/api/baskets/new", {
     method: "POST",

--- a/web/lib/baskets/submit.ts
+++ b/web/lib/baskets/submit.ts
@@ -68,14 +68,9 @@ export function buildContextBlocks(values: BasketValues): ContextBlock[] {
 import { apiClient } from "../api/client";
 
 export async function createBasket(values: BasketValues): Promise<{ basket_id: string }> {
-  const workspaceId =
-    (typeof window !== "undefined" &&
-      localStorage.getItem("workspace_id")) ||
-    "00000000-0000-0000-0000-000000000001";
   const payload = {
-    workspace_id: workspaceId,
-    name: values.topic || "Untitled Basket",
     idempotency_key: crypto.randomUUID(),
+    basket: { name: values.topic || "Untitled Basket" },
   };
   return apiClient.request<{ basket_id: string }>("/api/baskets/new", {
     method: "POST",

--- a/web/lib/schemas/baskets.ts
+++ b/web/lib/schemas/baskets.ts
@@ -2,9 +2,10 @@ import { z } from 'zod';
 import type { CreateBasketReq, CreateBasketRes } from '@shared/contracts/baskets';
 
 export const CreateBasketReqSchema = z.object({
-  workspace_id: z.string().uuid(),
-  name: z.string().optional(),
   idempotency_key: z.string().uuid(),
+  basket: z.object({
+    name: z.string().optional(),
+  }),
 }) satisfies z.ZodType<CreateBasketReq>;
 
 export const CreateBasketResSchema = z.object({


### PR DESCRIPTION
## Summary
- nest `name` under `basket` in CreateBasket request contract
- update API, frontend, and docs to match new CreateBasketReq shape

## Testing
- `pytest api/tests/api/test_basket_new.py api/tests/api/test_basket_flow.py api/tests/api/test_new_snapshot_flow.py` *(fails: cannot import name 'Client' from 'supabase')*
- `npx -y vitest run web/__tests__/createBasketDialog.test.tsx web/app/api/baskets/ingest/route.test.ts` *(fails: Cannot find module 'vitest/config')*


------
https://chatgpt.com/codex/tasks/task_e_68a026c531988329aed6e7019075c434