### PR TITLE
fix: use relative import for auth middleware

### DIFF
--- a/api/src/middleware/auth.py
+++ b/api/src/middleware/auth.py
@@ -6,7 +6,7 @@ import os
 from collections.abc import Iterable
 
 import jwt
-from api.src.auth.jwt_verifier import verify_jwt
+from ..auth.jwt_verifier import verify_jwt
 from fastapi import HTTPException, Request, Response
 from fastapi.responses import JSONResponse
 from starlette.middleware.base import BaseHTTPMiddleware


### PR DESCRIPTION
## Summary
- use package-relative import to locate JWT verifier

## Testing
- `python3 -m pytest api/test_imports.py` *(fails: fixture 'file_path' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a15311b07083298f9ad509870b5858