### PR TITLE
Log session presence in baskets/new route

### DIFF
--- a/web/app/api/baskets/new/route.ts
+++ b/web/app/api/baskets/new/route.ts
@@ -41,7 +41,15 @@ export async function POST(req: NextRequest) {
     data: { session },
   } = await supabase.auth.getSession();
 
-  const accessToken = session?.access_token;
+  console.log("session exists:", !!session);
+  if (!session) {
+    return NextResponse.json(
+      { error: { code: "UNAUTHORIZED", message: "Missing session" } },
+      { status: 401 }
+    );
+  }
+
+  const accessToken = session.access_token;
   if (!accessToken) {
     return NextResponse.json(
       { error: { code: "UNAUTHORIZED", message: "Missing Authorization" } },


### PR DESCRIPTION
## Summary
- log session availability in baskets new route
- return UNAUTHORIZED if session is missing before forwarding request

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a04d5b9f848329b76bc1c66a99fd74