### PR TITLE
Expose full analyzer report metadata

### DIFF
--- a/api/src/services/events_consumer.py
+++ b/api/src/services/events_consumer.py
@@ -1,0 +1,17 @@
+import asyncio  # noqa: F401
+import logging
+from app.event_bus import subscribe
+from services.manager import run_manager_plan
+
+log = logging.getLogger(__name__)
+
+async def consume_dump_created(db):
+    async with subscribe(['dump.created']) as queue:
+        while True:
+            evt = await queue.get()
+            try:
+                p = evt['payload']
+                req = {"mode": "evolve_turn", "focus": "interpretation", "dump_id": p["dump_id"]}
+                await run_manager_plan(db, p["basket_id"], req, p.get("workspace_id"))
+            except Exception:
+                log.exception("dump.created handler failed")

--- a/api/src/services/interpretation_adapter.py
+++ b/api/src/services/interpretation_adapter.py
@@ -1,0 +1,39 @@
+from typing import Any, Dict, List, Tuple
+
+
+def extract_graph_from_worker_output(out) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]], List[Dict[str, Any]]]:
+    ctx: List[Dict[str, Any]] = []
+    rel: List[Dict[str, Any]] = []
+    bl: List[Dict[str, Any]] = []
+    for ch in getattr(out, "changes", []) or []:
+        t = ch.get("type")
+        p = ch.get("payload", {})
+        if t == "context_item":
+            ctx.append({
+                "basket_id": ch["basket_id"],
+                "raw_dump_id": ch.get("raw_dump_id"),
+                "type": p["type"],
+                "title": p["title"],
+                "metadata": p.get("metadata", {}),
+            })
+        elif t == "relationship":
+            rel.append({
+                "basket_id": ch["basket_id"],
+                "from_type": p["from_type"],
+                "from_id": p["from_id"],
+                "to_type": p["to_type"],
+                "to_id": p["to_id"],
+                "relationship_type": p["relationship_type"],
+                "strength": p.get("strength", 0.5),
+            })
+        elif t == "block" and p.get("semantic_type") in ("theme", "concept"):
+            bl.append({
+                "basket_id": ch["basket_id"],
+                "semantic_type": p["semantic_type"],
+                "title": p.get("title"),
+                "content": p.get("content"),
+                "raw_dump_id": ch.get("raw_dump_id"),
+                "metadata": p.get("metadata", {}),
+            })
+    # fallback to out.metadata['report'] if needed…
+    return ctx, rel, bl

--- a/api/src/services/upserts.py
+++ b/api/src/services/upserts.py
@@ -1,0 +1,34 @@
+async def upsert_context_items(db, items):
+    for it in items:
+        await db.table("context_items").upsert({
+            "basket_id": it["basket_id"],
+            "raw_dump_id": it.get("raw_dump_id"),
+            "type": it["type"],
+            "title": it["title"],
+            "metadata": it.get("metadata", {}),
+            "status": "active",
+        }, on_conflict=["basket_id","raw_dump_id","type","title"])
+
+async def upsert_relationships(db, edges):
+    for e in edges:
+        await db.table("substrate_relationships").upsert({
+            "basket_id": e["basket_id"],
+            "from_type": e["from_type"],
+            "from_id": e["from_id"],
+            "to_type": e["to_type"],
+            "to_id": e["to_id"],
+            "relationship_type": e["relationship_type"],
+            "strength": e.get("strength", 0.5),
+        }, on_conflict=["basket_id","from_type","from_id","to_type","to_id","relationship_type"])
+
+async def upsert_blocks(db, blocks):
+    for b in blocks:
+        await db.table("blocks").upsert({
+            "basket_id": b["basket_id"],
+            "semantic_type": b["semantic_type"],
+            "title": b.get("title"),
+            "content": b.get("content"),
+            "raw_dump_id": b.get("raw_dump_id"),
+            "metadata": b.get("metadata", {}),
+            "state": "PROPOSED",
+        }, on_conflict=["basket_id","semantic_type","title"])


### PR DESCRIPTION
## Summary
- handle dump.created events by invoking manager in interpretation-only mode
- extract context items, relationships, and blocks from analyzer output and upsert them
- start the dump-created consumer during API server startup

## Testing
- `PYTHONPATH=api python3 -m pytest api/test_end_to_end.py::test_worker_adapter -q`
- `PYTHONPATH=api python3 -m pytest api/tests/test_pdf_ingestion.py::test_pdf_text_extraction -q` *(fails: ModuleNotFoundError: No module named 'src.app.main')*

------
https://chatgpt.com/codex/tasks/task_e_68a3f15b0fac8329b55a962ad3e7e666