### PR TITLE
refactor: use getUser for secure auth

### DIFF
--- a/web/components/AuthGuard.tsx
+++ b/web/components/AuthGuard.tsx
@@ -3,14 +3,11 @@
 
 import { useEffect, useState, useRef } from "react";
 import { useRouter } from "next/navigation";
-import { Session } from "@supabase/auth-helpers-react";
 import { supabase } from "@/lib/supabaseClient";
 import { dlog } from "@/lib/dev/log";
-import { getCachedSession } from "@/lib/api/http";
 
 export default function AuthGuard({ children }: { children: React.ReactNode }) {
   const [checking, setChecking] = useState(true);
-  const [session, setSession] = useState<Session | null>(null);
   const router = useRouter();
   
   // StrictMode guard - prevent double execution
@@ -27,21 +24,20 @@ export default function AuthGuard({ children }: { children: React.ReactNode }) {
     
     const checkAuth = async () => {
       dlog('auth/guard-check', { timestamp: Date.now() });
-      
-      const session = await getCachedSession();
 
-      dlog('auth/guard-result', { 
-        hasSession: !!session,
-        sessionId: session?.user?.id 
+      const { data: { user } } = await supabase.auth.getUser();
+
+      dlog('auth/guard-result', {
+        hasUser: !!user,
+        userId: user?.id
       });
 
-      if (!session) {
-        dlog('auth/guard-redirect', { reason: 'no-session' });
+      if (!user) {
+        dlog('auth/guard-redirect', { reason: 'no-user' });
         router.replace("/login");
         return;
       }
 
-      setSession(session);
       setChecking(false);
     };
 

--- a/web/lib/api/http.ts
+++ b/web/lib/api/http.ts
@@ -83,16 +83,28 @@ export async function getCachedSession() {
     });
     
     const { supabase } = await import('@/lib/supabaseClient');
-    const { data: { session } } = await supabase.auth.getSession();
-    
+    const [
+      {
+        data: { session },
+      },
+      {
+        data: { user },
+      },
+    ] = await Promise.all([
+      supabase.auth.getSession(),
+      supabase.auth.getUser(),
+    ]);
+
+    const mergedSession = session ? { ...session, user } : null;
+
     // Update cache
     sessionCache = {
-      session,
+      session: mergedSession,
       timestamp: now,
       expiry: now + SESSION_CACHE_TTL,
     };
-    
-    return session;
+
+    return mergedSession;
   }
 }
 


### PR DESCRIPTION
## Summary
- replace session.user usage with supabase.auth.getUser for verified auth data
- return authenticated user in cached sessions

## Testing
- `npm test`
- `npm run lint`
- `npm run build:check`


------
https://chatgpt.com/codex/tasks/task_e_68a15900a97c83298e678610feaf6992