### PR TITLE
feat(auth): log JWT details and support HS256

### DIFF
--- a/api/src/auth/jwt_verifier.py
+++ b/api/src/auth/jwt_verifier.py
@@ -1,103 +1,52 @@
-"""Supabase JWT verification using JWKS with caching."""
+"""Supabase JWT verification supporting HS256 and RS256."""
 
 from __future__ import annotations
 
-import json
-import logging
 import os
-import time
 
 import jwt
-import requests
-from jwt import InvalidTokenError
+from jwt import PyJWKClient
 
-logger = logging.getLogger(__name__)
+SUPABASE_URL = os.getenv("SUPABASE_URL", "").rstrip("/")
+ISSUER = os.getenv("SUPABASE_JWKS_ISSUER", f"{SUPABASE_URL}/auth/v1")
+AUD = os.getenv("SUPABASE_JWT_AUD", "authenticated")
+JWT_SECRET = os.getenv("SUPABASE_JWT_SECRET")
+JWKS_URL = os.getenv("SUPABASE_JWKS_URL", f"{SUPABASE_URL}/auth/v1/keys")
+LEEWAY = int(os.getenv("JWT_CLOCK_SKEW", "60"))
 
-# JWKS caching
-_JWKS_CACHE: dict[str, dict] = {}
-_JWKS_LAST_FETCH: float = 0
-_JWKS_TTL = 60 * 5  # 5 minutes
-
-
-def _jwks_url() -> str:
-    jwks_url = os.getenv("SUPABASE_JWKS_URL")
-    if jwks_url:
-        return jwks_url
-    base_url = os.getenv("SUPABASE_URL")
-    if not base_url:
-        raise RuntimeError("SUPABASE_JWKS_URL or SUPABASE_URL not configured")
-    return f"{base_url.rstrip('/')}/auth/v1/keys"
-
-
-def _expected_issuer() -> str:
-    issuer = os.getenv("SUPABASE_JWKS_ISSUER") or os.getenv("SUPABASE_JWT_ISS")
-    if issuer:
-        return issuer
-    base_url = os.getenv("SUPABASE_URL")
-    if not base_url:
-        raise RuntimeError("SUPABASE_JWKS_ISSUER or SUPABASE_URL not configured")
-    return f"{base_url.rstrip('/')}/auth/v1"
-
-
-def _expected_audience() -> str:
-    return os.getenv("SUPABASE_JWT_AUD", "authenticated")
-
-
-def _fetch_jwks(force: bool = False) -> dict[str, dict]:
-    """Fetch JWKS and cache results."""
-    global _JWKS_CACHE, _JWKS_LAST_FETCH
-    now = time.time()
-    if force or now - _JWKS_LAST_FETCH > _JWKS_TTL or not _JWKS_CACHE:
-        resp = requests.get(_jwks_url(), timeout=5)
-        resp.raise_for_status()
-        data = resp.json()
-        _JWKS_CACHE = {jwk["kid"]: jwk for jwk in data.get("keys", [])}
-        _JWKS_LAST_FETCH = now
-    return _JWKS_CACHE
-
-
-def _get_key(kid: str):
-    jwks = _fetch_jwks()
-    if kid not in jwks:
-        jwks = _fetch_jwks(force=True)
-    jwk = jwks.get(kid)
-    if not jwk:
-        raise InvalidTokenError("Unknown key id")
-    return jwt.algorithms.RSAAlgorithm.from_jwk(json.dumps(jwk))
+_jwk = PyJWKClient(JWKS_URL) if JWKS_URL else None
+_opts = {"verify_exp": True, "require": ["exp", "iat", "iss", "aud", "sub"]}
 
 
 def verify_jwt(token: str) -> dict:
     """Verify a Supabase JWT and return its payload."""
-    header = jwt.get_unverified_header(token)
-    kid = header.get("kid")
-    if not kid:
-        raise InvalidTokenError("Missing kid")
-    key = _get_key(kid)
-    try:
+    alg = (jwt.get_unverified_header(token).get("alg") or "").upper()
+    if alg == "HS256":
+        if not JWT_SECRET:
+            raise RuntimeError("SUPABASE_JWT_SECRET missing for HS256 verification")
+        return jwt.decode(
+            token,
+            JWT_SECRET,
+            algorithms=["HS256"],
+            audience=AUD,
+            issuer=ISSUER,
+            options=_opts,
+            leeway=LEEWAY,
+        )
+    if alg == "RS256":
+        if not _jwk:
+            raise RuntimeError("JWKS unavailable for RS256 verification")
+        key = _jwk.get_signing_key_from_jwt(token).key
         return jwt.decode(
             token,
             key,
             algorithms=["RS256"],
-            issuer=_expected_issuer(),
-            audience=_expected_audience(),
-            leeway=60,
+            audience=AUD,
+            issuer=ISSUER,
+            options=_opts,
+            leeway=LEEWAY,
         )
-    except InvalidTokenError as e:
-        try:
-            payload = jwt.decode(token, options={"verify_signature": False})
-            logger.error(
-                "JWT validation failed: iss=%s aud=%s sub=%s error=%s",
-                payload.get("iss"),
-                payload.get("aud"),
-                payload.get("sub"),
-                e.__class__.__name__,
-            )
-        except Exception:
-            logger.error(
-                "JWT validation failed: error=%s",
-                e.__class__.__name__,
-            )
-        raise
+    raise jwt.InvalidAlgorithmError(f"Unsupported JWT alg: {alg}")
 
 
 __all__ = ["verify_jwt"]


### PR DESCRIPTION
## Summary
- expose JWT header algorithm and payload in the `/api/baskets/new` Next.js route when the backend returns 401
- log JWT verification info in FastAPI middleware and surface `X-Auth-*` headers
- allow backend to validate both HS256 and RS256 Supabase tokens

## Testing
- `python3 -m pytest api/tests/api/test_basket_new.py::test_basket_new_replay -q` (fails: ImportError: cannot import name 'Client' from 'supabase')
- `npm test`
- `npm run build:check`

------
https://chatgpt.com/codex/tasks/task_e_68a07f03badc8329b37aafe552a70d1e