### PR TITLE
Compact onboarding cards for welcome flow

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -139,3 +139,10 @@
 .debug-brand {
     font-family: var(--font-pacifico), cursive !important;
 }
+
+/* Compact onboarding card variant */
+@layer components {
+  .onboarding-card--compact {
+    @apply p-4 md:p-5;
+  }
+}

--- a/web/app/welcome/page.tsx
+++ b/web/app/welcome/page.tsx
@@ -2,7 +2,7 @@ import { redirect } from 'next/navigation';
 import { createServerSupabaseClient } from '@/lib/supabase/server';
 import { getAuthenticatedUser } from '@/lib/auth/getAuthenticatedUser';
 import { onboardingGate } from '@/lib/server/onboarding';
-import OnboardingForm from '@/components/onboarding/OnboardingForm';
+import OnboardingDashboard from '@/components/onboarding/OnboardingDashboard';
 
 export default async function WelcomePage() {
   const supabase = createServerSupabaseClient();
@@ -55,7 +55,7 @@ export default async function WelcomePage() {
 
   return (
     <div className="min-h-screen bg-background flex items-center justify-center p-4">
-      <OnboardingForm basketId={basketId} />
+      <OnboardingDashboard basketId={basketId} />
     </div>
   );
 }

--- a/web/components/memory/OnboardingGate.tsx
+++ b/web/components/memory/OnboardingGate.tsx
@@ -1,7 +1,14 @@
 "use client";
 
-import OnboardingDashboard from "@/components/onboarding/OnboardingDashboard";
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
 
-export default function OnboardingGate({ basketId }: { basketId: string }) {
-  return <OnboardingDashboard basketId={basketId} />;
+export default function OnboardingGate({ basketId: _basketId }: { basketId: string }) {
+  const router = useRouter();
+
+  useEffect(() => {
+    router.replace("/welcome");
+  }, [router]);
+
+  return null;
 }

--- a/web/components/onboarding/OnboardingDashboard.tsx
+++ b/web/components/onboarding/OnboardingDashboard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, type ChangeEvent } from "react";
 import { useRouter } from "next/navigation";
 import { useAuth } from "@/lib/useAuth";
 import { Input } from "@/components/ui/Input";
@@ -8,6 +8,12 @@ import { Textarea } from "@/components/ui/Textarea";
 import { Button } from "@/components/ui/Button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/Card";
 import { CheckCircle2, Circle, User, Brain, Target, Archive } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+function autoResize(e: ChangeEvent<HTMLTextAreaElement>) {
+  e.target.style.height = "auto";
+  e.target.style.height = `${e.target.scrollHeight}px`;
+}
 
 interface Props {
   basketId: string;
@@ -95,20 +101,20 @@ export default function OnboardingDashboard({ basketId }: Props) {
   }
 
   return (
-    <div className="max-w-4xl mx-auto p-6 space-y-6">
+    <div className="max-w-3xl mx-auto p-4 space-y-4">
       {/* Header */}
-      <div className="text-center space-y-2">
+      <div className="text-center space-y-1">
         <h1 className="text-2xl font-semibold">Complete Your Identity Profile</h1>
-        <p className="text-muted-foreground">
+        <p className="text-sm text-muted-foreground">
           Help Yarnnn understand you better. Complete sections improve your memory workspace.
         </p>
-        <div className="text-sm text-muted-foreground">
+        <div className="text-xs text-muted-foreground">
           {completedCount} of 4 sections completed • {requiredCount} required
         </div>
       </div>
 
       {/* Progress Overview */}
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-2 mb-4">
         {[
           { key: 'name', label: 'Name', icon: User, required: true },
           { key: 'tension', label: 'Current Focus', icon: Brain, required: true },
@@ -117,24 +123,34 @@ export default function OnboardingDashboard({ basketId }: Props) {
         ].map(({ key, label, icon: Icon, required }) => {
           const isComplete = completion[key as keyof CompletionState];
           return (
-            <Card key={key} className={`transition-all ${isComplete ? 'ring-2 ring-green-500' : required ? 'ring-1 ring-orange-200' : 'ring-1 ring-gray-200'}`}>
-              <CardContent className="p-4 text-center">
-                <div className="flex items-center justify-center mb-2">
+            <Card
+              key={key}
+              className={cn(
+                "onboarding-card--compact transition-all !p-3",
+                isComplete
+                  ? "ring-2 ring-green-500"
+                  : required
+                  ? "ring-1 ring-orange-200"
+                  : "ring-1 ring-gray-200"
+              )}
+            >
+              <CardContent className="p-0 text-center space-y-1">
+                <div className="flex items-center justify-center">
                   {isComplete ? (
-                    <CheckCircle2 className="w-6 h-6 text-green-500" />
+                    <CheckCircle2 className="w-5 h-5 text-green-500" />
                   ) : (
-                    <Circle className="w-6 h-6 text-muted-foreground" />
+                    <Circle className="w-5 h-5 text-muted-foreground" />
                   )}
                 </div>
-                <div className="flex items-center justify-center mb-1">
+                <div className="flex items-center justify-center">
                   <Icon className="w-4 h-4 text-muted-foreground mr-1" />
-                  <span className="text-sm font-medium">{label}</span>
+                  <span className="text-xs font-medium">{label}</span>
                 </div>
                 {required && !isComplete && (
-                  <span className="text-xs text-orange-600">Required</span>
+                  <span className="text-[10px] text-orange-600">Required</span>
                 )}
                 {!required && (
-                  <span className="text-xs text-muted-foreground">Optional</span>
+                  <span className="text-[10px] text-muted-foreground">Optional</span>
                 )}
               </CardContent>
             </Card>
@@ -143,20 +159,25 @@ export default function OnboardingDashboard({ basketId }: Props) {
       </div>
 
       {/* Input Sections */}
-      <div className="grid gap-6">
+      <div className="grid gap-4">
         {/* Name Section */}
-        <Card className={completion.name ? 'ring-1 ring-green-200' : 'ring-1 ring-orange-200'}>
-          <CardHeader>
-            <CardTitle className="flex items-center">
-              <User className="w-5 h-5 mr-2" />
+        <Card
+          className={cn(
+            "onboarding-card--compact",
+            completion.name ? "ring-1 ring-green-200" : "ring-1 ring-orange-200"
+          )}
+        >
+          <CardHeader className="pb-2">
+            <CardTitle className="flex items-center text-base">
+              <User className="w-4 h-4 mr-2" />
               What's your name?
-              {completion.name && <CheckCircle2 className="w-5 h-5 ml-auto text-green-500" />}
+              {completion.name && (
+                <CheckCircle2 className="w-4 h-4 ml-auto text-green-500" />
+              )}
             </CardTitle>
-            <p className="text-sm text-muted-foreground">
-              We'll remember this. This is the start of your thread.
-            </p>
+            <p className="text-xs text-muted-foreground">Saved as part of your profile.</p>
           </CardHeader>
-          <CardContent>
+          <CardContent className="pt-2">
             <Input
               value={name}
               onChange={(e) => setName(e.target.value)}
@@ -167,66 +188,93 @@ export default function OnboardingDashboard({ basketId }: Props) {
         </Card>
 
         {/* Tension Section */}
-        <Card className={completion.tension ? 'ring-1 ring-green-200' : 'ring-1 ring-orange-200'}>
-          <CardHeader>
-            <CardTitle className="flex items-center">
-              <Brain className="w-5 h-5 mr-2" />
+        <Card
+          className={cn(
+            "onboarding-card--compact",
+            completion.tension ? "ring-1 ring-green-200" : "ring-1 ring-orange-200"
+          )}
+        >
+          <CardHeader className="pb-2">
+            <CardTitle className="flex items-center text-base">
+              <Brain className="w-4 h-4 mr-2" />
               What's something you keep circling back to lately?
-              {completion.tension && <CheckCircle2 className="w-5 h-5 ml-auto text-green-500" />}
+              {completion.tension && (
+                <CheckCircle2 className="w-4 h-4 ml-auto text-green-500" />
+              )}
             </CardTitle>
-            <p className="text-sm text-muted-foreground">
-              It doesn't need to be a formal plan. Just a thought, a worry, or a question that's taking up space in your mind.
+            <p className="text-xs text-muted-foreground">
+              A current question or worry. Saved as part of your profile.
             </p>
           </CardHeader>
-          <CardContent>
+          <CardContent className="pt-2">
             <Textarea
               value={tension}
               onChange={(e) => setTension(e.target.value)}
-              rows={3}
+              onInput={autoResize}
+              rows={1}
+              className="resize-none overflow-hidden"
               placeholder="Finding my first 10 true fans • The fear my idea isn't unique enough • Balancing my day job with this project"
             />
           </CardContent>
         </Card>
 
         {/* Aspiration Section */}
-        <Card className={completion.aspiration ? 'ring-1 ring-green-200' : 'ring-1 ring-orange-200'}>
-          <CardHeader>
-            <CardTitle className="flex items-center">
-              <Target className="w-5 h-5 mr-2" />
+        <Card
+          className={cn(
+            "onboarding-card--compact",
+            completion.aspiration ? "ring-1 ring-green-200" : "ring-1 ring-orange-200"
+          )}
+        >
+          <CardHeader className="pb-2">
+            <CardTitle className="flex items-center text-base">
+              <Target className="w-4 h-4 mr-2" />
               What's something you've always wanted to make time for?
-              {completion.aspiration && <CheckCircle2 className="w-5 h-5 ml-auto text-green-500" />}
+              {completion.aspiration && (
+                <CheckCircle2 className="w-4 h-4 ml-auto text-green-500" />
+              )}
             </CardTitle>
-            <p className="text-sm text-muted-foreground">
-              Think about the project or idea that truly excites you. This becomes a foundational part of your memory.
+            <p className="text-xs text-muted-foreground">
+              What you want to make time for. Saved as part of your profile.
             </p>
           </CardHeader>
-          <CardContent>
+          <CardContent className="pt-2">
             <Textarea
               value={aspiration}
               onChange={(e) => setAspiration(e.target.value)}
-              rows={3}
+              onInput={autoResize}
+              rows={1}
+              className="resize-none overflow-hidden"
               placeholder="Writing a book about my industry • Building a product that helps people like me • Finally learning to code in Rust"
             />
           </CardContent>
         </Card>
 
         {/* Memory Import Section */}
-        <Card className={completion.memory ? 'ring-1 ring-green-200' : 'ring-1 ring-gray-200'}>
-          <CardHeader>
-            <CardTitle className="flex items-center">
-              <Archive className="w-5 h-5 mr-2" />
-              Import existing memory (optional)
-              {completion.memory && <CheckCircle2 className="w-5 h-5 ml-auto text-green-500" />}
+        <Card
+          className={cn(
+            "onboarding-card--compact bg-muted/30",
+            completion.memory ? "ring-1 ring-green-200" : "ring-1 ring-gray-200"
+          )}
+        >
+          <CardHeader className="pb-2">
+            <CardTitle className="flex items-center text-sm text-muted-foreground">
+              <Archive className="w-4 h-4 mr-2" />
+              Memory Import
+              {completion.memory && (
+                <CheckCircle2 className="w-4 h-4 ml-auto text-green-500" />
+              )}
             </CardTitle>
-            <p className="text-sm text-muted-foreground">
-              Paste your ChatGPT Memory or other context. We'll ingest this so your reflections start with rich context.
+            <p className="text-xs text-muted-foreground">
+              Optional: paste existing memory or context.
             </p>
           </CardHeader>
-          <CardContent>
+          <CardContent className="pt-2">
             <Textarea
               value={memory}
               onChange={(e) => setMemory(e.target.value)}
-              rows={4}
+              onInput={autoResize}
+              rows={1}
+              className="resize-none overflow-hidden"
               placeholder="Paste any existing memory or context that would help Yarnnn understand you better..."
             />
           </CardContent>
@@ -234,29 +282,29 @@ export default function OnboardingDashboard({ basketId }: Props) {
       </div>
 
       {/* Submit Section */}
-      <Card className="bg-gradient-to-r from-primary/5 to-primary/10">
-        <CardContent className="p-6 text-center space-y-4">
+      <Card className="bg-gradient-to-r from-primary/5 to-primary/10 onboarding-card--compact">
+        <CardContent className="p-0 text-center space-y-3">
           <div>
-            <h3 className="font-semibold mb-2">Ready to enhance your memory workspace?</h3>
-            <p className="text-sm text-muted-foreground">
-              {canSubmit 
+            <h3 className="font-semibold mb-1">Ready to enhance your memory workspace?</h3>
+            <p className="text-xs text-muted-foreground">
+              {canSubmit
                 ? "All required sections complete. Your identity will seed this basket's substrate."
                 : `Complete ${requiredCount - Object.values({name: completion.name, tension: completion.tension, aspiration: completion.aspiration}).filter(Boolean).length} more required sections to continue.`
               }
             </p>
           </div>
-          
-          <Button 
-            onClick={submit} 
+
+          <Button
+            onClick={submit}
             disabled={!canSubmit || isSubmitting}
             size="lg"
             className="min-w-32"
           >
             {isSubmitting ? "Creating..." : "Complete Profile"}
           </Button>
-          
+
           {!canSubmit && (
-            <p className="text-xs text-muted-foreground">
+            <p className="text-[10px] text-muted-foreground">
               Name, Current Focus, and Aspiration are required
             </p>
           )}


### PR DESCRIPTION
## Summary
- Condense identity profile cards with shared `onboarding-card--compact` style and auto-expanding fields
- Route /welcome to use dashboard-style onboarding and redirect other entry points
- Downplay optional memory import section

## Testing
- `npm --prefix web run lint`
- `npm --prefix web run test:unit` *(fails: Cannot find module '@testing-library/react')*

------
https://chatgpt.com/codex/tasks/task_e_68aedf90fe4083299f3a9c17504c48b1