### PR TITLE
Log JWT claims when JWT verification fails and forward access token header

### DIFF
--- a/web/app/api/baskets/new/route.ts
+++ b/web/app/api/baskets/new/route.ts
@@ -63,6 +63,7 @@ export async function POST(req: NextRequest) {
     headers: {
       "content-type": "application/json",
       authorization: `Bearer ${accessToken}`,
+      "sb-access-token": accessToken,
     },
     body: JSON.stringify(parsed.data),
   });


### PR DESCRIPTION
## Summary
- log Supabase JWT `iss` and `aud` when verification fails
- forward `sb-access-token` header alongside `Authorization`

## Testing
- `PYENV_VERSION=3.11.12 make test` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `npm --prefix web run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a055ca04b8832981ba66b618a5a813