### PR TITLE
Sanitize Supabase env strings and gate auth debug header

### DIFF
--- a/web/app/api/baskets/new/route.ts
+++ b/web/app/api/baskets/new/route.ts
@@ -3,14 +3,45 @@ export const runtime = "nodejs"; // avoid Edge so supabase-helpers work
 export const dynamic = "force-dynamic";
 
 import { NextRequest, NextResponse } from "next/server";
-import { cookies } from "next/headers";
+import { cookies, headers as nextHeaders } from "next/headers";
 import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
 import { CreateBasketReqSchema } from "@/lib/schemas/baskets";
+import crypto from "node:crypto";
 
 const API_BASE =
   process.env.NEXT_PUBLIC_API_BASE_URL ?? "https://api.yarnnn.com";
 
+function hash(v: string) {
+  return crypto.createHash("sha256").update(v).digest("hex").slice(0, 8);
+}
+
+function safeDecode(token?: string) {
+  try {
+    if (!token) return {};
+    const [h, p] = token.split(".");
+    const header = JSON.parse(Buffer.from(h, "base64").toString());
+    const payload = JSON.parse(Buffer.from(p, "base64").toString());
+    return {
+      tokenHeaderAlg: header.alg,
+      tokenClaims: {
+        iss: payload.iss,
+        aud: payload.aud,
+        sub_hash: payload.sub ? hash(payload.sub) : undefined,
+        exp: payload.exp,
+        iat: payload.iat,
+        aal: payload.aal,
+        amr: Array.isArray(payload.amr)
+          ? payload.amr.map((m: any) => m.method)
+          : undefined,
+      },
+    };
+  } catch {
+    return {};
+  }
+}
+
 export async function POST(req: NextRequest) {
+  const DBG = nextHeaders().get("x-yarnnn-debug-auth") === "1";
   // 1) Parse & validate request (canon: { idempotency_key, basket: { name? } })
   let json: unknown;
   try {
@@ -42,21 +73,10 @@ export async function POST(req: NextRequest) {
     data: { user },
     error: userError,
   } = await supabase.auth.getUser();
-  
+
   if (userError || !user) {
-    console.error("baskets/new: No authenticated user", userError);
     return NextResponse.json(
-      { 
-        error: { 
-          code: "UNAUTHORIZED", 
-          message: "Not authenticated",
-          debug: {
-            location: "baskets/new route handler",
-            issue: "No authenticated user found",
-            error: userError?.message
-          }
-        } 
-      },
+      { error: { code: "UNAUTHORIZED", message: "Not authenticated" } },
       { status: 401 }
     );
   }
@@ -68,49 +88,12 @@ export async function POST(req: NextRequest) {
   
   if (!session?.access_token) {
     return NextResponse.json(
-      { 
-        error: { 
-          code: "UNAUTHORIZED", 
-          message: "No access token",
-          debug: {
-            location: "baskets/new route handler", 
-            issue: "Session exists but no access token",
-            hasUser: true,
-            userId: user.id
-          }
-        } 
-      },
+      { error: { code: "UNAUTHORIZED", message: "No access token" } },
       { status: 401 }
     );
   }
-  
-  const accessToken = session.access_token;
-  
-  // Decode token to check header & payload (without verification)
-  let tokenHeaderAlg: string | undefined;
-  let tokenPayload: any = undefined;
-  try {
-    const parts = accessToken.split(".");
-    if (parts.length === 3) {
-      tokenHeaderAlg = JSON.parse(
-        Buffer.from(parts[0], "base64").toString()
-      ).alg;
-      tokenPayload = JSON.parse(
-        Buffer.from(parts[1], "base64").toString()
-      );
-    }
-  } catch {
-    tokenHeaderAlg = "decode-failed";
-    tokenPayload = { error: "Failed to decode token" };
-  }
 
-  console.log("baskets/new: Token forwarding", {
-    hasToken: !!accessToken,
-    tokenPrefix: accessToken?.substring(0, 20) + "...",
-    apiBase: API_BASE,
-    tokenHeaderAlg,
-    tokenPayload,
-  });
+  const accessToken = session.access_token;
 
   // 3) Forward to FastAPI with Bearer token (workspace bootstrap is server-side)
   // Forward canonical payload to FastAPI
@@ -124,54 +107,34 @@ export async function POST(req: NextRequest) {
       "content-type": "application/json",
       Authorization: `Bearer ${accessToken}`,
       "sb-access-token": accessToken,
+      ...(DBG ? { "x-yarnnn-debug-auth": "1" } : {}),
     },
     body: JSON.stringify(payload),
   });
 
   const text = await res.text();
-  
-  // Log response for debugging
-  console.log("baskets/new: FastAPI response", { 
-    status: res.status, 
-    body: text.substring(0, 200) + (text.length > 200 ? "..." : "")
-  });
-  
-  // If FastAPI returns 401, add debug info
-  if (res.status === 401) {
-    try {
-      const errorData = JSON.parse(text);
-      return NextResponse.json({
-        ...errorData,
+  if (!res.ok && DBG) {
+    const { tokenHeaderAlg, tokenClaims } = safeDecode(accessToken);
+    return NextResponse.json(
+      {
+        error: { code: "UPSTREAM", message: "Auth failed" },
         debug: {
           location: "baskets/new -> FastAPI",
-          apiBase: API_BASE,
           apiUrl: `${API_BASE}/api/baskets/new`,
-          hasToken: !!accessToken,
-          tokenPrefix: accessToken?.substring(0, 20) + "...",
           tokenHeaderAlg,
-          tokenPayload,
-          headers: {
-            Authorization: `Bearer ${accessToken?.substring(0, 20)}...`,
-            "sb-access-token": accessToken?.substring(0, 20) + "..."
-          },
-          supabaseUrl: process.env.NEXT_PUBLIC_SUPABASE_URL,
-          expectedByBackend: {
-            hint: "Backend expects same SUPABASE_URL in its env vars",
-            issuer: `${process.env.NEXT_PUBLIC_SUPABASE_URL}/auth/v1`,
-            audience: "authenticated"
-          },
-          originalError: errorData
-        }
-      }, { status: 401 });
-    } catch {
-      // If response isn't JSON, return as-is
-    }
+          tokenClaims,
+          upstream: (() => {
+            try {
+              return JSON.parse(text);
+            } catch {
+              return { raw: text.slice(0, 200) };
+            }
+          })(),
+        },
+      },
+      { status: res.status }
+    );
   }
-  
-  return new NextResponse(text, {
-    status: res.status,
-    headers: {
-      "content-type": res.headers.get("content-type") ?? "application/json",
-    },
-  });
+
+  return new NextResponse(text, { status: res.status });
 }

--- a/web/lib/baskets/createBasketWithInput.ts
+++ b/web/lib/baskets/createBasketWithInput.ts
@@ -22,10 +22,14 @@ export async function createBasketWithInput({
     basket: {},
   };
   if (name) payload.basket.name = name;
-  console.log("[createBasketWithInput] Payload:", payload);
+  const extraHeaders =
+    typeof window !== "undefined" &&
+    localStorage.getItem("Y_AUTH_DEBUG") === "1"
+      ? { "x-yarnnn-debug-auth": "1" }
+      : {};
   const resp = await fetchWithToken("/api/baskets/new", {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": "application/json", ...extraHeaders },
     body: JSON.stringify(payload),
   });
   if (!resp.ok) {


### PR DESCRIPTION
## Summary
- Strip whitespace and trailing slashes from Supabase URL-related env vars
- Fail fast when SUPABASE_URL is missing and sanitize JWKS URL
- Log cleaned expected issuer and audience when JWT verification fails
- Gate auth debug behind `x-yarnnn-debug-auth` so diagnostics only emit when requested
- Allow client fetches to toggle the header via `localStorage`

## Testing
- `PYENV_VERSION=3.11.12 python -m py_compile api/src/auth/jwt_verifier.py api/src/middleware/auth.py`
- `PYENV_VERSION=3.11.12 make tests` *(fails: duplicate base class BaseSchema)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a13012b97883299f19acbbb5c4798a