### PR TITLE
feat: decouple capture from basket creation

### DIFF
--- a/web/app/api/substrate/add-context/route.ts
+++ b/web/app/api/substrate/add-context/route.ts
@@ -97,7 +97,7 @@ export async function POST(request: NextRequest) {
       triggerBackgroundIntelligenceGeneration({
         basketId,
         origin: 'raw_dump_added',
-        rawDumpId: dump.dump_id
+        rawDumpId: dump.id,
       });
       
       console.log(`Background intelligence generation triggered for raw dump in basket ${basketId}`);
@@ -108,13 +108,13 @@ export async function POST(request: NextRequest) {
     // Build response
     const result: AddContextResult = {
       success: true,
-      rawDumpId: dump.dump_id,
+      rawDumpId: dump.id,
       processingResults: {
         contentProcessed: content.length,
         insights: processingResults?.results ? 'Generated' : 'None',
         filesProcessed: fileUrls.length,
-        processingQuality: processingResults?.results?.metadata?.averageQuality || 'N/A'
-      }
+        processingQuality: processingResults?.results?.metadata?.averageQuality || 'N/A',
+      },
     };
 
     return NextResponse.json(result);

--- a/web/app/baskets/[id]/dashboard/DashboardClient.tsx
+++ b/web/app/baskets/[id]/dashboard/DashboardClient.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useState } from "react";
+import { TodayReflectionCard, ReflectionCards, MemoryStream, AddMemoryComposer } from "@/components/basket";
+import type { Note } from "@/lib/reflection";
+
+interface Props {
+  basketId: string;
+  initialNotes: Note[];
+  pattern?: string;
+  tension?: { a: string; b: string } | null;
+  question?: string;
+  fallback: string;
+}
+
+export default function DashboardClient({ basketId, initialNotes, pattern, tension, question, fallback }: Props) {
+  const [notes, setNotes] = useState<Note[]>(initialNotes);
+
+  return (
+    <div className="grid grid-cols-12 gap-4">
+      <div className="col-span-12">
+        <TodayReflectionCard line={undefined} fallback={fallback} />
+      </div>
+      <div className="col-span-8 space-y-4">
+        <AddMemoryComposer
+          basketId={basketId}
+          onSuccess={(dump) =>
+            setNotes((prev) => [
+              ...prev,
+              { id: dump.id, text: dump.text_dump || "", created_at: dump.created_at },
+            ])
+          }
+        />
+        <MemoryStream items={notes} />
+      </div>
+      <div className="col-span-4">
+        <ReflectionCards pattern={pattern} tension={tension || undefined} question={question} />
+      </div>
+    </div>
+  );
+}
+

--- a/web/app/baskets/[id]/dashboard/page.tsx
+++ b/web/app/baskets/[id]/dashboard/page.tsx
@@ -1,9 +1,9 @@
-import { TodayReflectionCard, ReflectionCards, MemoryStream } from "@/components/basket";
 import { topPhrases, findTension, makeQuestion, type Note } from "@/lib/reflection";
 import { notFound } from "next/navigation";
 import { cookies } from "next/headers";
 import { createServerComponentClient } from "@/lib/supabase/clients";
 import { ensureWorkspaceServer } from "@/lib/workspaces/ensureWorkspaceServer";
+import DashboardClient from "./DashboardClient";
 
 interface PageProps {
   params: Promise<{ id: string }>;
@@ -55,16 +55,13 @@ export default async function DashboardPage({ params }: PageProps) {
   const fallback = pattern ? `You keep orbiting “${pattern}”.` : "Add a note to see what emerges.";
 
   return (
-    <div className="grid grid-cols-12 gap-4">
-      <div className="col-span-12">
-        <TodayReflectionCard line={undefined} fallback={fallback} />
-      </div>
-      <div className="col-span-8">
-        <MemoryStream items={notes} />
-      </div>
-      <div className="col-span-4">
-        <ReflectionCards pattern={pattern} tension={tension} question={question} />
-      </div>
-    </div>
+    <DashboardClient
+      basketId={id}
+      initialNotes={notes}
+      pattern={pattern}
+      tension={tension}
+      question={question}
+      fallback={fallback}
+    />
   );
 }

--- a/web/app/create/page.tsx
+++ b/web/app/create/page.tsx
@@ -1,142 +1,120 @@
 "use client";
 
-import React, { useEffect, useState, useRef } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
-import { CreateFooter } from "@/components/basket/CreateFooter";
+import { getAllBaskets, type BasketOverview } from "@/lib/baskets/getAllBaskets";
 import { fetchWithToken } from "@/lib/fetchWithToken";
+import AddMemoryComposer from "@/components/basket/AddMemoryComposer";
+import { Button } from "@/components/ui/Button";
+import { Input } from "@/components/ui/Input";
 
 export default function CreatePage() {
-  const [raw, setRaw] = useState("");
-  const [intent, setIntent] = useState("");
-  const [note, setNote] = useState("");
-  const fileInput = useRef<HTMLInputElement>(null);
-  const [files, setFiles] = useState<File[]>([]);
   const router = useRouter();
-
-  const handleFiles = (list: FileList | null) => {
-    if (!list) return;
-    setFiles(Array.from(list));
-  };
-
-  const handleCreate = async () => {
-    const payload = {
-      idempotency_key: crypto.randomUUID(),
-      intent: intent.trim(),
-      raw_dump: { text: raw.trim(), file_urls: [] as string[] },
-      notes: note.trim() ? [note.trim()] : [],
-    };
-    try {
-      const res = await fetchWithToken("/api/baskets/new", {
-        method: "POST",
-        body: JSON.stringify(payload),
-      });
-      const data = await res.json().catch(() => ({}));
-      const id = data.id || data.basket_id;
-      if (id) {
-        router.push(`/baskets/${id}/dashboard`);
-      }
-    } catch (err) {
-      console.error(err);
-      // Auth canon: redirect to login on auth failure
-      if (err instanceof Error && err.message.includes("No authenticated user")) {
-        router.push("/login");
-      }
-    }
-  };
-
-  const handleClear = () => {
-    setRaw("");
-    setIntent("");
-    setNote("");
-    setFiles([]);
-    if (fileInput.current) fileInput.current.value = "";
-  };
+  const [baskets, setBaskets] = useState<BasketOverview[]>([]);
+  const [selected, setSelected] = useState("");
+  const [showSelector, setShowSelector] = useState(true);
+  const [creatingNew, setCreatingNew] = useState(false);
+  const [newName, setNewName] = useState("");
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
-        e.preventDefault();
-        handleCreate();
-      } else if (e.key === "Escape") {
-        e.preventDefault();
-        handleClear();
+    async function init() {
+      const list = await getAllBaskets();
+      setBaskets(list);
+      if (list.length === 1) {
+        setSelected(list[0].id);
+        setShowSelector(false);
       }
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  });
-
-  const onIntentKey = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === "Enter" && raw.trim()) {
-      e.preventDefault();
-      handleCreate();
+      if (list.length === 0 && process.env.NEXT_PUBLIC_AUTO_PERSONAL_BASKET === "1") {
+        const res = await fetchWithToken("/api/baskets/new", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ name: "Personal Memory" }),
+        });
+        if (res.ok) {
+          const data = await res.json();
+          const id = data.id || data.basket_id;
+          const basket = { id, name: data.name || "Personal Memory", created_at: data.created_at };
+          setBaskets([basket]);
+          setSelected(id);
+          setShowSelector(false);
+        }
+      }
+      setLoading(false);
     }
-  };
+    init();
+  }, []);
+
+  async function handleCreateBasket() {
+    const name = newName.trim();
+    if (!name) return;
+    const res = await fetchWithToken("/api/baskets/new", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name }),
+    });
+    if (res.ok) {
+      const data = await res.json();
+      const id = data.id || data.basket_id;
+      const basket = { id, name: data.name || name, created_at: data.created_at };
+      setBaskets((prev) => [...prev, basket]);
+      setSelected(id);
+      setCreatingNew(false);
+      setNewName("");
+    }
+  }
 
   return (
-    <div className="flex flex-col min-h-screen">
-      <main className="container max-w-3xl mx-auto px-4 py-6 space-y-6 flex-1">
+    <div className="max-w-2xl mx-auto p-4 space-y-4">
+      {!loading && (
         <div className="space-y-2">
-          <label className="font-medium">Raw Dump</label>
-          <textarea
-            value={raw}
-            onChange={(e) => setRaw(e.target.value)}
-            placeholder="Drop raw thinking here… paste text or drag files."
-            className="w-full border rounded p-2"
-            style={{ minHeight: "60vh" }}
-          />
-          <input
-            type="file"
-            multiple
-            ref={fileInput}
-            onChange={(e) => handleFiles(e.target.files)}
-            className="mt-2"
-          />
-          <p className="text-sm text-gray-500">
-            This is your primary capture. Messy is fine.
-          </p>
-          {files.length > 0 && (
-            <ul className="mt-2 text-sm text-gray-700 list-disc list-inside">
-              {files.map((f) => (
-                <li key={f.name}>{f.name}</li>
-              ))}
-            </ul>
+          {baskets.length === 1 && !showSelector ? (
+            <div className="text-sm">
+              Saving to <strong>{baskets[0].name || "Untitled"}</strong>{" "}
+              <button className="underline" onClick={() => setShowSelector(true)}>
+                Change…
+              </button>
+            </div>
+          ) : (
+            <div className="space-y-2">
+              <label className="text-sm font-medium">Choose a basket</label>
+              <select
+                className="border rounded p-2 w-full"
+                value={selected}
+                onChange={(e) => setSelected(e.target.value)}
+              >
+                <option value="">Select a basket</option>
+                {baskets.map((b) => (
+                  <option key={b.id} value={b.id}>
+                    {b.name || "Untitled"}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
+          {creatingNew ? (
+            <div className="flex gap-2 mt-2">
+              <Input
+                value={newName}
+                onChange={(e) => setNewName(e.target.value)}
+                placeholder="Basket name"
+              />
+              <Button onClick={handleCreateBasket} disabled={!newName.trim()}>
+                Create
+              </Button>
+            </div>
+          ) : (
+            <button className="text-sm underline" onClick={() => setCreatingNew(true)}>
+              New basket (advanced)
+            </button>
           )}
         </div>
+      )}
 
-        <div className="space-y-2">
-          <label className="font-medium">Intent</label>
-          <input
-            type="text"
-            value={intent}
-            onChange={(e) => setIntent(e.target.value)}
-            onKeyDown={onIntentKey}
-            placeholder="e.g., Outline my Sept launch plan"
-            className="w-full border rounded p-2"
-          />
-          <p className="text-sm text-gray-500">
-            We’ll name your basket from this—you can rename later.
-          </p>
-        </div>
-
-        <div className="space-y-2">
-          <label className="font-medium">Quick note (optional)</label>
-          <textarea
-            value={note}
-            onChange={(e) => setNote(e.target.value)}
-            maxLength={280}
-            rows={3}
-            className="w-full border rounded p-2"
-          />
-          <p className="text-xs text-gray-400">{note.length}/280</p>
-        </div>
-      </main>
-
-      <CreateFooter
-        filesCount={files.length}
-        notesCount={note.trim() ? 1 : 0}
-        onCreate={handleCreate}
-        onClear={handleClear}
+      <AddMemoryComposer
+        basketId={selected}
+        disabled={!selected}
+        onSuccess={(dump) => router.push(`/baskets/${dump.basket_id}/dashboard`)}
       />
     </div>
   );

--- a/web/components/basket/AddMemoryComposer.tsx
+++ b/web/components/basket/AddMemoryComposer.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useState } from "react";
+import { fetchWithToken } from "@/lib/fetchWithToken";
+import { Textarea } from "@/components/ui/Textarea";
+import { Button } from "@/components/ui/Button";
+
+interface AddMemoryComposerProps {
+  basketId: string;
+  disabled?: boolean;
+  onSuccess?: (dump: { id: string; basket_id: string; text_dump: string | null; created_at: string }) => void;
+}
+
+export default function AddMemoryComposer({ basketId, disabled, onSuccess }: AddMemoryComposerProps) {
+  const [text, setText] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const trimmed = text.trim();
+    if (!trimmed || !basketId || loading || disabled) return;
+    setLoading(true);
+    try {
+      const res = await fetchWithToken("/api/dumps/new", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          basket_id: basketId,
+          text_dump: trimmed,
+          dump_request_id: crypto.randomUUID(),
+          client_ts: Date.now(),
+        }),
+      });
+      if (res.ok) {
+        const dump = await res.json();
+        onSuccess?.(dump);
+        setText("");
+      } else {
+        console.error("Failed to create dump", await res.text());
+      }
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-2">
+      <Textarea
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        placeholder="Add a memory"
+        rows={3}
+        disabled={disabled || loading}
+      />
+      <div className="flex justify-end">
+        <Button type="submit" disabled={disabled || loading || !text.trim()}>
+          {loading ? "Adding..." : "Add memory"}
+        </Button>
+      </div>
+    </form>
+  );
+}
+

--- a/web/components/basket/index.ts
+++ b/web/components/basket/index.ts
@@ -1,3 +1,4 @@
 export { default as TodayReflectionCard } from "./TodayReflectionCard";
 export { ReflectionCards } from "./ReflectionCards";
 export { MemoryStream } from "./MemoryStream";
+export { default as AddMemoryComposer } from "./AddMemoryComposer";

--- a/web/components/create/useCreatePageMachine.ts
+++ b/web/components/create/useCreatePageMachine.ts
@@ -8,7 +8,8 @@ import { dlog } from '@/lib/dev/log';
 import { toast } from 'react-hot-toast';
 import { fetchWithToken } from '@/lib/fetchWithToken';
 import type { CreateBasketReq, CreateBasketRes } from '@shared/contracts/baskets';
-import type { CreateDumpReq, CreateDumpRes } from '@shared/contracts/dumps';
+import type { CreateDumpReq } from '@shared/contracts/dumps';
+import type { CreateDumpRes } from '@/lib/schemas/dumps';
 
 export type CreateState =
   | 'EMPTY'

--- a/web/components/create/useCreatePageMachine.ts
+++ b/web/components/create/useCreatePageMachine.ts
@@ -327,7 +327,7 @@ useEffect(() => {
 
       // Wait for all dumps to complete
       const dumpResults = await Promise.all(dumpPromises);
-      const dumpIds = dumpResults.map(result => result.dump_id);
+      const dumpIds = dumpResults.map(result => result.id);
       
       logStep('dumps created', { dumpIds });
       logEvent({ event: 'dumps_created', reqId, dumpIds, count: dumpIds.length });

--- a/web/lib/api/adapters/mock.ts
+++ b/web/lib/api/adapters/mock.ts
@@ -247,7 +247,7 @@ export class MockApiAdapter {
       // Create new dump
       const basketId = options.body?.basket_id || mockId('basket-default');
       return {
-        dump_id: mockId(`dump-${basketId}-new`),
+        id: mockId(`dump-${basketId}-new`),
         status: 'created',
         processing: 'triggered',
       };

--- a/web/lib/api/dumps.ts
+++ b/web/lib/api/dumps.ts
@@ -14,9 +14,10 @@ import {
 export async function createDump(
   request: Omit<CreateDumpRequest, 'dump_request_id'>,
 ): Promise<{
-  dump_id: string;
-  status: string;
-  processing: string;
+  id: string;
+  basket_id: string;
+  text_dump: string | null;
+  created_at: string;
 }> {
   const payload = { ...request, dump_request_id: crypto.randomUUID() };
 
@@ -31,9 +32,10 @@ export async function createDump(
   });
 
   return response as {
-    dump_id: string;
-    status: string;
-    processing: string;
+    id: string;
+    basket_id: string;
+    text_dump: string | null;
+    created_at: string;
   };
 }
 

--- a/web/lib/dumps/createDump.ts
+++ b/web/lib/dumps/createDump.ts
@@ -4,10 +4,10 @@ export async function createDump(
   basketId: string,
   textDump: string,
   fileUrl?: string,
-): Promise<{ dump_id: string }> {
+): Promise<{ id: string; basket_id: string; text_dump: string | null; created_at: string }> {
   const dumpRequestId = crypto.randomUUID();
 
-  return apiClient.request<{ dump_id: string }>("/api/dumps/new", {
+  return apiClient.request<{ id: string; basket_id: string; text_dump: string | null; created_at: string }>("/api/dumps/new", {
     method: "POST",
     body: JSON.stringify({
       basket_id: basketId,

--- a/web/lib/schemas/dumps.ts
+++ b/web/lib/schemas/dumps.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import type { CreateDumpReq, CreateDumpRes } from '@shared/contracts/dumps';
+import type { CreateDumpReq } from '@shared/contracts/dumps';
 
 export const CreateDumpReqSchema = z.object({
   basket_id: z.string().uuid(),
@@ -13,5 +13,9 @@ export const CreateDumpReqSchema = z.object({
 ) satisfies z.ZodType<CreateDumpReq>;
 
 export const CreateDumpResSchema = z.object({
-  dump_id: z.string().uuid(),
-}) satisfies z.ZodType<CreateDumpRes>;
+  id: z.string().uuid(),
+  basket_id: z.string().uuid(),
+  text_dump: z.string().nullable(),
+  created_at: z.string(),
+});
+export type CreateDumpRes = z.infer<typeof CreateDumpResSchema>;

--- a/web/lib/substrate/SubstrateService.ts
+++ b/web/lib/substrate/SubstrateService.ts
@@ -91,12 +91,12 @@ export class SubstrateService {
       // Use API route instead of direct Supabase insert
       // This ensures events are fired and proper processing happens
       const result = await createDump(basketId, content);
-      
+
       // Fetch the created dump to return full data
       const { data, error } = await this.supabase
         .from('raw_dumps')
         .select('*')
-        .eq('id', result.dump_id)
+        .eq('id', result.id)
         .single();
       
       if (error) throw new Error(`Failed to fetch created dump: ${error.message}`);


### PR DESCRIPTION
## Summary
- enable adding memories to existing baskets via new AddMemoryComposer component
- update /create flow to select existing or create new basket before capturing a dump
- emit `dump.created` events and return dump details from `/api/dumps/new`

## Testing
- `npm test`
- `npm --prefix web run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3e7e0a8e08329b3f5335ee6184c7d