### PR TITLE
feat: align dump and basket contracts

### DIFF
--- a/api/src/app/agents/services/dump_interpreter.py
+++ b/api/src/app/agents/services/dump_interpreter.py
@@ -59,7 +59,7 @@ class DumpInterpreterService:
         # Get the raw dump content including Supabase Storage file references
         dump_resp = (
             supabase.table("raw_dumps")
-            .select("id,body_md,basket_id,workspace_id,file_url,source_meta")
+            .select("id,body_md,basket_id,workspace_id,file_url,file_refs,source_meta")
             .eq("id", str(request.raw_dump_id))
             .eq("workspace_id", workspace_id)
             .maybe_single()
@@ -81,6 +81,13 @@ class DumpInterpreterService:
         
         # Process Supabase Storage file if present
         file_url = raw_dump.get("file_url")
+        if not file_url:
+            refs = raw_dump.get("file_refs")
+            if refs and isinstance(refs, list) and refs[0]:
+                file_url = refs[0]
+                logger.warning(
+                    "raw_dumps.file_refs is deprecated; use file_url instead",
+                )
         if file_url:
             try:
                 # Get MIME type from source_meta if available

--- a/api/src/app/routes/dump_new.py
+++ b/api/src/app/routes/dump_new.py
@@ -72,9 +72,9 @@ async def create_dump(
         {
             "dump_request_id": payload.dump_request_id,
             "text_dump": payload.text_dump,
-            "file_urls": [payload.file_url] if payload.file_url else None,
+            "file_url": payload.file_url,
             "source_meta": payload.meta or {},
-            "ingest_trace_id": payload.dump_request_id,
+            "ingest_trace_id": (payload.meta or {}).get("ingest_trace_id"),
         }
     ]
     resp = supabase.rpc(

--- a/docs/YARNNN_INTERFACE_SPEC_v0.1.0.md
+++ b/docs/YARNNN_INTERFACE_SPEC_v0.1.0.md
@@ -54,7 +54,7 @@ export type CreateDumpReq = {
   dump_request_id: string; // UUID
   text_dump?: string;
   file_url?: string;
-  meta?: Record<string, unknown>;
+  meta?: { client_ts?: string; ingest_trace_id?: string; [k: string]: unknown };
 };
 export type CreateDumpRes = { dump_id: string };
 // shared/contracts/ingest.ts (optional combined flow)

--- a/shared/contracts/baskets.ts
+++ b/shared/contracts/baskets.ts
@@ -19,12 +19,9 @@ export type Basket = {
 // API Request/Response types
 export type CreateBasketReq = {
   idempotency_key: string;
-  intent: string;
-  raw_dump: {
-    text: string;
-    file_urls: string[];
+  basket?: {
+    name?: string;
   };
-  notes?: string[];
 };
 
 export type CreateBasketRes = {

--- a/shared/contracts/documents.ts
+++ b/shared/contracts/documents.ts
@@ -13,10 +13,4 @@ export type Document = {
 };
 
 // API Request/Response types
-export type CreateDocumentRequest = {
-  basket_id: string;
-  title: string;
-  content_raw: string;
-  document_type: string;
-  metadata?: Record<string, any>;
-};
+// Deprecated: legacy document creation request (use universal change system instead)

--- a/shared/contracts/dumps.ts
+++ b/shared/contracts/dumps.ts
@@ -27,12 +27,13 @@ export type CreateDumpReq = {
   dump_request_id: string;
   text_dump?: string;  // User text content (including pasted URLs)
   file_url?: string;   // Supabase Storage URL for uploaded files
-  meta?: Record<string, any>;
+  meta?: {
+    client_ts?: string;
+    ingest_trace_id?: string;
+    [k: string]: any;
+  };
 };
 
 export type CreateDumpRes = {
-  id: string;
-  basket_id: string;
-  text_dump: string | null;
-  created_at: string;
+  dump_id: string;
 };

--- a/supabase/migrations/20250824_raw_dumps_file_url.sql
+++ b/supabase/migrations/20250824_raw_dumps_file_url.sql
@@ -1,0 +1,10 @@
+-- Add canonical file_url column to raw_dumps and backfill from legacy file_refs
+ALTER TABLE public.raw_dumps
+  ADD COLUMN IF NOT EXISTS file_url text;
+
+-- Backfill single-element file_refs into file_url
+UPDATE public.raw_dumps
+SET file_url = file_refs[1]
+WHERE file_url IS NULL AND cardinality(file_refs) = 1;
+
+-- Retain existing unique index on (basket_id, dump_request_id)

--- a/web/app/api/baskets/new/route.ts
+++ b/web/app/api/baskets/new/route.ts
@@ -32,7 +32,7 @@ export async function POST(req: NextRequest) {
 
   const DBG = req.headers.get("x-yarnnn-debug-auth") === "1";
   const requestId = req.headers.get("x-request-id") ?? randomUUID();
-  // 1) Parse & validate request (canon: { idempotency_key, intent, raw_dump, notes? })
+  // 1) Parse & validate request (canon: { idempotency_key, basket? })
   let json: unknown;
   try {
     json = await req.json();

--- a/web/app/api/substrate/add-context/route.ts
+++ b/web/app/api/substrate/add-context/route.ts
@@ -64,13 +64,12 @@ export async function POST(request: NextRequest) {
       .filter((item: SubstrateContentInput) => item.metadata?.fileObject)
       .map((item: SubstrateContentInput) => item.metadata!.filename)
       .filter(Boolean);
-    
-    // Create raw_dump using existing function
-    const { dumpId } = await createDump({
-      basketId,
-      text: consolidatedContent,
-      fileUrls: fileUrls.length ? fileUrls : null,
-    });
+
+    // Create raw_dump(s) using existing function
+    const { dumpId } = await createDump({ basketId, text: consolidatedContent });
+    for (const url of fileUrls) {
+      await createDump({ basketId, fileUrl: url });
+    }
     
     // Trigger immediate background intelligence generation for raw dumps
     try {

--- a/web/components/basket/AddMemoryComposer.tsx
+++ b/web/components/basket/AddMemoryComposer.tsx
@@ -9,7 +9,7 @@ import { Button } from "@/components/ui/Button";
 interface AddMemoryComposerProps {
   basketId: string;
   disabled?: boolean;
-  onSuccess?: (dump: { id: string; basket_id: string; text_dump: string | null; created_at: string }) => void;
+  onSuccess?: (res: { dump_id: string }) => void;
 }
 
 export default function AddMemoryComposer({ basketId, disabled, onSuccess }: AddMemoryComposerProps) {
@@ -50,7 +50,10 @@ export default function AddMemoryComposer({ basketId, disabled, onSuccess }: Add
           basket_id: basketId,
           text_dump: trimmed,
           dump_request_id: crypto.randomUUID(),
-          client_ts: Date.now(),
+          meta: {
+            client_ts: new Date().toISOString(),
+            ingest_trace_id: crypto.randomUUID(),
+          },
         }),
       });
       if (res.ok) {

--- a/web/components/dump/DumpBarPanel.tsx
+++ b/web/components/dump/DumpBarPanel.tsx
@@ -100,7 +100,12 @@ export default function DumpBarPanel({ basketId, onClose }: DumpBarPanelProps) {
     if (!text.trim() && urls.length === 0) return;
     setSubmitting(true);
     try {
-      await createDump({ basketId, text: text.trim() || null, fileUrls: urls.length ? urls : null });
+      if (text.trim()) {
+        await createDump({ basketId, text: text.trim() });
+      }
+      for (const url of urls) {
+        await createDump({ basketId, fileUrl: url });
+      }
       toast.success(
         <span>
           Captured

--- a/web/hooks/useCreateActions.ts
+++ b/web/hooks/useCreateActions.ts
@@ -59,17 +59,13 @@ export function useCreateActions() {
     handleSelectedFiles: async (files: FileList) => {
       if (!basketId || !user?.id || !files.length) return;
       try {
-        const urls: string[] = [];
         for (const file of Array.from(files)) {
           const sanitized = sanitizeFilename(file.name);
           const filename = `${Date.now()}-${sanitized}`;
           const url = await uploadFile(file, `dump_${user.id}/${filename}`);
-          urls.push(url);
+          await createDump({ basketId, fileUrl: url });
         }
-        if (urls.length) {
-          await createDump({ basketId, fileUrls: urls });
-          showSuccess(`Captured ${urls.length} file(s) as raw dumps`);
-        }
+        showSuccess(`Captured ${files.length} file(s) as raw dumps`);
       } catch (e) {
         console.warn("uploadFiles failed", e);
         showWarning("Upload failed");

--- a/web/lib/api/contracts.ts
+++ b/web/lib/api/contracts.ts
@@ -139,13 +139,12 @@ export type ApiError = z.infer<typeof ApiErrorSchema>;
 // Request/Response helpers
 export const CreateBasketRequestSchema = z.object({
   idempotency_key: UUIDSchema,
-  intent: z.string(),
-  raw_dump: z.object({
-    text: z.string(),
-    file_urls: z.array(z.string()),
-  }),
-  notes: z.array(z.string()).optional(),
-});
+  basket: z
+    .object({
+      name: z.string().optional(),
+    })
+    .optional(),
+}).strict();
 
 export type CreateBasketRequest = z.infer<typeof CreateBasketRequestSchema>;
 
@@ -157,22 +156,13 @@ export const UpdateBlockRequestSchema = z.object({
 
 export type UpdateBlockRequest = z.infer<typeof UpdateBlockRequestSchema>;
 
-export const CreateDocumentRequestSchema = z.object({
-  basket_id: UUIDSchema,
-  title: z.string(),
-  content_raw: z.string(),
-  document_type: z.string(),
-  metadata: z.record(z.unknown()).optional(),
-});
-
-export type CreateDocumentRequest = z.infer<typeof CreateDocumentRequestSchema>;
-
 // Raw dump schema
 export const RawDumpSchema = z.object({
   id: UUIDSchema,
   basket_id: UUIDSchema,
   workspace_id: UUIDSchema,
   body_md: z.string(),
+  file_url: z.string().url().nullable().optional(),
   file_refs: z.array(z.string()).optional(),
   processing_status: z.enum(['pending', 'processing', 'processed', 'failed']),
   metadata: z.record(z.unknown()).optional(),
@@ -182,12 +172,17 @@ export const RawDumpSchema = z.object({
 
 export type RawDump = z.infer<typeof RawDumpSchema>;
 
-export const CreateDumpRequestSchema = z.object({
-  dump_request_id: UUIDSchema,
-  basket_id: UUIDSchema,
-  text_dump: z.string(),
-  file_url: z.string().optional(),
-});
+export const CreateDumpRequestSchema = z
+  .object({
+    dump_request_id: UUIDSchema,
+    basket_id: UUIDSchema,
+    text_dump: z.string().optional(),
+    file_url: z.string().url().optional(),
+    meta: z.record(z.unknown()).optional(),
+  })
+  .refine((d) => d.text_dump || d.file_url, {
+    message: 'Provide text_dump or file_url',
+  });
 
 export type CreateDumpRequest = z.infer<typeof CreateDumpRequestSchema>;
 

--- a/web/lib/api/documents.ts
+++ b/web/lib/api/documents.ts
@@ -2,10 +2,8 @@ import { apiClient, timeoutSignal } from './http';
 import {
   DocumentSchema,
   PaginatedSchema,
-  CreateDocumentRequestSchema,
   type Document,
   type Paginated,
-  type CreateDocumentRequest,
 } from './contracts';
 
 /**
@@ -53,21 +51,6 @@ export async function listDocuments(basketId: string, options?: {
   });
   
   return PaginatedSchema(DocumentSchema).parse(response);
-}
-
-// Create new document
-export async function createDocument(request: CreateDocumentRequest): Promise<Document> {
-  // Validate request payload
-  const validatedRequest = CreateDocumentRequestSchema.parse(request);
-  
-  const response = await apiClient({
-    url: '/api/documents',
-    method: 'POST',
-    body: validatedRequest,
-    signal: timeoutSignal(15000),
-  });
-  
-  return DocumentSchema.parse(response);
 }
 
 // Update document

--- a/web/lib/api/dumps.ts
+++ b/web/lib/api/dumps.ts
@@ -3,24 +3,24 @@ import { apiClient, timeoutSignal } from './http';
 export interface CreateDumpInput {
   basketId: string;
   text?: string | null;
-  fileUrls?: string[] | null;
+  fileUrl?: string | null;
   meta?: Record<string, unknown> | null;
 }
 
-export async function createDump({ basketId, text, fileUrls, meta }: CreateDumpInput): Promise<{ dumpId: string }> {
+export async function createDump({ basketId, text, fileUrl, meta }: CreateDumpInput): Promise<{ dumpId: string }> {
   const ingestTraceId = globalThis.crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random()}`;
-  const dumpRequestId = ingestTraceId;
+  const dumpRequestId = globalThis.crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random()}`;
 
   const body = {
     basket_id: basketId,
+    dump_request_id: dumpRequestId,
     text_dump: text ?? null,
-    file_urls: fileUrls ?? null,
-    source_meta: {
+    file_url: fileUrl ?? null,
+    meta: {
       ua: typeof navigator !== 'undefined' ? navigator.userAgent : 'server',
+      ingest_trace_id: ingestTraceId,
       ...meta,
     },
-    ingest_trace_id: ingestTraceId,
-    dump_request_id: dumpRequestId,
   };
 
   const res = (await apiClient({

--- a/web/lib/schemas/baskets.ts
+++ b/web/lib/schemas/baskets.ts
@@ -9,13 +9,13 @@ import type { CreateBasketReq, CreateBasketRes } from '@shared/contracts/baskets
 
 export const CreateBasketReqSchema = z.object({
   idempotency_key: z.string().uuid(),
-  intent: z.string(),
-  raw_dump: z.object({
-    text: z.string(),
-    file_urls: z.array(z.string()),
-  }),
-  notes: z.array(z.string()).optional(),
-}) satisfies z.ZodType<CreateBasketReq>;
+  basket: z
+    .object({
+      name: z.string().optional(),
+    })
+    .optional(),
+})
+  .strict() satisfies z.ZodType<CreateBasketReq>;
 
 export const CreateBasketResSchema = z.object({
   basket_id: z.string().uuid(),

--- a/web/lib/schemas/dumps.ts
+++ b/web/lib/schemas/dumps.ts
@@ -5,23 +5,29 @@
  * @contract output : CreateDumpRes
  */
 import { z } from 'zod';
-import type { CreateDumpReq } from '@shared/contracts/dumps';
+import type { CreateDumpReq, CreateDumpRes } from '@shared/contracts/dumps';
 
 export const CreateDumpReqSchema = z.object({
   basket_id: z.string().uuid(),
   dump_request_id: z.string().uuid(),
   text_dump: z.string().optional(),
-  file_url: z.string().url().optional(),  // Supabase Storage URL for uploaded files
-  meta: z.record(z.unknown()).optional(),
-}).refine(
-  (data) => data.text_dump || data.file_url,
-  { message: "Either text_dump or file_url (Supabase Storage) must be provided" }
-) satisfies z.ZodType<CreateDumpReq>;
+  file_url: z.string().url().optional(),
+  meta: z
+    .object({
+      client_ts: z.string().optional(),
+      ingest_trace_id: z.string().uuid().optional(),
+    })
+    .catchall(z.unknown())
+    .optional(),
+})
+  .refine(
+    (data) => data.text_dump || data.file_url,
+    { message: "Either text_dump or file_url (Supabase Storage) must be provided" }
+  )
+  .strict() satisfies z.ZodType<CreateDumpReq>;
 
 export const CreateDumpResSchema = z.object({
-  id: z.string().uuid(),
-  basket_id: z.string().uuid(),
-  text_dump: z.string().nullable(),
-  created_at: z.string(),
-});
+  dump_id: z.string().uuid(),
+}) satisfies z.ZodType<CreateDumpRes>;
+
 export type CreateDumpRes = z.infer<typeof CreateDumpResSchema>;


### PR DESCRIPTION
## Summary
- align dump contracts to canon v1.3.1 with meta and singular `file_url`
- simplify basket creation DTO and server route
- migrate `raw_dumps` to new `file_url` column with backfill

## Testing
- `rg -n "file_urls" web | wc -l`
- `rg -n "onSuccess" web | rg "dump_id"`
- `npm run contracts:trace` *(fails: Cannot find module minimatch)*
- `npm run contracts:check`
- `rg -n "dump_id" api | wc -l`
- `rg -n "file_url" api/src | wc -l`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa760d1fb08329aa403ca33b3e1be0