### PR TITLE
fix: handle timeline events safely and update blocks page

### DIFF
--- a/web/app/baskets/[id]/blocks/page.tsx
+++ b/web/app/baskets/[id]/blocks/page.tsx
@@ -28,7 +28,7 @@ export default async function BlocksPage({ params }: PageProps) {
     // Verify basket exists and user has access
     const { data: basket, error: basketError } = await supabase
       .from('baskets')
-      .select('id, title, user_id, visibility, workspace_id')
+      .select('id, name, user_id, visibility, workspace_id')
       .eq('id', basketId)
       .maybeSingle();
 
@@ -61,7 +61,7 @@ export default async function BlocksPage({ params }: PageProps) {
     return (
       <BlocksListView 
         basketId={basketId}
-        basketTitle={basket.title}
+        basketTitle={basket.name}
         initialBlocks={blocks || []}
         canEdit={basket.user_id === userId}
       />


### PR DESCRIPTION
## Summary
- avoid strict timeline schema validation and read from timeline_events table
- use simple timestamp cursor and include preview/ref_id in events
- fix blocks page by selecting `name` column and using `basket.name`

## Testing
- `npm test`
- `npm run lint`
- `npm run build:check`

------
https://chatgpt.com/codex/tasks/task_e_68ad18d33dbc8329a3ae21be9f4b2223