### PR TITLE
Stabilize work page auth flow and API proxy runtime

### DIFF
--- a/docs/YARNNN_INTERFACE_SPEC_v0.1.0.md
+++ b/docs/YARNNN_INTERFACE_SPEC_v0.1.0.md
@@ -30,7 +30,7 @@ export type CreateBasketReq = {
   idempotency_key: string; // UUID
   basket: { name?: string };
 };
-export type CreateBasketRes = { basket_id: string };
+export type CreateBasketRes = { basket_id: string; id: string; name: string };
 // shared/contracts/dumps.ts
 export type CreateDumpReq = {
   basket_id: string;
@@ -56,6 +56,8 @@ export type IngestReq = {
 };
 export type IngestRes = {
   basket_id: string;
+  id: string;
+  name: string;
   dumps: CreateDumpRes[];
 };
 ```

--- a/scripts/check-auth-handshake.mjs
+++ b/scripts/check-auth-handshake.mjs
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import path from 'path';
 
 function extractRef(url) {
   const match = url?.match(/^https:\/\/([^.]+)\.supabase\.co/);
@@ -23,10 +24,63 @@ if (!refUrl || refUrl !== refJwks || refUrl !== refIssuer) {
   process.exit(1);
 }
 
-const route = fs.readFileSync('web/app/api/baskets/new/route.ts', 'utf8');
-if (!route.includes('export const runtime = "nodejs"')) {
-  console.error('web/app/api/baskets/new/route.ts missing runtime export');
-  process.exit(1);
+function walk(dir, cb) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const res = path.join(dir, entry.name);
+    if (entry.isDirectory()) walk(res, cb);
+    else cb(res);
+  }
 }
+
+// Ensure all API proxies using NEXT_PUBLIC_API_BASE_URL run on node
+const routeFiles = [];
+walk('web/app/api', (file) => {
+  if (file.endsWith('route.ts')) routeFiles.push(file);
+});
+for (const file of routeFiles) {
+  const content = fs.readFileSync(file, 'utf8');
+  if (
+    content.includes('NEXT_PUBLIC_API_BASE_URL') &&
+    !content.includes('export const runtime = "nodejs"')
+  ) {
+    console.error(`${file} missing runtime export`);
+    process.exit(1);
+  }
+}
+
+// Fail on hardcoded api.yarnnn.com
+let literalFound = false;
+walk('web', (file) => {
+  if (file.includes('node_modules')) return;
+  if (
+    file.includes(`${path.sep}tests${path.sep}`) ||
+    file.includes(`${path.sep}__tests__${path.sep}`) ||
+    file.includes(`${path.sep}__mocks__${path.sep}`) ||
+    file.includes(`${path.sep}fixtures${path.sep}`)
+  )
+    return;
+  if (!file.match(/\.(tsx?|jsx?|mjs|cjs)$/)) return;
+  const content = fs.readFileSync(file, 'utf8');
+  if (content.includes('https://api.yarnnn.com')) {
+    console.error(`Disallowed api.yarnnn.com literal in ${file}`);
+    literalFound = true;
+  }
+});
+if (literalFound) process.exit(1);
+
+// Ensure client code doesn't send workspace_id
+walk('web', (file) => {
+  if (file.includes(`${path.sep}app${path.sep}api${path.sep}`)) return;
+  if (file.includes(`${path.sep}lib${path.sep}`)) return;
+  if (!file.match(/\.(tsx?|jsx?)$/)) return;
+  const content = fs.readFileSync(file, 'utf8');
+  if (
+    content.includes("localStorage.getItem('workspace_id')") ||
+    content.includes('X-Workspace-Id')
+  ) {
+    console.error(`workspace_id found in client code: ${file}`);
+    process.exit(1);
+  }
+});
 
 console.log('Auth handshake check passed');

--- a/shared/contracts/baskets.ts
+++ b/shared/contracts/baskets.ts
@@ -10,4 +10,6 @@ export type CreateBasketReq = {
 
 export type CreateBasketRes = {
   basket_id: string; // UUID
+  id: string; // UUID (duplicate of basket_id for legacy clients)
+  name: string;
 };

--- a/web/app/api/baskets/[id]/deltas/route.ts
+++ b/web/app/api/baskets/[id]/deltas/route.ts
@@ -1,145 +1,98 @@
-import { NextRequest, NextResponse } from "next/server";
-import { createServerSupabaseClient } from "@/lib/supabaseServerClient";
-import { ensureWorkspaceServer } from "@/lib/workspaces/ensureWorkspaceServer";
+export const runtime = "nodejs";
+
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { createServerClient } from "@supabase/auth-helpers-nextjs";
+import { createHash, randomUUID } from "node:crypto";
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL!;
+
+function hash(v: string) {
+  return createHash("sha256").update(v).digest("hex").slice(0, 8);
+}
+
+function safeDecode(token?: string) {
+  try {
+    if (!token) return {};
+    const [h, p] = token.split(".");
+    const header = JSON.parse(Buffer.from(h, "base64").toString());
+    const payload = JSON.parse(Buffer.from(p, "base64").toString());
+    return {
+      tokenHeaderAlg: header.alg,
+      tokenClaims: {
+        iss: payload.iss,
+        aud: payload.aud,
+        sub_hash: payload.sub ? hash(payload.sub) : undefined,
+        exp: payload.exp,
+        iat: payload.iat,
+        aal: payload.aal,
+        amr: Array.isArray(payload.amr)
+          ? payload.amr.map((m: any) => m.method)
+          : undefined,
+      },
+    };
+  } catch {
+    return {};
+  }
+}
 
 interface RouteContext {
   params: Promise<{ id: string }>;
 }
 
-// GET basket deltas - Proxy to external backend with CORS handling
-export async function GET(
-  request: NextRequest,
-  context: RouteContext
-) {
-  try {
-    const { id: basketId } = await context.params;
-    const supabase = createServerSupabaseClient();
-    
-    // Verify authentication
-    const {
-      data: { user },
-      error: authError,
-    } = await supabase.auth.getUser();
-
-    if (authError || !user) {
-      return NextResponse.json(
-        { error: "Authentication required" },
-        { status: 401 }
-      );
-    }
-
-    // Ensure user has a workspace and can access this basket
-    const workspace = await ensureWorkspaceServer(supabase);
-    if (!workspace) {
-      return NextResponse.json(
-        { error: "Failed to get workspace" },
-        { status: 500 }
-      );
-    }
-
-    // Verify basket exists and user has access
-    const { data: basket, error: basketError } = await supabase
-      .from("baskets")
-      .select("id")
-      .eq("id", basketId)
-      .eq("workspace_id", workspace.id)
-      .single();
-
-    if (basketError || !basket) {
-      return NextResponse.json(
-        { error: "Basket not found or access denied" },
-        { status: 404 }
-      );
-    }
-
-    // Try external backend first, fallback to local data
-    const backendUrl = process.env.BACKEND_URL || process.env.NEXT_PUBLIC_API_BASE_URL || 'https://rightnow-api.onrender.com';
-    const endpoint = `${backendUrl}/api/baskets/${basketId}/deltas`;
-    
-    console.log('🔄 Deltas Proxy: Attempting backend call:', endpoint);
-    
-    try {
-      const response = await fetch(endpoint, {
-        method: 'GET',
-        headers: {
-          'Content-Type': 'application/json',
-          'User-Agent': 'NextJS-Proxy/1.0',
-        },
-        // Add timeout to prevent hanging
-        signal: AbortSignal.timeout(10000), // 10 second timeout
-      });
-
-      if (response.ok) {
-        const deltas = await response.json();
-        console.log('✅ Deltas Proxy: Backend success:', deltas?.length || 0, 'deltas');
-        
-        // Add CORS headers
-        const corsResponse = NextResponse.json(deltas);
-        corsResponse.headers.set('Access-Control-Allow-Origin', '*');
-        corsResponse.headers.set('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');
-        corsResponse.headers.set('Access-Control-Allow-Headers', 'Content-Type, Authorization');
-        
-        return corsResponse;
-      } else {
-        console.warn('⚠️ Deltas Proxy: Backend failed:', response.status, response.statusText);
-      }
-    } catch (fetchError) {
-      console.warn('⚠️ Deltas Proxy: Backend unreachable:', fetchError instanceof Error ? fetchError.message : 'Unknown error');
-    }
-
-    // Fallback: Return local mock data or empty array
-    console.log('🔄 Deltas Proxy: Using fallback - returning empty deltas array');
-    
-    const fallbackDeltas = [
-      {
-        delta_id: `mock-${Date.now()}`,
-        basket_id: basketId,
-        summary: "System initializing - no deltas available yet",
-        created_at: new Date().toISOString(),
-        status: "info",
-        changes: [],
-        metadata: {
-          source: "fallback",
-          reason: "backend_unavailable"
-        }
-      }
-    ];
-
-    const response = NextResponse.json(fallbackDeltas);
-    response.headers.set('Access-Control-Allow-Origin', '*');
-    response.headers.set('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');
-    response.headers.set('Access-Control-Allow-Headers', 'Content-Type, Authorization');
-    
-    return response;
-
-  } catch (error) {
-    console.error('❌ Deltas Proxy error:', error);
-    const errorResponse = NextResponse.json(
-      { 
-        error: 'Failed to fetch deltas',
-        details: error instanceof Error ? error.message : 'Unknown error'
-      },
-      { status: 500 }
+export async function GET(req: NextRequest, ctx: RouteContext) {
+  const { id: basketId } = await ctx.params;
+  const DBG = req.headers.get("x-yarnnn-debug-auth") === "1";
+  const cookieStore = cookies();
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    { cookies: { get: (name) => cookieStore.get(name)?.value } }
+  );
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+  if (!session?.access_token) {
+    return NextResponse.json(
+      { error: { code: "UNAUTHORIZED", message: "Missing session" } },
+      { status: 401 }
     );
-    
-    // Add CORS headers even for errors
-    errorResponse.headers.set('Access-Control-Allow-Origin', '*');
-    errorResponse.headers.set('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');
-    errorResponse.headers.set('Access-Control-Allow-Headers', 'Content-Type, Authorization');
-    
-    return errorResponse;
   }
-}
-
-// Handle preflight requests
-export async function OPTIONS(request: NextRequest) {
-  return new NextResponse(null, {
-    status: 200,
+  const requestId = req.headers.get("x-request-id") ?? randomUUID();
+  const res = await fetch(`${API_BASE}/api/baskets/${basketId}/deltas`, {
+    method: "GET",
+    cache: "no-store",
     headers: {
-      'Access-Control-Allow-Origin': '*',
-      'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
-      'Access-Control-Allow-Headers': 'Content-Type, Authorization',
-      'Access-Control-Max-Age': '86400',
+      "content-type": "application/json",
+      Authorization: `Bearer ${session.access_token}`,
+      "sb-access-token": session.access_token,
+      "x-request-id": requestId,
+      ...(DBG ? { "x-yarnnn-debug-auth": "1" } : {}),
     },
   });
+  const text = await res.text();
+  if (!res.ok && DBG) {
+    const { tokenHeaderAlg, tokenClaims } = safeDecode(session.access_token);
+    return NextResponse.json(
+      {
+        error: { code: "UPSTREAM", message: "Upstream error" },
+        debug: {
+          location: "baskets/deltas -> FastAPI",
+          apiUrl: `${API_BASE}/api/baskets/${basketId}/deltas`,
+          tokenHeaderAlg,
+          tokenClaims,
+          upstream: (() => {
+            try {
+              return JSON.parse(text);
+            } catch {
+              return { raw: text.slice(0, 200) };
+            }
+          })(),
+        },
+      },
+      { status: res.status }
+    );
+  }
+  return new NextResponse(text, { status: res.status });
 }

--- a/web/app/api/baskets/[id]/deltas/route.ts
+++ b/web/app/api/baskets/[id]/deltas/route.ts
@@ -3,7 +3,7 @@ export const runtime = "nodejs";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
-import { createServerClient } from "@supabase/auth-helpers-nextjs";
+import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
 import { createHash, randomUUID } from "node:crypto";
 
 const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL!;
@@ -44,12 +44,7 @@ interface RouteContext {
 export async function GET(req: NextRequest, ctx: RouteContext) {
   const { id: basketId } = await ctx.params;
   const DBG = req.headers.get("x-yarnnn-debug-auth") === "1";
-  const cookieStore = cookies();
-  const supabase = createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-    { cookies: { get: (name) => cookieStore.get(name)?.value } }
-  );
+  const supabase = createRouteHandlerClient({ cookies });
   const {
     data: { session },
   } = await supabase.auth.getSession();

--- a/web/app/api/baskets/[id]/work/route.ts
+++ b/web/app/api/baskets/[id]/work/route.ts
@@ -1,137 +1,169 @@
-// API Bridge: Frontend Next.js → Backend Manager Agent
-// This is the critical missing link between the two systems
+export const runtime = "nodejs";
 
-import { NextRequest, NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
-import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
-import { z, ZodError } from 'zod';
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { createServerClient } from "@supabase/auth-helpers-nextjs";
+import { z, ZodError } from "zod";
+import { createHash, randomUUID } from "node:crypto";
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL!;
+
+function hash(v: string) {
+  return createHash("sha256").update(v).digest("hex").slice(0, 8);
+}
+
+function safeDecode(token?: string) {
+  try {
+    if (!token) return {};
+    const [h, p] = token.split(".");
+    const header = JSON.parse(Buffer.from(h, "base64").toString());
+    const payload = JSON.parse(Buffer.from(p, "base64").toString());
+    return {
+      tokenHeaderAlg: header.alg,
+      tokenClaims: {
+        iss: payload.iss,
+        aud: payload.aud,
+        sub_hash: payload.sub ? hash(payload.sub) : undefined,
+        exp: payload.exp,
+        iat: payload.iat,
+        aal: payload.aal,
+        amr: Array.isArray(payload.amr)
+          ? payload.amr.map((m: any) => m.method)
+          : undefined,
+      },
+    };
+  } catch {
+    return {};
+  }
+}
 
 interface RouteContext {
   params: Promise<{ id: string }>;
 }
 
-export async function POST(
-  request: NextRequest, 
-  context: RouteContext
-) {
+export async function POST(req: NextRequest, ctx: RouteContext) {
   try {
-    const { id: basketId } = await context.params;
-    const reqId = request.headers.get('X-Req-Id') || `ui-${Date.now()}`;
+    const { id: basketId } = await ctx.params;
+    const DBG = req.headers.get("x-yarnnn-debug-auth") === "1";
     let body: unknown;
     try {
-      body = await request.json();
-    } catch (err) {
-      return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+      body = await req.json();
+    } catch {
+      return NextResponse.json(
+        { error: { code: "INVALID_JSON", message: "Malformed JSON" } },
+        { status: 400 }
+      );
     }
 
-    // Support both new mode format and legacy format
-    const hasMode =
-      typeof body === 'object' && body !== null && 'mode' in body;
-    
+    const hasMode = typeof body === "object" && body !== null && "mode" in body;
     let parsed: any;
     if (hasMode) {
-      // New BasketWorkRequest format
       const NewSchema = z.object({
-        mode: z.enum(['init_build', 'evolve_turn']),
-        sources: z.array(
-          z.object({
-            type: z.string(),
-            id: z.string(),
-            content: z.string().optional()
+        mode: z.enum(["init_build", "evolve_turn"]),
+        sources: z
+          .array(
+            z.object({
+              type: z.string(),
+              id: z.string(),
+              content: z.string().optional(),
+            })
+          )
+          .min(1, "sources must include at least one item"),
+        policy: z
+          .object({
+            allow_structural_changes: z.boolean().optional(),
+            preserve_blocks: z.array(z.string()).optional(),
+            update_document_ids: z.array(z.string()).optional(),
+            strict_link_provenance: z.boolean().optional(),
           })
-        ).min(1, 'sources must include at least one item'),
-        policy: z.object({
-          allow_structural_changes: z.boolean().optional(),
-          preserve_blocks: z.array(z.string()).optional(),
-          update_document_ids: z.array(z.string()).optional(),
-          strict_link_provenance: z.boolean().optional()
-        }).optional(),
-        options: z.object({
-          fast: z.boolean().optional(),
-          max_tokens: z.number().optional(),
-          trace_req_id: z.string().optional()
-        }).optional()
+          .optional(),
+        options: z
+          .object({
+            fast: z.boolean().optional(),
+            max_tokens: z.number().optional(),
+            trace_req_id: z.string().optional(),
+          })
+          .optional(),
       });
       parsed = NewSchema.parse(body);
     } else {
-      // Legacy BasketChangeRequest format
       const LegacySchema = z.object({
         request_id: z.string(),
         basket_id: z.string().uuid(),
         intent: z.string().optional(),
-        sources: z.array(z.object({ type: z.string(), id: z.string().optional() })).optional(),
+        sources: z
+          .array(z.object({ type: z.string(), id: z.string().optional() }))
+          .optional(),
       });
       parsed = LegacySchema.parse(body);
     }
 
-    const supabase = createRouteHandlerClient({ cookies });
+    const cookieStore = cookies();
+    const supabase = createServerClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+      { cookies: { get: (name) => cookieStore.get(name)?.value } }
+    );
     const {
       data: { session },
     } = await supabase.auth.getSession();
-
     if (!session?.access_token) {
-      console.error('baskets/work unauthorized', { reqId });
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+      return NextResponse.json(
+        { error: { code: "UNAUTHORIZED", message: "Missing session" } },
+        { status: 401 }
+      );
     }
+    const requestId = req.headers.get("x-request-id") ?? randomUUID();
 
-    const workspaceId =
-      (session.user?.app_metadata as any)?.workspace_id ||
-      (session.user?.user_metadata as any)?.workspace_id ||
-      null;
-
-    const backendUrl = process.env.API_BASE ?? 'https://api.yarnnn.com';
-    const endpoint = `${backendUrl}/api/baskets/${basketId}/work`;
-
-    console.log('🌉 API Bridge: Proxying to backend:', endpoint);
-
-    const response = await fetch(endpoint, {
-      method: 'POST',
+    const res = await fetch(`${API_BASE}/api/baskets/${basketId}/work`, {
+      method: "POST",
+      cache: "no-store",
       headers: {
-        'Content-Type': 'application/json',
+        "content-type": "application/json",
         Authorization: `Bearer ${session.access_token}`,
-        ...(workspaceId ? { 'X-Workspace-Id': String(workspaceId) } : {}),
-        'X-Req-Id': reqId,
+        "sb-access-token": session.access_token,
+        "x-request-id": requestId,
+        ...(DBG ? { "x-yarnnn-debug-auth": "1" } : {}),
       },
       body: JSON.stringify(parsed),
     });
 
-    if (!response.ok) {
-      const text = await response.text();
-      console.error('❌ Backend Manager Agent failed:', response.status, text.slice(0, 500));
+    const text = await res.text();
+    if (!res.ok && DBG) {
+      const { tokenHeaderAlg, tokenClaims } = safeDecode(session.access_token);
       return NextResponse.json(
-        { error: text || `Manager Agent failed (${response.status})` },
-        { status: response.status }
+        {
+          error: { code: "UPSTREAM", message: "Upstream error" },
+          debug: {
+            location: "baskets/work -> FastAPI",
+            apiUrl: `${API_BASE}/api/baskets/${basketId}/work`,
+            tokenHeaderAlg,
+            tokenClaims,
+            upstream: (() => {
+              try {
+                return JSON.parse(text);
+              } catch {
+                return { raw: text.slice(0, 200) };
+              }
+            })(),
+          },
+        },
+        { status: res.status }
       );
     }
 
-    const result = await response.json();
-    console.log('✅ Manager Agent response:', { deltaId: result.delta_id, changes: result.changes?.length });
-
-    return NextResponse.json(result);
+    return new NextResponse(text, { status: res.status });
   } catch (error) {
     if (error instanceof ZodError) {
-      return NextResponse.json({ error: 'Invalid request', details: error.errors }, { status: 400 });
+      return NextResponse.json(
+        { error: { code: "INVALID_INPUT", details: error.errors } },
+        { status: 422 }
+      );
     }
-    console.error('❌ API Bridge error:', error);
-    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
     return NextResponse.json(
-      { error: 'API bridge failed', details: errorMessage },
+      { error: { code: "UPSTREAM", message: "API bridge failed" } },
       { status: 500 }
     );
   }
-}
-
-// Also handle GET for testing
-export async function GET(
-  request: NextRequest,
-  context: RouteContext
-) {
-  const { id: basketId } = await context.params;
-  
-  return NextResponse.json({
-    bridge: 'active',
-    basketId,
-    backendUrl: process.env.NEXT_PUBLIC_API_BASE_URL || 'https://rightnow-api.onrender.com',
-    message: 'API bridge is working. Use POST to send basket work requests.'
-  });
 }

--- a/web/app/api/baskets/[id]/work/route.ts
+++ b/web/app/api/baskets/[id]/work/route.ts
@@ -3,7 +3,7 @@ export const runtime = "nodejs";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
-import { createServerClient } from "@supabase/auth-helpers-nextjs";
+import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
 import { z, ZodError } from "zod";
 import { createHash, randomUUID } from "node:crypto";
 
@@ -99,12 +99,7 @@ export async function POST(req: NextRequest, ctx: RouteContext) {
       parsed = LegacySchema.parse(body);
     }
 
-    const cookieStore = cookies();
-    const supabase = createServerClient(
-      process.env.NEXT_PUBLIC_SUPABASE_URL!,
-      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-      { cookies: { get: (name) => cookieStore.get(name)?.value } }
-    );
+    const supabase = createRouteHandlerClient({ cookies });
     const {
       data: { session },
     } = await supabase.auth.getSession();

--- a/web/app/api/baskets/new/route.ts
+++ b/web/app/api/baskets/new/route.ts
@@ -8,8 +8,7 @@ import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
 import { CreateBasketReqSchema } from "@/lib/schemas/baskets";
 import crypto, { randomUUID } from "node:crypto";
 
-const API_BASE =
-  process.env.NEXT_PUBLIC_API_BASE_URL ?? "https://api.yarnnn.com";
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL!;
 
 function hash(v: string) {
   return crypto.createHash("sha256").update(v).digest("hex").slice(0, 8);
@@ -104,6 +103,7 @@ export async function POST(req: NextRequest) {
   };
   const res = await fetch(`${API_BASE}/api/baskets/new`, {
     method: "POST",
+    cache: "no-store",
     headers: {
       "content-type": "application/json",
       Authorization: `Bearer ${accessToken}`,

--- a/web/app/api/intelligence/generate/[basketId]/route.ts
+++ b/web/app/api/intelligence/generate/[basketId]/route.ts
@@ -1,4 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
+
+export const runtime = "nodejs";
 import { createServerSupabaseClient } from "@/lib/supabaseServerClient";
 import { ensureWorkspaceServer } from "@/lib/workspaces/ensureWorkspaceServer";
 import { getWorkspaceFromBasket } from "@/lib/utils/workspace";
@@ -215,11 +217,12 @@ export async function POST(
       // Call Python agent backend at deployed URL
       let agentResponse;
       try {
-        const agentUrl = process.env.NEXT_PUBLIC_API_BASE_URL || 'https://api.yarnnn.com';
+        const agentUrl = process.env.NEXT_PUBLIC_API_BASE_URL!;
         console.log('🤖 Calling agent backend:', `${agentUrl}/api/agent`);
         
         const response = await fetch(`${agentUrl}/api/agent`, {
           method: 'POST',
+          cache: 'no-store',
           headers: {
             'Content-Type': 'application/json',
             'Authorization': `Bearer ${user.id}` // Use user ID as auth for now

--- a/web/app/baskets/[id]/work/@center/page.tsx
+++ b/web/app/baskets/[id]/work/@center/page.tsx
@@ -1,5 +1,11 @@
-import DashboardCenter from '@/components/features/basket/centers/DashboardCenter';
-import CenterBoundary from '@/components/common/CenterBoundary';
+import DashboardCenter from "@/components/features/basket/centers/DashboardCenter";
+import CenterBoundary from "@/components/common/CenterBoundary";
+import { cookies } from "next/headers";
+import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
+import type { Database } from "@/lib/dbTypes";
+import { redirect } from "next/navigation";
+
+export const dynamic = "force-dynamic";
 
 interface DashboardPageProps {
   params: Promise<{ id: string }>;
@@ -7,6 +13,13 @@ interface DashboardPageProps {
 
 export default async function DashboardPage({ params }: DashboardPageProps) {
   const { id } = await params;
+  const supabase = createServerComponentClient<Database>({ cookies });
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    redirect(`/login?redirect=/baskets/${id}/work`);
+  }
   return (
     <CenterBoundary skeletonType="dashboard">
       <DashboardCenter basketId={id} />

--- a/web/components/BasketCard.tsx
+++ b/web/components/BasketCard.tsx
@@ -18,10 +18,11 @@ export default function BasketCard({ basket }: BasketCardProps) {
   const preview =
     basket.raw_dump_body?.slice(0, 150) || "No dump yet. Add something?";
   return (
-    <Link
-      href={`/baskets/${basket.id}/work`}
-      className="rounded-md border p-4 hover:bg-muted block"
-    >
+      <Link
+        href={`/baskets/${basket.id}/work`}
+        prefetch={false}
+        className="rounded-md border p-4 hover:bg-muted block"
+      >
       <div className="flex justify-between">
         <h3 className="text-md font-semibold truncate">
           🧺 {basket.name || "Untitled Basket"}

--- a/web/lib/api/http.ts
+++ b/web/lib/api/http.ts
@@ -124,13 +124,6 @@ export async function apiClient(request: ApiRequest): Promise<unknown> {
     authToken = session?.access_token;
   }
   
-  // Get workspace ID if available
-  let workspaceId: string | undefined;
-  if (typeof window !== 'undefined') {
-    // Try to get from local storage or context
-    workspaceId = localStorage.getItem('workspace_id') || undefined;
-  }
-  
   // Build full URL - handle both absolute and relative URLs
   const baseUrl = process.env.NEXT_PUBLIC_APP_URL || '';
   const fullUrl = url.startsWith('http') ? url : `${baseUrl}${url}`;
@@ -146,16 +139,12 @@ export async function apiClient(request: ApiRequest): Promise<unknown> {
     finalHeaders['Authorization'] = `Bearer ${authToken}`;
   }
   
-  if (workspaceId) {
-    finalHeaders['X-Workspace-Id'] = workspaceId;
-  }
   
   // Log request in development
   dlog('api/http/request', {
     url,
     method,
     requestId,
-    workspaceId,
     hasAuth: !!authToken,
   });
   

--- a/web/lib/schemas/baskets.ts
+++ b/web/lib/schemas/baskets.ts
@@ -10,4 +10,6 @@ export const CreateBasketReqSchema = z.object({
 
 export const CreateBasketResSchema = z.object({
   basket_id: z.string().uuid(),
+  id: z.string().uuid(),
+  name: z.string(),
 }) satisfies z.ZodType<CreateBasketRes>;

--- a/web/lib/schemas/ingest.ts
+++ b/web/lib/schemas/ingest.ts
@@ -18,6 +18,8 @@ export const IngestReqSchema = z.object({
 
 export const IngestResSchema = z.object({
   basket_id: z.string().uuid(),
+  id: z.string().uuid(),
+  name: z.string(),
   dumps: z.array(z.object({
     dump_id: z.string().uuid(),
   })),


### PR DESCRIPTION
## Summary
- Gate basket work page with server-side Supabase session and force dynamic rendering
- Disable prefetch on work page links and drop client workspace_id header
- Standardize basket work and delta API proxies on Node runtime with token forwarding and debug gating
- Add CI checks to block direct api.yarnnn.com usage and ensure proxies run on Node
- Use req.headers in all work-page proxies and disable caching on upstream fetches
- Ignore test and mock folders when scanning for direct API calls

## Testing
- `NEXT_PUBLIC_SUPABASE_URL=https://foo.supabase.co SUPABASE_JWKS_URL=https://foo.supabase.co/auth/v1/keys SUPABASE_JWKS_ISSUER=https://foo.supabase.co node scripts/check-auth-handshake.mjs`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a141d268708329836a382386b5ca20