### PR TITLE
Polish memory page layout

### DIFF
--- a/web/app/baskets/[id]/memory/MemoryClient.tsx
+++ b/web/app/baskets/[id]/memory/MemoryClient.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from 'react';
-import { TodayReflectionCard, ReflectionCards } from "@/components/basket";
+import { ReflectionCards } from "@/components/basket";
 import { DocumentsList } from '@/components/documents/DocumentsList';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card';
 import { Button } from '@/components/ui/Button';
@@ -15,11 +15,10 @@ interface Props {
   pattern?: string;
   tension?: string | null;
   question?: string;
-  fallback: string;
   needsOnboarding?: boolean;
 }
 
-export default function MemoryClient({ basketId, pattern, tension, question, fallback, needsOnboarding }: Props) {
+export default function MemoryClient({ basketId, pattern, tension, question, needsOnboarding }: Props) {
   const [showAddMemory, setShowAddMemory] = useState(false);
   const refreshDocuments = () => {
     // This will trigger DocumentsList to refresh
@@ -55,34 +54,25 @@ export default function MemoryClient({ basketId, pattern, tension, question, fal
         />
       )}
       
-      <TodayReflectionCard line={undefined} fallback={fallback} />
-      
-      <div className="grid grid-cols-12 gap-6">
-        {/* Left Column - Documents */}
-        <div className="col-span-8">
-          <Card>
-            <CardHeader>
-              <CardTitle>Documents & Files</CardTitle>
-              <p className="text-sm text-gray-600">Your uploaded documents and files</p>
-            </CardHeader>
-            <CardContent>
-              <DocumentsList basketId={basketId} />
-            </CardContent>
-          </Card>
-        </div>
+      <div className="space-y-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>Documents</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <DocumentsList basketId={basketId} />
+          </CardContent>
+        </Card>
 
-        {/* Right Column - Insights */}
-        <div className="col-span-4">
-          <Card className="sticky top-6">
-            <CardHeader>
-              <CardTitle>Memory Insights</CardTitle>
-              <p className="text-sm text-gray-600">Patterns discovered in your memory</p>
-            </CardHeader>
-            <CardContent>
-              <ReflectionCards pattern={pattern} tension={tension} question={question || null} />
-            </CardContent>
-          </Card>
-        </div>
+        <Card>
+          <CardHeader>
+            <CardTitle>Memory Insights</CardTitle>
+            <p className="text-sm text-gray-600">Patterns discovered in your memory</p>
+          </CardHeader>
+          <CardContent>
+            <ReflectionCards pattern={pattern} tension={tension} question={question || null} />
+          </CardContent>
+        </Card>
       </div>
 
       {/* Modals */}

--- a/web/app/baskets/[id]/memory/page.tsx
+++ b/web/app/baskets/[id]/memory/page.tsx
@@ -55,16 +55,12 @@ export default async function MemoryPage({ params, searchParams }: PageProps) {
         pattern={undefined}
         tension={undefined}
         question={undefined}
-        fallback="Unable to load reflections. Please try again."
         needsOnboarding={needsOnboarding}
       />
     );
   }
 
   const { reflections } = projection;
-  const fallback = reflections.pattern
-    ? `You keep orbiting "${reflections.pattern}".`
-    : "Add a note to see what emerges.";
 
   return (
     <div className="space-y-6 pb-8">
@@ -87,7 +83,6 @@ export default async function MemoryPage({ params, searchParams }: PageProps) {
         pattern={reflections.pattern ?? undefined}
         tension={reflections.tension ?? undefined}
         question={reflections.question ?? undefined}
-        fallback={fallback}
         needsOnboarding={needsOnboarding}
       />
     </div>

--- a/web/components/documents/DocumentsList.tsx
+++ b/web/components/documents/DocumentsList.tsx
@@ -124,13 +124,7 @@ export function DocumentsList({ basketId }: DocumentsListProps) {
       <Card className="border-2 border-dashed border-gray-200">
         <CardContent className="p-12 text-center">
           <FileText className="h-16 w-16 text-gray-400 mx-auto mb-4" />
-          <h3 className="text-lg font-medium text-gray-900 mb-2">No documents yet</h3>
-          <p className="text-gray-600 text-sm mb-6">
-            Upload your first document to start building your knowledge library
-          </p>
-          <div className="text-xs text-gray-500">
-            Supported: PDF, TXT, MD, DOCX, images
-          </div>
+          <h3 className="text-lg font-medium text-gray-900">No documents yet</h3>
         </CardContent>
       </Card>
     );

--- a/web/components/memory/OnboardingPanel.tsx
+++ b/web/components/memory/OnboardingPanel.tsx
@@ -101,7 +101,7 @@ export default function OnboardingPanel({ basketId, onComplete, onDismiss }: Onb
         </div>
       </CardHeader>
       <CardContent className="p-6">
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div className="grid grid-cols-1 gap-4">
           {/* Add Memory Card */}
           <div className="border border-gray-200 rounded-lg p-4 bg-white">
             <div className="flex items-center gap-2 mb-2">


### PR DESCRIPTION
## Summary
- streamline memory page by removing placeholder reflection card and renaming documents section
- stack documents and insights vertically with simpler empty states
- simplify onboarding panel to single-column card layout

## Testing
- `npm run lint`
- `npm run test:unit` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68be45de3a088329a8e4cb24c36d45bf