### PR TITLE
feat: align supabase auth flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,8 @@ jobs:
           node-version: '20'
           cache: 'npm'
           cache-dependency-path: web/package-lock.json
+      - name: Auth handshake guard
+        run: node scripts/check-auth-handshake.mjs
       - name: Build web
         working-directory: web
         run: |

--- a/api/src/app/agent_server.py
+++ b/api/src/app/agent_server.py
@@ -30,6 +30,7 @@ from .deps import close_db
 from .routes.agent_memory import router as agent_memory_router
 from .routes.agent_run import router as agent_run_router
 from .routes.agents import router as agents_router
+from .routes.auth_health import router as auth_health_router
 from .routes.basket_from_template import router as template_router
 from .routes.basket_new import router as basket_new_router
 from .routes.basket_snapshot import router as snapshot_router
@@ -87,6 +88,7 @@ routers = (
     template_router,
     context_intelligence_router,
     narrative_intelligence_router,
+    auth_health_router,
 )
 
 for r in routers:

--- a/api/src/app/routes/auth_health.py
+++ b/api/src/app/routes/auth_health.py
@@ -1,0 +1,16 @@
+"""Auth health endpoint for verifying JWT env alignment."""
+from __future__ import annotations
+
+from fastapi import APIRouter, Request
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+
+
+@router.get("/health")
+async def auth_health(request: Request):
+    payload = getattr(request.state, "jwt_payload", {}) or {}
+    return {
+        "iss": payload.get("iss"),
+        "aud": payload.get("aud"),
+        "sub": payload.get("sub"),
+    }

--- a/api/src/auth/jwt_verifier.py
+++ b/api/src/auth/jwt_verifier.py
@@ -3,13 +3,13 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 import time
 
 import jwt
 import requests
 from jwt import InvalidTokenError
-import logging
 
 logger = logging.getLogger(__name__)
 
@@ -80,18 +80,23 @@ def verify_jwt(token: str) -> dict:
             algorithms=["RS256"],
             issuer=_expected_issuer(),
             audience=_expected_audience(),
+            leeway=60,
         )
     except InvalidTokenError as e:
         try:
             payload = jwt.decode(token, options={"verify_signature": False})
             logger.error(
-                "JWT validation failed: iss=%s aud=%s error=%s",
+                "JWT validation failed: iss=%s aud=%s sub=%s error=%s",
                 payload.get("iss"),
                 payload.get("aud"),
-                e,
+                payload.get("sub"),
+                e.__class__.__name__,
             )
         except Exception:
-            logger.error("JWT validation failed and payload could not be decoded: %s", e)
+            logger.error(
+                "JWT validation failed: error=%s",
+                e.__class__.__name__,
+            )
         raise
 
 

--- a/api/src/middleware/auth.py
+++ b/api/src/middleware/auth.py
@@ -2,14 +2,13 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable
 import logging
+from collections.abc import Iterable
 
 from auth.jwt_verifier import verify_jwt
 from fastapi import Request
 from fastapi.responses import JSONResponse
 from starlette.middleware.base import BaseHTTPMiddleware
-
 
 logger = logging.getLogger(__name__)
 
@@ -56,9 +55,13 @@ class AuthMiddleware(BaseHTTPMiddleware):
             )
 
         logger.info(
-            "JWT verified iss=%s sub=%s", payload.get("iss"), payload.get("sub")
+            "JWT verified iss=%s aud=%s sub=%s",
+            payload.get("iss"),
+            payload.get("aud"),
+            payload.get("sub"),
         )
         request.state.user_id = payload.get("sub")
+        request.state.jwt_payload = payload
         return await call_next(request)
 
 

--- a/scripts/check-auth-handshake.mjs
+++ b/scripts/check-auth-handshake.mjs
@@ -1,0 +1,32 @@
+import fs from 'fs';
+
+function extractRef(url) {
+  const match = url?.match(/^https:\/\/([^.]+)\.supabase\.co/);
+  return match ? match[1] : null;
+}
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const jwksUrl = process.env.SUPABASE_JWKS_URL;
+const issuer = process.env.SUPABASE_JWKS_ISSUER;
+
+if (!supabaseUrl || !jwksUrl || !issuer) {
+  console.error('Missing Supabase env vars');
+  process.exit(1);
+}
+
+const refUrl = extractRef(supabaseUrl);
+const refJwks = extractRef(jwksUrl);
+const refIssuer = extractRef(issuer);
+
+if (!refUrl || refUrl !== refJwks || refUrl !== refIssuer) {
+  console.error('Supabase project refs mismatch');
+  process.exit(1);
+}
+
+const route = fs.readFileSync('web/app/api/baskets/new/route.ts', 'utf8');
+if (!route.includes('export const runtime = "nodejs"')) {
+  console.error('web/app/api/baskets/new/route.ts missing runtime export');
+  process.exit(1);
+}
+
+console.log('Auth handshake check passed');

--- a/web/app/api/baskets/new/route.ts
+++ b/web/app/api/baskets/new/route.ts
@@ -40,22 +40,13 @@ export async function POST(req: NextRequest) {
   const {
     data: { session },
   } = await supabase.auth.getSession();
-
-  console.log("session exists:", !!session);
   if (!session) {
     return NextResponse.json(
       { error: { code: "UNAUTHORIZED", message: "Missing session" } },
       { status: 401 }
     );
   }
-
   const accessToken = session.access_token;
-  if (!accessToken) {
-    return NextResponse.json(
-      { error: { code: "UNAUTHORIZED", message: "Missing Authorization" } },
-      { status: 401 }
-    );
-  }
 
   // 3) Forward to FastAPI with Bearer token (workspace bootstrap is server-side)
   const payload = {
@@ -68,7 +59,7 @@ export async function POST(req: NextRequest) {
     method: "POST",
     headers: {
       "content-type": "application/json",
-      authorization: `Bearer ${accessToken}`,
+      Authorization: `Bearer ${accessToken}`,
       "sb-access-token": accessToken,
     },
     body: JSON.stringify(payload),


### PR DESCRIPTION
## Summary
- send user session token from web basket proxy using Node runtime
- verify Supabase JWTs with issuer/audience env vars, clock skew tolerance, and minimal failure logging
- expose auth health route and ensure CI validates env alignment

## Testing
- `pre-commit run --files web/app/api/baskets/new/route.ts api/src/auth/jwt_verifier.py api/src/middleware/auth.py api/src/app/routes/auth_health.py api/src/app/agent_server.py scripts/check-auth-handshake.mjs .github/workflows/ci.yml`
- `make tests` *(fails: duplicate base class BaseSchema)*
- `node scripts/check-auth-handshake.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68a06c6d058c8329b5be9c632a87c5b8