### PR TITLE
feat: soften borders and polish inputs

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -43,24 +43,24 @@
 
 :root {
     --radius: 0.75rem;
-    --background: oklch(1 0 0);
-    --foreground: oklch(0.141 0.005 285.823);
-    --card: oklch(1 0 0);
-    --card-foreground: oklch(0.141 0.005 285.823);
-    --popover: oklch(1 0 0);
-    --popover-foreground: oklch(0.141 0.005 285.823);
-    --primary: oklch(0.21 0.006 285.885);
-    --primary-foreground: oklch(0.985 0 0);
+    --background: 0 0% 100%;
+    --foreground: 225 15% 15%;
+    --card: 0 0% 100%;
+    --card-foreground: 225 15% 12%;
+    --popover: 0 0% 100%;
+    --popover-foreground: 225 15% 12%;
+    --primary: 150 60% 40%;
+    --primary-foreground: 0 0% 100%;
     --secondary: oklch(0.967 0.001 286.375);
     --secondary-foreground: oklch(0.21 0.006 285.885);
-    --muted: oklch(0.967 0.001 286.375);
-    --muted-foreground: oklch(0.552 0.016 285.938);
+    --muted: 210 20% 98%;
+    --muted-foreground: 225 10% 45%;
     --accent: oklch(0.967 0.001 286.375);
     --accent-foreground: oklch(0.21 0.006 285.885);
     --destructive: oklch(0.577 0.245 27.325);
-    --border: oklch(0.92 0.004 286.32);
-    --input: oklch(0.92 0.004 286.32);
-    --ring: oklch(0.705 0.015 286.067);
+    --border: 210 16% 88%;
+    --input: 0 0% 100%;
+    --ring: 150 60% 40%;
     --chart-1: oklch(0.646 0.222 41.116);
     --chart-2: oklch(0.6 0.118 184.704);
     --chart-3: oklch(0.398 0.07 227.392);
@@ -77,24 +77,24 @@
 }
 
 .dark {
-    --background: oklch(0.141 0.005 285.823);
-    --foreground: oklch(0.985 0 0);
-    --card: oklch(0.21 0.006 285.885);
-    --card-foreground: oklch(0.985 0 0);
-    --popover: oklch(0.21 0.006 285.885);
-    --popover-foreground: oklch(0.985 0 0);
-    --primary: oklch(0.92 0.004 286.32);
-    --primary-foreground: oklch(0.21 0.006 285.885);
+    --background: 222 15% 10%;
+    --foreground: 0 0% 98%;
+    --card: 222 14% 12%;
+    --card-foreground: 0 0% 98%;
+    --popover: 222 14% 12%;
+    --popover-foreground: 0 0% 98%;
+    --primary: 150 60% 50%;
+    --primary-foreground: 0 0% 100%;
     --secondary: oklch(0.274 0.006 286.033);
     --secondary-foreground: oklch(0.985 0 0);
-    --muted: oklch(0.274 0.006 286.033);
-    --muted-foreground: oklch(0.705 0.015 286.067);
+    --muted: 220 8% 16%;
+    --muted-foreground: 215 12% 65%;
     --accent: oklch(0.274 0.006 286.033);
     --accent-foreground: oklch(0.985 0 0);
     --destructive: oklch(0.704 0.191 22.216);
-    --border: oklch(1 0 0 / 10%);
-    --input: oklch(1 0 0 / 15%);
-    --ring: oklch(0.552 0.016 285.938);
+    --border: 220 10% 22%;
+    --input: 222 14% 12%;
+    --ring: 150 60% 50%;
     --chart-1: oklch(0.488 0.243 264.376);
     --chart-2: oklch(0.696 0.17 162.48);
     --chart-3: oklch(0.769 0.188 70.08);
@@ -111,8 +111,8 @@
 }
 
 @layer base {
-    * {
-        @apply border-border outline-ring/50;
+    *, ::before, ::after {
+        @apply border-border;
     }
     body {
         @apply bg-background text-foreground font-sans;

--- a/web/components/onboarding/OnboardingDashboard.tsx
+++ b/web/components/onboarding/OnboardingDashboard.tsx
@@ -131,7 +131,7 @@ export default function OnboardingDashboard({ basketId }: Props) {
                   ? "ring-2 ring-green-500"
                   : required
                   ? "ring-1 ring-orange-200"
-                  : "ring-1 ring-gray-200"
+                  : "ring-1 ring-border"
               )}
             >
               <CardContent className="p-0 text-center space-y-1">
@@ -253,7 +253,7 @@ export default function OnboardingDashboard({ basketId }: Props) {
         <Card
           className={cn(
             "onboarding-card--compact bg-muted/30",
-            completion.memory ? "ring-1 ring-green-200" : "ring-1 ring-gray-200"
+            completion.memory ? "ring-1 ring-green-200" : "ring-1 ring-border"
           )}
         >
           <CardHeader className="pb-2">

--- a/web/components/ui/Card.tsx
+++ b/web/components/ui/Card.tsx
@@ -6,7 +6,7 @@ export function Card({ className, ...props }: React.HTMLAttributes<HTMLDivElemen
     <div
       className={cn(
         // Use theme variables for card styling
-        "bg-card text-card-foreground rounded-2xl border border-border p-6 shadow-sm",
+        "bg-card text-card-foreground rounded-2xl border border-border p-6 shadow-subtle",
         className
       )}
       {...props}

--- a/web/components/ui/Input.tsx
+++ b/web/components/ui/Input.tsx
@@ -11,9 +11,7 @@ export const Input = React.forwardRef<
   return (
     <input
       className={cn(
-        // Theme-based input styling
-        "w-full p-3 rounded-lg border border-input bg-input text-base text-foreground shadow-sm placeholder:text-muted-foreground",
-        "focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50",
+        "w-full rounded-xl border border-border bg-input text-foreground placeholder:text-muted-foreground/70 px-4 py-2.5 shadow-sm focus:outline-none focus:ring-2 focus:ring-ring/20 focus:border-ring/50 transition-colors disabled:opacity-50",
         className
       )}
       ref={ref}

--- a/web/components/ui/Textarea.tsx
+++ b/web/components/ui/Textarea.tsx
@@ -11,8 +11,7 @@ export const Textarea = React.forwardRef<
   return (
     <textarea
       className={cn(
-        "w-full p-3 rounded-lg border border-input bg-input text-base text-foreground shadow-sm placeholder:text-muted-foreground",
-        "focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50",
+        "w-full rounded-xl border border-border bg-input text-foreground placeholder:text-muted-foreground/70 px-4 py-2.5 shadow-sm focus:outline-none focus:ring-2 focus:ring-ring/20 focus:border-ring/50 transition-colors disabled:opacity-50",
         className
       )}
       ref={ref}

--- a/web/tailwind.config.ts
+++ b/web/tailwind.config.ts
@@ -1,16 +1,16 @@
-import { type Config } from "tailwindcss";
-import colors from "tailwindcss/colors";
+import type { Config } from "tailwindcss";
 
-const config = {
-  darkMode: "class",
-    content: {
+const config: Config = {
+  darkMode: ["class"],
+  content: {
     files: [
-        "./app/**/*.{ts,tsx}",
-        "./components/**/*.{ts,tsx}",
-        "./lib/**/*.{ts,tsx}",
+      "./app/**/*.{ts,tsx}",
+      "./components/**/*.{ts,tsx}",
+      "./lib/**/*.{ts,tsx}",
+      "../shared/**/*.{ts,tsx}",
     ],
     safelist: ["font-brand"],
-    },
+  },
   theme: {
     container: {
       center: true,
@@ -18,24 +18,34 @@ const config = {
     },
     extend: {
       colors: {
-        background: "var(--background)",
-        foreground: "var(--foreground)",
-        card: "var(--card)",
-        "card-foreground": "var(--card-foreground)",
+        border: "hsl(var(--border))",
+        input: "hsl(var(--input))",
+        ring: "hsl(var(--ring))",
+        background: "hsl(var(--background))",
+        foreground: "hsl(var(--foreground))",
+        muted: {
+          DEFAULT: "hsl(var(--muted))",
+          foreground: "hsl(var(--muted-foreground))",
+        },
+        card: {
+          DEFAULT: "hsl(var(--card))",
+          foreground: "hsl(var(--card-foreground))",
+        },
+        primary: {
+          DEFAULT: "hsl(var(--primary))",
+          foreground: "hsl(var(--primary-foreground))",
+        },
+        secondary: {
+          DEFAULT: "var(--secondary)",
+          foreground: "var(--secondary-foreground)",
+        },
+        accent: {
+          DEFAULT: "var(--accent)",
+          foreground: "var(--accent-foreground)",
+        },
+        destructive: "var(--destructive)",
         popover: "var(--popover)",
         "popover-foreground": "var(--popover-foreground)",
-        primary: "var(--primary)",
-        "primary-foreground": "var(--primary-foreground)",
-        secondary: "var(--secondary)",
-        "secondary-foreground": "var(--secondary-foreground)",
-        muted: "var(--muted)",
-        "muted-foreground": "var(--muted-foreground)",
-        accent: "var(--accent)",
-        "accent-foreground": "var(--accent-foreground)",
-        destructive: "var(--destructive)",
-        border: "var(--border)",
-        input: "var(--input)",
-        ring: "var(--ring)",
         sidebar: "var(--sidebar)",
         "sidebar-foreground": "var(--sidebar-foreground)",
         "sidebar-primary": "var(--sidebar-primary)",
@@ -60,11 +70,22 @@ const config = {
         md: "0.5rem",
         lg: "0.75rem",
         xl: "1rem",
-        "2xl": "1.5rem",
+        "2xl": "1.25rem",
+      },
+      boxShadow: {
+        subtle: "0 1px 2px rgba(0,0,0,0.04), 0 4px 14px rgba(0,0,0,0.03)",
       },
     },
   },
-  plugins: [require("tailwindcss-animate")],
+  plugins: [
+    require("tailwindcss-animate"),
+    function ({ addBase }) {
+      addBase({
+        "*, ::before, ::after": { borderColor: "hsl(var(--border))" },
+      });
+    },
+  ],
 };
 
 export default config;
+


### PR DESCRIPTION
## Summary
- add theme tokens and default border override to tailwind config
- refine global CSS variables and base border color
- refresh card, input, and textarea styles for softer UI
- tokenized onboarding rings to use border color

## Testing
- `npm test` *(fails: tsx: not found)*
- `npm --prefix web run test:unit` *(fails: cannot find module 'vitest')*


------
https://chatgpt.com/codex/tasks/task_e_68aee8ae034c832993d93b2c61585419