### PR TITLE
fix: use basket name in graph page

### DIFF
--- a/web/app/baskets/[id]/graph/page.tsx
+++ b/web/app/baskets/[id]/graph/page.tsx
@@ -28,7 +28,7 @@ export default async function GraphPage({ params }: PageProps) {
     // Verify basket exists and user has access
     const { data: basket, error: basketError } = await supabase
       .from('baskets')
-      .select('id, title, user_id, visibility, workspace_id')
+      .select('id, name, user_id, visibility, workspace_id')
       .eq('id', basketId)
       .maybeSingle();
 
@@ -98,7 +98,7 @@ export default async function GraphPage({ params }: PageProps) {
     return (
       <GraphView 
         basketId={basketId}
-        basketTitle={basket.title}
+        basketTitle={basket.name}
         graphData={graphData}
         canEdit={basket.user_id === userId}
       />


### PR DESCRIPTION
## Summary
- query basket `name` instead of `title` on graph page
- pass basket name to graph view props

## Testing
- `npm test`
- `npm --prefix web run lint`
- `npm run build:check`


------
https://chatgpt.com/codex/tasks/task_e_68ad2d431ec083299b1fb730ea68e9ec