### PR TITLE
feat: auto name baskets and refresh create UX

### DIFF
--- a/shared/contracts/baskets.ts
+++ b/shared/contracts/baskets.ts
@@ -3,11 +3,15 @@
 
 export type CreateBasketReq = {
   idempotency_key: string; // UUID
-  basket: {
-    name?: string;
+  intent: string;
+  raw_dump: {
+    text: string;
+    file_urls: string[];
   };
+  notes?: string[];
 };
 
 export type CreateBasketRes = {
-  basket_id: string; // UUID
+  id: string; // UUID
+  name: string;
 };

--- a/web/app/api/baskets/new/route.ts
+++ b/web/app/api/baskets/new/route.ts
@@ -43,7 +43,7 @@ function safeDecode(token?: string) {
 export async function POST(req: NextRequest) {
   const DBG = req.headers.get("x-yarnnn-debug-auth") === "1";
   const requestId = req.headers.get("x-request-id") ?? randomUUID();
-  // 1) Parse & validate request (canon: { idempotency_key, basket: { name? } })
+  // 1) Parse & validate request (canon: { idempotency_key, intent, raw_dump, notes? })
   let json: unknown;
   try {
     json = await req.json();
@@ -98,10 +98,7 @@ export async function POST(req: NextRequest) {
 
   // 3) Forward to FastAPI with Bearer token (workspace bootstrap is server-side)
   // Forward canonical payload to FastAPI
-  const payload = {
-    idempotency_key: parsed.data.idempotency_key,
-    basket: parsed.data.basket,
-  };
+  const payload = parsed.data;
   const res = await fetch(`${API_BASE}/api/baskets/new`, {
     method: "POST",
     headers: {

--- a/web/app/create/page.tsx
+++ b/web/app/create/page.tsx
@@ -1,26 +1,138 @@
 "use client";
 
-import { CaptureTray } from "@/components/create/CaptureTray";
-import { useCreatePageMachine } from "@/components/create/useCreatePageMachine";
+import React, { useEffect, useState, useRef } from "react";
+import { useRouter } from "next/navigation";
+import { CreateFooter } from "@/components/basket/CreateFooter";
 
 export default function CreatePage() {
-  const machine = useCreatePageMachine();
+  const [raw, setRaw] = useState("");
+  const [intent, setIntent] = useState("");
+  const [note, setNote] = useState("");
+  const fileInput = useRef<HTMLInputElement>(null);
+  const [files, setFiles] = useState<File[]>([]);
+  const router = useRouter();
+
+  const handleFiles = (list: FileList | null) => {
+    if (!list) return;
+    setFiles(Array.from(list));
+  };
+
+  const handleCreate = async () => {
+    const payload = {
+      idempotency_key: crypto.randomUUID(),
+      intent: intent.trim(),
+      raw_dump: { text: raw.trim(), file_urls: [] as string[] },
+      notes: note.trim() ? [note.trim()] : [],
+    };
+    try {
+      const res = await fetch("/api/baskets/new", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      const data = await res.json().catch(() => ({}));
+      const id = data.id || data.basket_id;
+      if (id) {
+        router.push(`/baskets/${id}/work`);
+      }
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const handleClear = () => {
+    setRaw("");
+    setIntent("");
+    setNote("");
+    setFiles([]);
+    if (fileInput.current) fileInput.current.value = "";
+  };
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+        e.preventDefault();
+        handleCreate();
+      } else if (e.key === "Escape") {
+        e.preventDefault();
+        handleClear();
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  });
+
+  const onIntentKey = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter" && raw.trim()) {
+      e.preventDefault();
+      handleCreate();
+    }
+  };
 
   return (
-    <div className="container py-8">
-      <CaptureTray
-        intent={machine.intent}
-        items={machine.items}
-        state={machine.state}
-        progress={machine.progress}
-        onIntent={machine.setIntent}
-        addFiles={machine.addFiles}
-        addUploadedFile={machine.addUploadedFile}
-        addUrl={machine.addUrl}
-        addNote={machine.addNote}
-        removeItem={machine.removeItem}
-        clearAll={machine.clearAll}
-        generate={machine.generate}
+    <div className="flex flex-col min-h-screen">
+      <main className="container max-w-3xl mx-auto px-4 py-6 space-y-6 flex-1">
+        <div className="space-y-2">
+          <label className="font-medium">Raw Dump</label>
+          <textarea
+            value={raw}
+            onChange={(e) => setRaw(e.target.value)}
+            placeholder="Drop raw thinking here… paste text or drag files."
+            className="w-full border rounded p-2"
+            style={{ minHeight: "60vh" }}
+          />
+          <input
+            type="file"
+            multiple
+            ref={fileInput}
+            onChange={(e) => handleFiles(e.target.files)}
+            className="mt-2"
+          />
+          <p className="text-sm text-gray-500">
+            This is your primary capture. Messy is fine.
+          </p>
+          {files.length > 0 && (
+            <ul className="mt-2 text-sm text-gray-700 list-disc list-inside">
+              {files.map((f) => (
+                <li key={f.name}>{f.name}</li>
+              ))}
+            </ul>
+          )}
+        </div>
+
+        <div className="space-y-2">
+          <label className="font-medium">Intent</label>
+          <input
+            type="text"
+            value={intent}
+            onChange={(e) => setIntent(e.target.value)}
+            onKeyDown={onIntentKey}
+            placeholder="e.g., Outline my Sept launch plan"
+            className="w-full border rounded p-2"
+          />
+          <p className="text-sm text-gray-500">
+            We’ll name your basket from this—you can rename later.
+          </p>
+        </div>
+
+        <div className="space-y-2">
+          <label className="font-medium">Quick note (optional)</label>
+          <textarea
+            value={note}
+            onChange={(e) => setNote(e.target.value)}
+            maxLength={280}
+            rows={3}
+            className="w-full border rounded p-2"
+          />
+          <p className="text-xs text-gray-400">{note.length}/280</p>
+        </div>
+      </main>
+
+      <CreateFooter
+        filesCount={files.length}
+        notesCount={note.trim() ? 1 : 0}
+        onCreate={handleCreate}
+        onClear={handleClear}
       />
     </div>
   );

--- a/web/components/basket/CreateFooter.tsx
+++ b/web/components/basket/CreateFooter.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+
+interface Props {
+  filesCount: number;
+  notesCount: number;
+  onCreate: () => void;
+  onClear: () => void;
+}
+
+export function CreateFooter({ filesCount, notesCount, onCreate, onClear }: Props) {
+  return (
+    <footer className="sticky bottom-0 w-full border-t bg-white py-4">
+      <div className="container max-w-3xl mx-auto flex items-center justify-between px-4">
+        <span className="text-sm text-gray-600">
+          {filesCount} files · {notesCount} notes
+        </span>
+        <div className="flex gap-2">
+          <button
+            type="button"
+            className="px-4 py-2 border rounded bg-white text-sm"
+            onClick={onClear}
+          >
+            Clear
+          </button>
+          <button
+            type="button"
+            className="px-4 py-2 rounded bg-blue-600 text-white text-sm"
+            onClick={onCreate}
+          >
+            Create &amp; Open Basket
+          </button>
+        </div>
+      </div>
+    </footer>
+  );
+}
+

--- a/web/components/create/useCreatePageMachine.ts
+++ b/web/components/create/useCreatePageMachine.ts
@@ -225,7 +225,9 @@ useEffect(() => {
       logStep('before basket create', { idempotency_key });
       const basketReq: CreateBasketReq = {
         idempotency_key,
-        basket: { name: intent.trim() || 'Untitled Basket' },
+        intent: intent.trim(),
+        raw_dump: { text: '', file_urls: [] },
+        notes: [],
       };
       
       const basketRes = await fetch('/api/baskets/new', {
@@ -241,7 +243,7 @@ useEffect(() => {
       }
       
       const basketResult: CreateBasketRes = await safeJson(basketRes);
-      const basketId = basketResult.basket_id;
+      const basketId = (basketResult as any).id || (basketResult as any).basket_id;
       logStep('after basket create', { basketId });
       
       if (!basketId) {

--- a/web/lib/api/contracts.ts
+++ b/web/lib/api/contracts.ts
@@ -140,9 +140,12 @@ export type ApiError = z.infer<typeof ApiErrorSchema>;
 // Request/Response helpers
 export const CreateBasketRequestSchema = z.object({
   idempotency_key: UUIDSchema,
-  basket: z.object({
-    name: z.string().optional(),
+  intent: z.string(),
+  raw_dump: z.object({
+    text: z.string(),
+    file_urls: z.array(z.string()),
   }),
+  notes: z.array(z.string()).optional(),
 });
 
 export type CreateBasketRequest = z.infer<typeof CreateBasketRequestSchema>;

--- a/web/lib/schemas/baskets.ts
+++ b/web/lib/schemas/baskets.ts
@@ -3,11 +3,15 @@ import type { CreateBasketReq, CreateBasketRes } from '@shared/contracts/baskets
 
 export const CreateBasketReqSchema = z.object({
   idempotency_key: z.string().uuid(),
-  basket: z.object({
-    name: z.string().optional(),
+  intent: z.string(),
+  raw_dump: z.object({
+    text: z.string(),
+    file_urls: z.array(z.string()),
   }),
+  notes: z.array(z.string()).optional(),
 }) satisfies z.ZodType<CreateBasketReq>;
 
 export const CreateBasketResSchema = z.object({
-  basket_id: z.string().uuid(),
+  id: z.string().uuid(),
+  name: z.string(),
 }) satisfies z.ZodType<CreateBasketRes>;


### PR DESCRIPTION
## Summary
- derive basket name from intent on create
- add modern create page with raw dump, intent, note and sticky footer
- update basket schemas and API route for new create payload

## Testing
- `npm test`
- `make tests` *(fails: duplicate base class BaseSchema)*

------
https://chatgpt.com/codex/tasks/task_e_68a145195ae48329883df292a34a50cf