### PR TITLE
Fix auth middleware import path

### DIFF
--- a/api/src/middleware/auth.py
+++ b/api/src/middleware/auth.py
@@ -6,7 +6,7 @@ import os
 from collections.abc import Iterable
 
 import jwt
-from ..auth.jwt_verifier import verify_jwt
+from auth.jwt_verifier import verify_jwt
 from fastapi import HTTPException, Request, Response
 from fastapi.responses import JSONResponse
 from starlette.middleware.base import BaseHTTPMiddleware


### PR DESCRIPTION
## Summary
- fix `AuthMiddleware` import path to use absolute import and avoid ImportError when running under uvicorn

## Testing
- `PYENV_VERSION=3.11.12 python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*


------
https://chatgpt.com/codex/tasks/task_e_68a155657aa8832982689a5551422775