### PR TITLE
handle missing db during startup

### DIFF
--- a/api/RENDER_TROUBLESHOOTING.md
+++ b/api/RENDER_TROUBLESHOOTING.md
@@ -139,6 +139,12 @@ python run_migrations.py
    - Version conflicts
    - Build tools missing (gcc, postgresql-dev)
 
+### Database Connection Errors
+- **`asyncpg.exceptions.InternalServerError: Tenant or user not found`**
+  - Indicates an invalid `DATABASE_URL`
+  - Verify the connection string includes the correct Supabase project reference and credentials
+  - The server will now start without a database, but features that depend on it will be disabled
+
 ### Emergency Fallback
 If all else fails, you can temporarily simplify:
 


### PR DESCRIPTION
## Summary
- avoid Render deploy crash by skipping DB startup when connection fails
- document resolving `Tenant or user not found` errors for invalid `DATABASE_URL`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68a4043c727483299a9f0a3ca7c052ce