### PR TITLE
Validate basket work requests

### DIFF
--- a/api/src/app/baskets/schemas.py
+++ b/api/src/app/baskets/schemas.py
@@ -28,7 +28,8 @@ class WorkOptions(BaseModel):
 
 class BasketWorkRequest(BaseModel):
     mode: WorkMode
-    sources: list[Source] = Field(default_factory=list)
+    # Require at least one source to avoid undefined work requests
+    sources: list[Source] = Field(..., min_length=1)
     policy: WorkPolicy = WorkPolicy()
     options: WorkOptions = WorkOptions()
 

--- a/api/tests/api/test_basket_work_validation.py
+++ b/api/tests/api/test_basket_work_validation.py
@@ -1,0 +1,41 @@
+import os
+import sys
+import types
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+# Set env vars and stub external deps before importing router
+os.environ.setdefault("SUPABASE_URL", "http://stub.local")
+os.environ.setdefault("SUPABASE_ANON_KEY", "stub-anon")
+sys.modules["supabase"] = types.SimpleNamespace(create_client=lambda *a, **k: None, Client=object)
+sys.modules["app.utils.jwt"] = types.SimpleNamespace(verify_jwt=lambda *_a, **_k: {"user_id": "u"})
+
+from app.routes import baskets
+
+
+def build_client(monkeypatch: types.SimpleNamespace) -> TestClient:
+    monkeypatch.setattr(baskets, "get_or_create_workspace", lambda _u: "ws1")
+    app = FastAPI()
+    app.include_router(baskets.router)
+
+    async def _get_db_override():
+        return None
+
+    app.dependency_overrides[baskets.get_db] = _get_db_override
+    return TestClient(app)
+
+
+def test_work_requires_sources(monkeypatch):
+    client = build_client(monkeypatch)
+    resp = client.post("/api/baskets/b1/work", json={"mode": "init_build", "sources": []})
+    assert resp.status_code == 422
+
+
+def test_invalid_json(monkeypatch):
+    client = build_client(monkeypatch)
+    resp = client.post(
+        "/api/baskets/b1/work",
+        content=b"not-json",
+        headers={"Content-Type": "application/json"},
+    )
+    assert resp.status_code in (400, 422)

--- a/web/app/api/baskets/[id]/work/route.ts
+++ b/web/app/api/baskets/[id]/work/route.ts
@@ -4,7 +4,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { cookies } from 'next/headers';
 import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
-import { z } from 'zod';
+import { z, ZodError } from 'zod';
 
 interface RouteContext {
   params: Promise<{ id: string }>;
@@ -17,7 +17,12 @@ export async function POST(
   try {
     const { id: basketId } = await context.params;
     const reqId = request.headers.get('X-Req-Id') || `ui-${Date.now()}`;
-    const body = await request.json();
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch (err) {
+      return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+    }
 
     // Support both new mode format and legacy format
     const hasMode = 'mode' in body;
@@ -27,11 +32,13 @@ export async function POST(
       // New BasketWorkRequest format
       const NewSchema = z.object({
         mode: z.enum(['init_build', 'evolve_turn']),
-        sources: z.array(z.object({ 
-          type: z.string(), 
-          id: z.string(),
-          content: z.string().optional()
-        })),
+        sources: z.array(
+          z.object({
+            type: z.string(),
+            id: z.string(),
+            content: z.string().optional()
+          })
+        ).min(1, 'sources must include at least one item'),
         policy: z.object({
           allow_structural_changes: z.boolean().optional(),
           preserve_blocks: z.array(z.string()).optional(),
@@ -101,6 +108,9 @@ export async function POST(
 
     return NextResponse.json(result);
   } catch (error) {
+    if (error instanceof ZodError) {
+      return NextResponse.json({ error: 'Invalid request', details: error.errors }, { status: 400 });
+    }
     console.error('❌ API Bridge error:', error);
     const errorMessage = error instanceof Error ? error.message : 'Unknown error';
     return NextResponse.json(

--- a/web/app/api/baskets/[id]/work/route.ts
+++ b/web/app/api/baskets/[id]/work/route.ts
@@ -25,7 +25,8 @@ export async function POST(
     }
 
     // Support both new mode format and legacy format
-    const hasMode = 'mode' in body;
+    const hasMode =
+      typeof body === 'object' && body !== null && 'mode' in body;
     
     let parsed: any;
     if (hasMode) {

--- a/web/app/api/baskets/new/route.ts
+++ b/web/app/api/baskets/new/route.ts
@@ -3,10 +3,10 @@ export const runtime = "nodejs"; // avoid Edge so supabase-helpers work
 export const dynamic = "force-dynamic";
 
 import { NextRequest, NextResponse } from "next/server";
-import { cookies, headers as nextHeaders } from "next/headers";
+import { cookies } from "next/headers";
 import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
 import { CreateBasketReqSchema } from "@/lib/schemas/baskets";
-import crypto from "node:crypto";
+import crypto, { randomUUID } from "node:crypto";
 
 const API_BASE =
   process.env.NEXT_PUBLIC_API_BASE_URL ?? "https://api.yarnnn.com";
@@ -41,7 +41,8 @@ function safeDecode(token?: string) {
 }
 
 export async function POST(req: NextRequest) {
-  const DBG = nextHeaders().get("x-yarnnn-debug-auth") === "1";
+  const DBG = req.headers.get("x-yarnnn-debug-auth") === "1";
+  const requestId = req.headers.get("x-request-id") ?? randomUUID();
   // 1) Parse & validate request (canon: { idempotency_key, basket: { name? } })
   let json: unknown;
   try {
@@ -107,6 +108,7 @@ export async function POST(req: NextRequest) {
       "content-type": "application/json",
       Authorization: `Bearer ${accessToken}`,
       "sb-access-token": accessToken,
+      "x-request-id": requestId,
       ...(DBG ? { "x-yarnnn-debug-auth": "1" } : {}),
     },
     body: JSON.stringify(payload),

--- a/web/lib/baskets/createBasketWithInput.ts
+++ b/web/lib/baskets/createBasketWithInput.ts
@@ -22,7 +22,7 @@ export async function createBasketWithInput({
     basket: {},
   };
   if (name) payload.basket.name = name;
-  const extraHeaders =
+  const extraHeaders: Record<string, string> =
     typeof window !== "undefined" &&
     localStorage.getItem("Y_AUTH_DEBUG") === "1"
       ? { "x-yarnnn-debug-auth": "1" }


### PR DESCRIPTION
## Summary
- require at least one source in `BasketWorkRequest`
- validate and handle malformed JSON in `/api/baskets/{id}/work`
- add frontend bridge schema and error handling
- add tests for missing sources and bad JSON

## Testing
- `PYENV_VERSION=3.11.12 python -m pytest api/tests/api/test_basket_work_validation.py -q`
- `cd web && npx vitest run --reporter=basic` *(fails: Cannot find module 'vitest/config')*

------
https://chatgpt.com/codex/tasks/task_e_68a137996b7483299caf0eaf70b24169